### PR TITLE
fix(cli): bump distinct-backend count to 31 after erddap merge

### DIFF
--- a/tests/cli/test_adapter.py
+++ b/tests/cli/test_adapter.py
@@ -36,7 +36,7 @@ class TestListBackends:
         backends = list_backends()
         providers = [b.provider for b in backends]
         assert len(providers) == len(set(providers)), "provider ids must be unique"
-        assert len(backends) == 30, f"expected 30 backends, got {len(backends)}"
+        assert len(backends) == 31, f"expected 31 backends, got {len(backends)}"
 
     def test_sorted_by_provider(self):
         """Backends are returned sorted by canonical provider id."""

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -233,7 +233,7 @@ class TestRefresh:
         )
         result = runner.invoke(app, ["datasets", "refresh", "all", "--json"])
         payload = json.loads(result.output)
-        assert len(payload) == 30, "one outcome per backend"
+        assert len(payload) == 31, "one outcome per backend"
         assert any(o["provider"] == "stac" for o in payload), "stac included"
 
     def test_stac_json_reports_new_ids(self, monkeypatch):


### PR DESCRIPTION
# Description

Fixes the `main` branch going red on **Wheel - Build & Test** immediately after the
ERDDAP backend (#490) merged.

The erddap (#490) and bathymetry (#503) branches each independently raised the
distinct-backend assertions from 29 to 30. Git auto-merged the two identical
`30 -> 30` line changes with **no conflict**, but the real combined total is **31**
(29 base + bathymetry + erddap, each collapsing its registry aliases to one backend).

The gap was invisible on the PRs because **`Tests - Suite` runs only per-backend
markers** (`pixi run test-backend <marker>`), so it never executes these
`tests/cli/` count assertions. **`wheel-test.yml` runs the full suite but only
triggers on push to `main`** — so the failure only appeared once both backends had
landed on `main`.

This change sets both assertions to 31. No production code changes.

# Issues
- No tracked issue — post-merge CI hotfix for `main`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the two previously-failing tests against the merged `main` source
(`PYTHONPATH` pointed at the merged tree so `earthlens` resolves to the bb9b3c92
code with both backends registered):

- [x] `tests/cli/test_adapter.py::TestListBackends::test_collapses_aliases_to_distinct_backends` — passes (count is 31)
- [x] `tests/cli/test_datasets.py::TestRefresh::test_all_covers_every_backend` — passes

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
