### PR TITLE
fix(cli): keep refresh/curate written paths off the wrap boundary

### DIFF
--- a/src/earthlens/cli/datasets.py
+++ b/src/earthlens/cli/datasets.py
@@ -457,7 +457,8 @@ def _refresh_tiles(selected: list[BackendInfo], *, json_output: bool) -> None:
         if result["status"] == "ok":
             out_console().print(
                 f"[green]wrote {result['tiles']} tiles[/green] "
-                f"({result['provider']}) -> {result['written']}"
+                f"({result['provider']}) -> {result['written']}",
+                soft_wrap=True,
             )
         else:
             err_console().print(
@@ -538,7 +539,8 @@ def refresh(
         if outcome.written:
             out_console().print(
                 f"[green]wrote {outcome.live_count} ids[/green] "
-                f"({outcome.provider}) -> {outcome.written}"
+                f"({outcome.provider}) -> {outcome.written}",
+                soft_wrap=True,
             )
 
 
@@ -696,7 +698,8 @@ def curate(
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
         out_console().print(
-            f"[green]wrote {result.key}[/green] ({result.provider}) -> {written}"
+            f"[green]wrote {result.key}[/green] ({result.provider}) -> {written}",
+            soft_wrap=True,
         )
         return
 

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -315,6 +315,36 @@ class TestRefresh:
         assert result.exit_code == 0, f"refresh --write failed: {result.output}"
         assert "wrote" in result.output and "_index.yaml" in result.output
 
+    def test_write_path_intact_on_narrow_terminal(self, tmp_path, monkeypatch):
+        """The written path is emitted contiguously even on a narrow terminal.
+
+        A width that cannot fit the path forces Rich to fold it unless the line
+        opts out of wrapping; the full path must survive as one unbroken span.
+        """
+        import io
+        import shutil
+
+        from rich.console import Console
+
+        import earthlens.stac.catalog as stac_catalog
+
+        dst = tmp_path / "catalog"
+        shutil.copytree(stac_catalog.CATALOG_PATH, dst)
+        monkeypatch.setattr(stac_catalog, "CATALOG_PATH", dst)
+        monkeypatch.setattr(
+            refresh_mod,
+            "_get_json",
+            lambda url: {"collections": [{"id": "x"}], "links": []},
+        )
+        buf = io.StringIO()
+        monkeypatch.setattr(
+            datasets_mod, "out_console", lambda: Console(file=buf, width=40)
+        )
+        result = runner.invoke(app, ["datasets", "refresh", "stac", "--write"])
+        assert result.exit_code == 0, f"refresh --write failed: {result.output}"
+        written = str(dst / "_index.yaml")
+        assert written in buf.getvalue(), "path was folded across lines by Rich"
+
 
 class TestAudit:
     """Tests for `datasets audit` (curated-vs-live drift; network mocked)."""


### PR DESCRIPTION
# Description

The `earthlens datasets refresh --write`, `curate --write`, and `refresh --tiles` commands print the path of the
file they just wrote through a Rich `Console`, which word-wraps to the terminal width. On a narrow (80-column)
terminal — the default in CI — the trailing path is split across lines (e.g. `_index.ya` + newline + `ml`),
corrupting a value meant to be copied/piped and breaking the `refresh --write` path assertion.

This was failing the `wheel-test` workflow on `main`
(`tests/cli/test_datasets.py::TestRefresh::test_write_reports_written_path`). The fix prints the three
"wrote … -> <path>" lines with `soft_wrap=True`, so Rich emits the path intact regardless of terminal width.

No new dependencies.

# Issues
- Fixes #409

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Reproduced the failure at a pinned width of 80: unfixed `Console(width=80).print(... -> path)` drops
  `_index.yaml` (wrapped to `_index.ya\nml`); with `soft_wrap=True` the path is emitted intact.
- Ran the full CLI test module and confirmed CI (including the previously-failing wheel-test) is green.

- [x] `tests/cli/test_datasets.py` — 67 passed locally
- [x] `Wheel - Build & Test` workflow — green on this branch (py311–py314)

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
