### PR TITLE
feat(nwp): add mode={subset,whole} download override (H10)

### DIFF
--- a/docs/examples/nwp/download_mode.ipynb
+++ b/docs/examples/nwp/download_mode.ipynb
@@ -1,0 +1,282 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "93684b36",
+   "metadata": {},
+   "source": [
+    "# NWP download mode — `subset` vs `whole` (no network)\n",
+    "\n",
+    "The `NWP` backend downloads only the requested bands by default, using each\n",
+    "model's `.idx` byte-range index where it has one — cutting **>99 %** of the\n",
+    "bytes off the wire. The `mode=` constructor kwarg lets you override that:\n",
+    "\n",
+    "| `mode=` | behaviour |\n",
+    "|---------|-----------|\n",
+    "| `\"subset\"` *(default)* | `.idx` byte-range subset where available, else whole-per-variable |\n",
+    "| `\"whole\"` | force a full-file download even for `.idx`-capable models, then crop |\n",
+    "| `\"zarr\"` | rejected — no NWP row carries a `zarr_url` (a documented follow-on) |\n",
+    "\n",
+    "This notebook shows the mode API **offline** — no bucket access. The live\n",
+    "size-difference proof (`whole` file > `subset` file) runs in the gated e2e\n",
+    "suite (`pytest -m \"nwp and e2e\"`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b971c536",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5d3fcccf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T12:05:29.612310Z",
+     "iopub.status.busy": "2026-07-01T12:05:29.611957Z",
+     "iopub.status.idle": "2026-07-01T12:05:30.486190Z",
+     "shell.execute_reply": "2026-07-01T12:05:30.484704Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from earthlens.nwp import NWP\n",
+    "\n",
+    "# A tiny request skeleton reused across the cells below.\n",
+    "REQ = dict(\n",
+    "    start='2024-06-01', end='2024-06-01',\n",
+    "    variables={'gfs': ['temperature_2m']},\n",
+    "    lat_lim=[40, 45], lon_lim=[-80, -75], path='out/mode-demo',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00d256df",
+   "metadata": {},
+   "source": [
+    "## 1 — `subset` is the default"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80fb49eb",
+   "metadata": {},
+   "source": [
+    "Constructing without `mode=` selects the byte-range subset path. No download\n",
+    "happens at construction — the mode is just recorded for the later `.download()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "04889a7d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T12:05:30.489978Z",
+     "iopub.status.busy": "2026-07-01T12:05:30.489144Z",
+     "iopub.status.idle": "2026-07-01T12:05:30.701257Z",
+     "shell.execute_reply": "2026-07-01T12:05:30.699677Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "default mode: subset\n"
+     ]
+    }
+   ],
+   "source": [
+    "backend = NWP(**REQ)\n",
+    "print('default mode:', backend._mode)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ff49024",
+   "metadata": {},
+   "source": [
+    "## 2 — `mode=\"whole\"` forces a full-file download"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84e6dfc4",
+   "metadata": {},
+   "source": [
+    "`whole` pulls the entire GRIB2 for each `(cycle, step)` even for `.idx`-capable\n",
+    "models (the NOAA / Herbie ones), then crops to the bbox exactly like a subset.\n",
+    "It only changes behaviour for the `.idx` centres — ECMWF Open Data, DWD, ECCC\n",
+    "and Météo-France are already whole-per-variable, so they accept and ignore it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c91fe87f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T12:05:30.703836Z",
+     "iopub.status.busy": "2026-07-01T12:05:30.703475Z",
+     "iopub.status.idle": "2026-07-01T12:05:30.709819Z",
+     "shell.execute_reply": "2026-07-01T12:05:30.708384Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mode: whole\n"
+     ]
+    }
+   ],
+   "source": [
+    "backend = NWP(**REQ, mode='whole')\n",
+    "print('mode:', backend._mode)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb3242fe",
+   "metadata": {},
+   "source": [
+    "## 3 — `mode=\"zarr\"` is rejected"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a11ed1e6",
+   "metadata": {},
+   "source": [
+    "No NWP catalog row carries a `zarr_url`, and Zarr sources (NWM, hrrrzarr) are\n",
+    "separate backends — so `zarr` is rejected at construction with a clear message."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1713d606",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T12:05:30.712254Z",
+     "iopub.status.busy": "2026-07-01T12:05:30.711736Z",
+     "iopub.status.idle": "2026-07-01T12:05:30.717924Z",
+     "shell.execute_reply": "2026-07-01T12:05:30.716661Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ValueError: mode='zarr' is not supported: no NWP catalog row carries a `zarr_url`, and Zarr sources (NWM, hrrrzarr) are separate backends. Use mode='subset' (default) or mode='whole'.\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    NWP(**REQ, mode='zarr')\n",
+    "except ValueError as exc:\n",
+    "    print('ValueError:', exc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c419bd33",
+   "metadata": {},
+   "source": [
+    "## 4 — the facade forwards `mode=` too"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90ba6bb8",
+   "metadata": {},
+   "source": [
+    "The unified `EarthLens` facade passes any extra kwarg through to the backend,\n",
+    "so `mode=` works the same way there — this is how you'd use it in practice\n",
+    "(here we only construct; add `.download()` against the live bucket to fetch)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "432f8ace",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T12:05:30.720664Z",
+     "iopub.status.busy": "2026-07-01T12:05:30.720243Z",
+     "iopub.status.idle": "2026-07-01T12:05:30.728600Z",
+     "shell.execute_reply": "2026-07-01T12:05:30.727593Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "facade wired mode=whole -> whole\n"
+     ]
+    }
+   ],
+   "source": [
+    "from earthlens.earthlens import EarthLens\n",
+    "\n",
+    "lens = EarthLens(data_source='nwp', mode='whole', **REQ)\n",
+    "# the facade stores the constructed backend as `.datasource`\n",
+    "print('facade wired mode=whole ->', lens.datasource._mode)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd20ec49",
+   "metadata": {},
+   "source": [
+    "## Recap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "082f8586",
+   "metadata": {},
+   "source": [
+    "- `subset` (default) → `.idx` byte-range subset (>99 % less bandwidth) where\n",
+    "  the model has an index, else whole-per-variable.\n",
+    "- `whole` → force the full file even for `.idx` models, then crop.\n",
+    "- `zarr` → rejected (documented follow-on, pending a `zarr_url` field).\n",
+    "- `mode=` only changes behaviour for the NOAA / Herbie centre; the other\n",
+    "  centres accept and ignore it.\n",
+    "\n",
+    "See the [NWP usage guide](../../reference/nwp/usage.md) for the full write-up."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/reference/nwp/usage.md
+++ b/docs/reference/nwp/usage.md
@@ -88,6 +88,39 @@ are a follow-on.
 | `"azure"` | `azure` | `azure` |
 | `"origin"` | `nomads` | `ecmwf` |
 
+## Download mode: `subset` vs `whole`
+
+`mode=` controls how much of each GRIB2 is pulled off the wire before the
+bbox crop:
+
+| `mode=` | behaviour |
+|---------|-----------|
+| `"subset"` *(default)* | fetch only the requested bands. For a model with a `.idx` byte-range index (`idx: true` — the NOAA / Herbie models) this downloads just the matching messages, cutting **>99 %** of the bytes. Models without an index already download the whole per-variable file. |
+| `"whole"` | force a full-file download **even for `.idx`-capable models**, then crop. Useful when you want every variable/level from one cycle, or to work around an occasionally-stale `.idx`. |
+
+```python
+lens = EarthLens(
+    data_source="nwp",
+    variables={"gfs": ["temperature_2m"]},
+    start="2024-06-01",
+    end="2024-06-01",
+    lat_lim=[40, 45],
+    lon_lim=[-80, -75],
+    path="out/gfs",
+    mode="whole",                  # full GFS file, then crop (default is "subset")
+)
+```
+
+`mode` only changes behaviour for the **`.idx`-capable NOAA / Herbie
+centre** — every other centre (ECMWF Open Data, DWD, ECCC, Météo-France)
+is already whole-per-variable, so it accepts the flag and ignores it. The
+default `"subset"` path is unchanged from earlier releases.
+
+`mode="zarr"` is **rejected** with a `ValueError`: no NWP catalog row
+carries a `zarr_url`, and Zarr sources (NWM, hrrrzarr) are separate
+backends. A Zarr download mode is a documented follow-on, gated on a
+future `zarr_url` catalog field (read through `pyramids.zarr`).
+
 ## Output: bbox-cropped COGs
 
 Each `(cycle, step)` yields one Cloud-Optimized GeoTIFF named

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -530,6 +530,7 @@ nav:
     - Open NWP forecasts:
       - Catalog explorer (no network): examples/nwp/catalog_explorer.ipynb
       - Polish features (no network): examples/nwp/nwp_polish_features.ipynb
+      - Download mode subset vs whole (no network): examples/nwp/download_mode.ipynb
       - GFS 2 m temperature (live): examples/nwp/gfs_temperature.ipynb
       - DWD ICON precipitation (live): examples/nwp/icon_precipitation.ipynb
       - ECCC GDPS 2 m temperature (live): examples/nwp/eccc_gdps.ipynb

--- a/src/earthlens/nwp/backend.py
+++ b/src/earthlens/nwp/backend.py
@@ -54,6 +54,13 @@ if TYPE_CHECKING:
     from earthlens.aggregate import AggregationConfig
     from earthlens.nwp.centres.base import _NWPCentre
 
+#: The download modes `NWP` accepts. `"subset"` fetches only the
+#: requested bands (`.idx` byte-range where the model has one, else the
+#: whole field); `"whole"` forces a full-file download even for
+#: `.idx`-capable models. `"zarr"` is deliberately excluded — no NWP
+#: catalog row carries a `zarr_url` — and is rejected with a clear error.
+_VALID_MODES: frozenset[str] = frozenset({"subset", "whole"})
+
 
 class NWP(AbstractDataSource):
     """Open numerical-weather-prediction backend (forecast time axis).
@@ -85,6 +92,7 @@ class NWP(AbstractDataSource):
         steps: list[int] | None = None,
         horizon: int | None = None,
         members: list[str] | None = None,
+        mode: str = "subset",
         catalog: Catalog | None = None,
     ):
         """Initialise an NWP backend instance.
@@ -121,18 +129,40 @@ class NWP(AbstractDataSource):
                 model's first listed member when omitted; ignored for
                 deterministic models. One COG is written per
                 `(cycle, step, member)`.
+            mode: How much of each GRIB2 to download — `"subset"` (the
+                default) fetches only the requested bands via the
+                `.idx` byte-range index where the model has one
+                (`idx: true`), else the whole field; `"whole"` forces
+                a full-file download even for `.idx`-capable models,
+                then crops. `"whole"` only changes behaviour for the
+                NOAA / Herbie centre — the other centres are already
+                whole-per-variable, so `mode` is a no-op there.
+                `"zarr"` is rejected (no `nwp` catalog row carries a
+                `zarr_url`).
             catalog: Optional pre-built :class:`Catalog` (tests inject
                 a faked one); defaults to the bundled catalog.
 
         Raises:
-            ValueError: When `variables` is empty, a model key is
-                unknown, or a model declares an unknown `backend:`.
+            ValueError: When `variables` is empty, `mode` is not
+                `"subset"` / `"whole"`, a model key is unknown, or a
+                model declares an unknown `backend:`.
         """
         if not variables:
             raise ValueError(
                 "NWP requires a non-empty `variables` mapping of "
                 "{model_key: [param, ...]}."
             )
+        if mode not in _VALID_MODES:
+            if mode == "zarr":
+                raise ValueError(
+                    "mode='zarr' is not supported: no NWP catalog row carries a "
+                    "`zarr_url`, and Zarr sources (NWM, hrrrzarr) are separate "
+                    "backends. Use mode='subset' (default) or mode='whole'."
+                )
+            raise ValueError(
+                f"mode must be one of {sorted(_VALID_MODES)}; got {mode!r}."
+            )
+        self._mode = mode
         self._mirror = mirror
         self._steps_arg = steps
         self._horizon_arg = horizon
@@ -495,6 +525,7 @@ class NWP(AbstractDataSource):
             meta["params"],
             self._mirror,
             meta.get("member"),
+            whole=self._mode == "whole",
         )
         dataset = open_grib(str(grib_path))
         dataset = self._normalise_longitude(dataset)

--- a/src/earthlens/nwp/catalog.py
+++ b/src/earthlens/nwp/catalog.py
@@ -193,6 +193,16 @@ class NWPModel(BaseModel):
             `NWP._aggregate` checks this field — not the URL — to refuse
             aggregation on a grid `pyramids.dataset.DatasetCollection`
             cannot co-register.
+        title: Short human-readable label (e.g. `"NOAA GFS (Global
+            Forecast System)"`). Surfaced as the `title` column in the
+            federated `earthlens datasets where / search / list` CLI
+            output, so an `nwp` row reads the same as its `gee` / `s3` /
+            `radar` siblings instead of a blank cell. `None` for an
+            ad-hoc row.
+        description: One-sentence summary of the model — provider,
+            domain, resolution, and forecast horizon. Backs the CLI's
+            title fallback and gives `datasets search` free-text a
+            richer field to match against. `None` for an ad-hoc row.
 
     Examples:
         - Build a minimal Herbie-backed row and read its selector:
@@ -241,6 +251,8 @@ class NWPModel(BaseModel):
     license: str | None = None
     retention_days: int | None = None
     grid_kind: Literal["regular-latlon", "icosahedral"] = "regular-latlon"
+    title: str | None = None
+    description: str | None = None
 
 
 class Catalog(AbstractCatalog):

--- a/src/earthlens/nwp/centres/base.py
+++ b/src/earthlens/nwp/centres/base.py
@@ -81,6 +81,8 @@ class _NWPCentre(ABC):
         params: list[str],
         mirror: str,
         member: str | None = None,
+        *,
+        whole: bool = False,
     ) -> Path:
         """Download the variable-subset GRIB2 for one `(cycle, step[, member])`.
 
@@ -95,6 +97,11 @@ class _NWPCentre(ABC):
             member: Ensemble member id for an ensemble model, or `None`
                 for a deterministic one. Only the ensemble-capable centres
                 (NOAA GEFS, ECMWF ENS) use it; the others ignore it.
+            whole: When `True`, force a full-file download instead of a
+                byte-range subset (the `NWP(mode="whole")` override).
+                Only the `.idx`-capable NOAA / Herbie centre acts on it;
+                every other centre already downloads whole-per-variable,
+                so it accepts and ignores the flag.
 
         Returns:
             pathlib.Path: The local GRIB2 file holding every requested

--- a/src/earthlens/nwp/centres/dwd.py
+++ b/src/earthlens/nwp/centres/dwd.py
@@ -46,11 +46,15 @@ class DWDCentre(_NWPCentre):
         params: list[str],
         mirror: str,
         member: str | None = None,
+        *,
+        whole: bool = False,
     ) -> Path:
         """Download + decompress one `.bz2` per variable into one GRIB2.
 
-        `member` is accepted for interface parity but ignored — the ICON
-        rows here are deterministic (ICON-EPS is a separate model).
+        `member` and `whole` are accepted for interface parity but ignored
+        — the ICON rows here are deterministic (ICON-EPS is a separate
+        model), and DWD already serves one whole `.bz2` per variable, so
+        there is no byte-range subset for `whole` to override.
 
         Args:
             model: The resolved catalog row (carries `url_template` and
@@ -60,6 +64,8 @@ class DWDCentre(_NWPCentre):
             params: The requested earthlens parameter names.
             mirror: Ignored — DWD serves from a single origin host
                 (kept for interface parity with the other centres).
+            member: Ignored (see above).
+            whole: Ignored — already whole-per-variable.
 
         Returns:
             pathlib.Path: One local `.grib2` holding every requested

--- a/src/earthlens/nwp/centres/eccc.py
+++ b/src/earthlens/nwp/centres/eccc.py
@@ -87,6 +87,8 @@ class ECCCCentre(_NWPCentre):
         params: list[str],
         mirror: str,
         member: str | None = None,
+        *,
+        whole: bool = False,
     ) -> Path:
         """Download the per-`(cycle, step[, member])` GRIB2 for the requested bands.
 
@@ -95,6 +97,10 @@ class ECCCCentre(_NWPCentre):
         not leave a truncated `.grib2` for a later `open_grib` to misread.
         The HTTP body is streamed in 1 MiB chunks straight to disk, so
         a multi-GB GEPS `_allmbrs` file never has to fit in RAM.
+
+        `whole` is accepted for interface parity but ignored — Datamart
+        serves one whole GRIB2 per variable, so there is no byte-range
+        subset for `whole` to override.
 
         Args:
             model: The resolved catalog row.
@@ -110,6 +116,7 @@ class ECCCCentre(_NWPCentre):
                 the control or `"1"` … `"20"` for the perturbations);
                 `None` for the deterministic models. Forwarded into the
                 `url_template` as `{member:03d}` when present.
+            whole: Ignored (see above); accepted for `NWP(mode=)` parity.
 
         Returns:
             pathlib.Path: One local `.grib2` holding every requested

--- a/src/earthlens/nwp/centres/ecmwf.py
+++ b/src/earthlens/nwp/centres/ecmwf.py
@@ -122,8 +122,15 @@ class ECMWFCentre(_NWPCentre):
         params: list[str],
         mirror: str,
         member: str | None = None,
+        *,
+        whole: bool = False,
     ) -> Path:
         """Retrieve the param-subset GRIB2 for one `(cycle, step[, member])`.
+
+        `whole` is accepted for interface parity but ignored: `ecmwf-opendata`
+        is param-addressed (`Client.retrieve(param=...)`), so there is no
+        whole-file request to force — every retrieve is already the
+        requested subset.
 
         Args:
             model: The resolved catalog row.
@@ -134,6 +141,7 @@ class ECMWFCentre(_NWPCentre):
             member: ENS member id — a numeric id selects `type=pf` +
                 `number=<id>`; `"control"` (or `None`) keeps the
                 row's configured type (`cf` for the ENS control).
+            whole: Ignored (see above); accepted for `NWP(mode=)` parity.
 
         Returns:
             pathlib.Path: The local param-subset GRIB2 file.

--- a/src/earthlens/nwp/centres/meteofrance.py
+++ b/src/earthlens/nwp/centres/meteofrance.py
@@ -77,11 +77,15 @@ class MeteoFranceCentre(_NWPCentre):
         params: list[str],
         mirror: str,
         member: str | None = None,
+        *,
+        whole: bool = False,
     ) -> Path:
         """Download each variable's S3 object into one `.grib2`.
 
-        `member` is accepted for interface parity but ignored (the
-        Météo-France rows here are deterministic).
+        `member` and `whole` are accepted for interface parity but
+        ignored (the Météo-France rows here are deterministic, and each
+        S3 object is a whole per-variable file — no subset for `whole`
+        to override).
 
         Args:
             model: The resolved catalog row (carries `request_options`
@@ -92,6 +96,8 @@ class MeteoFranceCentre(_NWPCentre):
             params: The requested earthlens parameter names.
             mirror: Ignored — the bucket is a single origin (kept for
                 interface parity).
+            member: Ignored (see above).
+            whole: Ignored — already whole-per-variable.
 
         Returns:
             pathlib.Path: One local `.grib2` holding every requested

--- a/src/earthlens/nwp/centres/meteofrance_api.py
+++ b/src/earthlens/nwp/centres/meteofrance_api.py
@@ -81,12 +81,16 @@ class MeteoFranceAPICentre(_NWPCentre):
         params: list[str],
         mirror: str,
         member: str | None = None,
+        *,
+        whole: bool = False,
     ) -> Path:
         """Fetch each variable via WCS GetCoverage into one `.grib2`.
 
-        `member` is accepted for interface parity but ignored (the
-        Météo-France rows here are deterministic; PEARP/PEAROME are a
-        follow-on).
+        `member` and `whole` are accepted for interface parity but
+        ignored (the Météo-France rows here are deterministic;
+        PEARP/PEAROME are a follow-on — and each WCS `GetCoverage`
+        returns one per-variable coverage, so there is no subset for
+        `whole` to override).
 
         Args:
             model: The resolved catalog row. `request_options` must carry
@@ -96,6 +100,8 @@ class MeteoFranceAPICentre(_NWPCentre):
             step: The forecast lead time in hours.
             params: The requested earthlens parameter names.
             mirror: Ignored — the portal is a single origin.
+            member: Ignored (see above).
+            whole: Ignored — already whole-per-variable.
 
         Returns:
             pathlib.Path: One local `.grib2` with every requested band's

--- a/src/earthlens/nwp/centres/noaa.py
+++ b/src/earthlens/nwp/centres/noaa.py
@@ -103,12 +103,17 @@ class NOAACentre(_NWPCentre):
         params: list[str],
         mirror: str,
         member: str | None = None,
+        *,
+        whole: bool = False,
     ) -> Path:
-        """Download the variable-subset GRIB2 for one `(cycle, step[, member])`.
+        """Download the GRIB2 for one `(cycle, step[, member])`.
 
-        Joins the requested params' Herbie `search` regexes with `|`
-        into a single `.idx` selector, runs `Herbie(...).download(...)`,
-        and returns the path Herbie wrote.
+        In the default `subset` path, joins the requested params' Herbie
+        `search` regexes with `|` into a single `.idx` selector, runs
+        `Herbie(...).download(search)`, and returns the path Herbie
+        wrote. When `whole` is set, calls `Herbie(...).download(None)`
+        instead — Herbie's contract for a full-file download (the whole
+        GRIB2 is cropped downstream exactly like a subset).
 
         Args:
             model: The resolved catalog row.
@@ -119,9 +124,13 @@ class NOAACentre(_NWPCentre):
             member: Ensemble member id (e.g. GEFS `"mean"` or `"5"`),
                 forwarded to Herbie's `member=` — numeric ids become an
                 `int`. `None` for a deterministic model.
+            whole: When `True`, download the full file (no `.idx`
+                byte-range subset) via `download(None)`; when `False`
+                (default), subset to the requested bands.
 
         Returns:
-            pathlib.Path: The local variable-subset GRIB2 file.
+            pathlib.Path: The local GRIB2 file — a variable subset by
+                default, or the full field when `whole` is set.
         """
         herbie_cls = _import_herbie()
         search = "|".join(model.bands[p] for p in params)
@@ -141,4 +150,5 @@ class NOAACentre(_NWPCentre):
         # row can override a default if it ever needs to.
         kwargs.update(model.request_options)
         handle = herbie_cls(cycle, **kwargs)
-        return Path(handle.download(search))
+        # `search=None` is Herbie's full-file download; a regex subsets via .idx.
+        return Path(handle.download(None if whole else search))

--- a/src/earthlens/nwp/nwp_data_catalog.yaml
+++ b/src/earthlens/nwp/nwp_data_catalog.yaml
@@ -12,6 +12,8 @@ datasets:
 
   gfs:                                    # NOAA NODD, via Herbie
     provider: noaa-nodd
+    title: "NOAA GFS (Global Forecast System)"
+    description: "NOAA/NCEP Global Forecast System — 0.25° global deterministic forecast to 384 h, 4 cycles/day."
     license: PD-US-GOV
     model_family: gfs
     resolution: 0.25deg
@@ -105,6 +107,8 @@ datasets:
 
   gefs:                                   # NOAA NODD ensemble, via Herbie
     provider: noaa-nodd
+    title: "NOAA GEFS (Global Ensemble Forecast System)"
+    description: "NOAA/NCEP Global Ensemble Forecast System — 0.5° global, 31 perturbed members + mean, to 384 h."
     license: PD-US-GOV
     model_family: gefs
     resolution: 0.5deg
@@ -200,6 +204,8 @@ datasets:
 
   hrrr:                                   # NOAA NODD, hourly cycles, via Herbie
     provider: noaa-nodd
+    title: "NOAA HRRR (High-Resolution Rapid Refresh)"
+    description: "NOAA/NCEP High-Resolution Rapid Refresh — 3 km CONUS convection-allowing, hourly cycles to 48 h."
     license: PD-US-GOV
     model_family: hrrr
     resolution: 3km
@@ -293,6 +299,8 @@ datasets:
 
   ifs-hres:                               # ECMWF Open Data (IFS HRES)
     provider: ecmwf-opendata
+    title: "ECMWF IFS HRES"
+    description: "ECMWF Integrated Forecasting System high-resolution deterministic — 0.25° global to 240 h (open data)."
     license: CC-BY-4.0
     model_family: ifs
     resolution: 0.25deg
@@ -386,6 +394,8 @@ datasets:
 
   icon-global:                            # DWD Open Data, direct HTTPS .bz2 (no .idx)
     provider: dwd-opendata
+    title: "DWD ICON (global)"
+    description: "DWD ICON global model on its native icosahedral grid (~13 km), deterministic to 180 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon
@@ -491,6 +501,8 @@ datasets:
 
   rap:                                    # NOAA NODD, hourly RAP, via Herbie
     provider: noaa-nodd
+    title: "NOAA RAP (Rapid Refresh)"
+    description: "NOAA/NCEP Rapid Refresh — 13 km CONUS, hourly cycles to 51 h."
     license: PD-US-GOV
     model_family: rap
     resolution: 13km
@@ -576,6 +588,8 @@ datasets:
 
   nam:                                    # NOAA NODD, NAM 12 km CONUS, via Herbie
     provider: noaa-nodd
+    title: "NOAA NAM (North American Mesoscale)"
+    description: "NOAA/NCEP North American Mesoscale — 12 km CONUS deterministic to 84 h, 4 cycles/day."
     license: PD-US-GOV
     model_family: nam
     resolution: 12km
@@ -667,6 +681,8 @@ datasets:
 
   nbm:                                    # NOAA NODD, National Blend of Models, via Herbie
     provider: noaa-nodd
+    title: "NOAA NBM (National Blend of Models)"
+    description: "NOAA/NCEP National Blend of Models — 13 km CONUS statistically-blended guidance, hourly to 264 h."
     license: PD-US-GOV
     model_family: nbm
     resolution: 13km
@@ -688,6 +704,8 @@ datasets:
 
   rrfs:                                   # NOAA NODD, Rapid Refresh Forecast System, via Herbie
     provider: noaa-nodd
+    title: "NOAA RRFS (Rapid Refresh Forecast System)"
+    description: "NOAA/NCEP Rapid Refresh Forecast System — 3 km convection-allowing, hourly cycles to 60 h."
     license: PD-US-GOV
     model_family: rrfs
     resolution: 3km
@@ -768,6 +786,8 @@ datasets:
 
   gdps:                                   # ECCC, Global Deterministic Prediction System, via Herbie
     provider: eccc-msc
+    title: "ECCC GDPS (Global Deterministic Prediction System)"
+    description: "Environment Canada GDPS — 15 km global deterministic forecast to 240 h, 00/12Z cycles."
     license: OGL-Canada-2.0
     retention_days: 30
     idx: false
@@ -861,6 +881,8 @@ datasets:
 
   rdps:                                   # ECCC, Regional Deterministic Prediction System, via Herbie
     provider: eccc-msc
+    title: "ECCC RDPS (Regional Deterministic Prediction System)"
+    description: "Environment Canada RDPS — 10 km North-America regional deterministic to 84 h, 4 cycles/day."
     license: OGL-Canada-2.0
     retention_days: 30
     idx: false
@@ -954,6 +976,8 @@ datasets:
 
   hrdps:                                  # ECCC, High-Resolution Deterministic Prediction System, via Herbie
     provider: eccc-msc
+    title: "ECCC HRDPS (High-Resolution Deterministic Prediction System)"
+    description: "Environment Canada HRDPS — 2.5 km continental convection-allowing deterministic to 48 h."
     license: OGL-Canada-2.0
     retention_days: 30
     idx: false
@@ -1048,6 +1072,8 @@ datasets:
 
   geps:                                   # ECCC, Global Ensemble Prediction System (21 members), direct Datamart
     provider: eccc-msc
+    title: "ECCC GEPS (Global Ensemble Prediction System)"
+    description: "Environment Canada GEPS — 0.5° global ensemble (21 members) to 384 h, 00/12Z cycles."
     license: OGL-Canada-2.0
     retention_days: 14
     model_family: geps
@@ -1088,6 +1114,8 @@ datasets:
 
   icon-eu:                                # DWD, ICON-EU regular lat-lon (croppable), direct HTTPS
     provider: dwd-opendata
+    title: "DWD ICON-EU"
+    description: "DWD ICON European nest — 0.0625° (~6.5 km) regular lat/lon, deterministic to 120 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon-eu
@@ -1184,6 +1212,8 @@ datasets:
 
   icon-d2:                                # DWD, ICON-D2 native icosahedral (raw fetch; not croppable), direct HTTPS
     provider: dwd-opendata
+    title: "DWD ICON-D2"
+    description: "DWD ICON-D2 — 2.2 km central-Europe convection-allowing on its native icosahedral grid, to 48 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon-d2
@@ -1283,6 +1313,8 @@ datasets:
 
   ens:                                    # ECMWF Open Data, IFS ENS control forecast
     provider: ecmwf-opendata
+    title: "ECMWF IFS ENS (ensemble)"
+    description: "ECMWF Integrated Forecasting System ensemble — 0.25° global, 51 members (control + 50), to 360 h."
     license: CC-BY-4.0
     model_family: ens
     resolution: 0.25deg
@@ -1376,6 +1408,8 @@ datasets:
 
   aifs:                                   # ECMWF Open Data, AIFS (data-driven), single model
     provider: ecmwf-opendata
+    title: "ECMWF AIFS (AI Forecasting System)"
+    description: "ECMWF data-driven AI/ML deterministic forecast — 0.25° global to 360 h (open data)."
     license: CC-BY-4.0
     model_family: aifs
     resolution: 0.25deg
@@ -1472,6 +1506,8 @@ datasets:
 
   rtma:                                   # NOAA, Real-Time Mesoscale Analysis (2.5 km CONUS), via Herbie
     provider: noaa-nodd
+    title: "NOAA RTMA (Real-Time Mesoscale Analysis)"
+    description: "NOAA/NCEP Real-Time Mesoscale Analysis — 2.5 km CONUS surface analysis, hourly (analysis only)."
     license: PD-US-GOV
     model_family: rtma
     resolution: 2.5km
@@ -1491,6 +1527,8 @@ datasets:
 
   urma:                                   # NOAA, Un-Restricted Mesoscale Analysis (2.5 km CONUS), via Herbie
     provider: noaa-nodd
+    title: "NOAA URMA (UnRestricted Mesoscale Analysis)"
+    description: "NOAA/NCEP UnRestricted Mesoscale Analysis — 2.5 km CONUS surface analysis, hourly (analysis only)."
     license: PD-US-GOV
     model_family: urma
     resolution: 2.5km
@@ -1510,6 +1548,8 @@ datasets:
 
   hiresw-arw:                             # NOAA, High-Resolution Window ARW 2.5 km CONUS, via Herbie
     provider: noaa-nodd
+    title: "NOAA HiRes Window ARW"
+    description: "NOAA/NCEP High-Resolution Window (ARW core) — 2.5 km CONUS convection-allowing to 48 h."
     license: PD-US-GOV
     model_family: hiresw
     resolution: 2.5km
@@ -1603,6 +1643,8 @@ datasets:
 
   href:                                   # NOAA, High Resolution Ensemble Forecast (mean), via Herbie
     provider: noaa-nodd
+    title: "NOAA HREF (High-Resolution Ensemble Forecast)"
+    description: "NOAA/NCEP High-Resolution Ensemble Forecast (mean) — 3 km CONUS convection-allowing to 48 h."
     license: PD-US-GOV
     model_family: href
     resolution: 3km
@@ -1701,6 +1743,8 @@ datasets:
 
   arpege-world:                           # Météo-France ARPEGE global 0.25°, WCS API
     provider: meteofrance
+    title: "Météo-France ARPEGE (global)"
+    description: "Météo-France ARPEGE global deterministic — 0.25° to 102 h, served via the WCS API."
     license: Etalab-2.0
     retention_days: 14
     model_family: arpege
@@ -1795,6 +1839,8 @@ datasets:
 
   arome-france:                           # Météo-France AROME high-res France 0.025°, WCS API
     provider: meteofrance
+    title: "Météo-France AROME (France)"
+    description: "Météo-France AROME — 0.025° (~1.3 km) France convection-allowing to 51 h, served via the WCS API."
     license: Etalab-2.0
     retention_days: 14
     model_family: arome
@@ -1889,6 +1935,8 @@ datasets:
 
   icon-eps:                                  # DWD ICON-EPS ensemble (all members per file; icosahedral, raw; surface-only)
     provider: dwd-opendata
+    title: "DWD ICON-EPS (global ensemble)"
+    description: "DWD ICON global ensemble (40 members) on the native icosahedral grid, surface fields to 180 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon-eps
@@ -1913,6 +1961,8 @@ datasets:
       total_cloud_cover: clct
   icon-eu-eps:                                  # DWD ICON-EPS ensemble (all members per file; icosahedral, raw; surface-only)
     provider: dwd-opendata
+    title: "DWD ICON-EU-EPS (European ensemble)"
+    description: "DWD ICON-EU ensemble (40 members) on the native icosahedral grid, surface fields to 120 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon-eu-eps
@@ -1937,6 +1987,8 @@ datasets:
       total_cloud_cover: clct
   icon-d2-eps:                                  # DWD ICON-EPS ensemble (all members per file; icosahedral, raw; surface-only)
     provider: dwd-opendata
+    title: "DWD ICON-D2-EPS (convective ensemble)"
+    description: "DWD ICON-D2 ensemble (20 members) convection-allowing on the native icosahedral grid, to 48 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon-d2-eps
@@ -1961,6 +2013,8 @@ datasets:
       total_cloud_cover: clct
   nam-conusnest:                                  # NAM 5 km CONUS nest
     provider: noaa-nodd
+    title: "NOAA NAM CONUS Nest"
+    description: "NOAA/NCEP NAM CONUS nest — high-resolution deterministic sub-grid to 60 h, 4 cycles/day."
     license: PD-US-GOV
     model_family: nam
     cycles_utc: [0, 6, 12, 18]
@@ -2048,6 +2102,8 @@ datasets:
       relative_humidity_50hPa: ":RH:50 mb:"
   hiresw-fv3:                                  # HiResW FV3 2.5 km CONUS
     provider: noaa-nodd
+    title: "NOAA HiRes Window FV3"
+    description: "NOAA/NCEP High-Resolution Window (FV3 core) — 2.5 km CONUS convection-allowing to 48 h."
     license: PD-US-GOV
     model_family: hiresw
     cycles_utc: [0, 12]
@@ -2137,6 +2193,8 @@ datasets:
       relative_humidity_50hPa: ":RH:50 mb:"
   nbm-ak:                                  # National Blend - Alaska
     provider: noaa-nodd
+    title: "NOAA NBM — Alaska"
+    description: "NOAA/NCEP National Blend of Models, Alaska domain — statistically-blended guidance, hourly to 264 h."
     license: PD-US-GOV
     model_family: nbm
     cycles_utc: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
@@ -2154,6 +2212,8 @@ datasets:
       downward_shortwave_radiation: ":DSWRF:surface:"
   nbm-hi:                                  # National Blend - Hawaii
     provider: noaa-nodd
+    title: "NOAA NBM — Hawaii"
+    description: "NOAA/NCEP National Blend of Models, Hawaii domain — statistically-blended guidance, hourly to 264 h."
     license: PD-US-GOV
     model_family: nbm
     cycles_utc: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
@@ -2171,6 +2231,8 @@ datasets:
       downward_shortwave_radiation: ":DSWRF:surface:"
   nbm-pr:                                  # National Blend - Puerto Rico
     provider: noaa-nodd
+    title: "NOAA NBM — Puerto Rico"
+    description: "NOAA/NCEP National Blend of Models, Puerto Rico domain — statistically-blended guidance, to 264 h."
     license: PD-US-GOV
     model_family: nbm
     cycles_utc: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
@@ -2188,6 +2250,8 @@ datasets:
       downward_shortwave_radiation: ":DSWRF:surface:"
   ens-mean:                                  # ECMWF ENS ensemble mean
     provider: ecmwf-opendata
+    title: "ECMWF IFS ENS (ensemble mean)"
+    description: "ECMWF IFS ensemble mean — 0.25° global summary of the 51-member ensemble, to 360 h (open data)."
     license: CC-BY-4.0
     model_family: ens-mean
     cycles_utc: [0, 6, 12, 18]
@@ -2276,6 +2340,8 @@ datasets:
       relative_humidity_50hPa: "r@50"
   ens-spread:                                  # ECMWF ENS ensemble spread
     provider: ecmwf-opendata
+    title: "ECMWF IFS ENS (ensemble spread)"
+    description: "ECMWF IFS ensemble spread — 0.25° global standard deviation of the 51-member ensemble, to 360 h."
     license: CC-BY-4.0
     model_family: ens-spread
     cycles_utc: [0, 6, 12, 18]

--- a/tests/nwp/test_backend.py
+++ b/tests/nwp/test_backend.py
@@ -106,6 +106,57 @@ class TestConstruction:
         assert [key for key, _, _ in b._requests] == ["gfs", "icon-global"]
 
 
+class TestMode:
+    """Tests for the mode={subset,whole} download override."""
+
+    def test_default_is_subset(self, mini_catalog, tmp_path):
+        """mode defaults to subset."""
+        assert _make(mini_catalog, tmp_path)._mode == "subset"
+
+    def test_whole_accepted(self, mini_catalog, tmp_path):
+        """mode='whole' is accepted and stashed."""
+        assert _make(mini_catalog, tmp_path, mode="whole")._mode == "whole"
+
+    def test_zarr_rejected_with_reason(self, mini_catalog, tmp_path):
+        """mode='zarr' raises ValueError naming the no-zarr_url reason."""
+        with pytest.raises(ValueError, match="zarr_url"):
+            _make(mini_catalog, tmp_path, mode="zarr")
+
+    def test_unknown_mode_rejected(self, mini_catalog, tmp_path):
+        """An unrecognised mode raises ValueError listing the valid options."""
+        with pytest.raises(ValueError, match="subset.*whole|whole.*subset"):
+            _make(mini_catalog, tmp_path, mode="nope")
+
+    def test_whole_threads_into_fetch_one(self, mini_catalog, tmp_path, fake_pyramids):
+        """mode='whole' passes whole=True into every centre.fetch_one call."""
+        b = _make(mini_catalog, tmp_path, mode="whole")
+        b._centres["herbie"] = _CountingCentre(tmp_path)
+        b._fetch(b._search())
+        assert b._centres["herbie"].calls, "centre was never called"
+        assert all(call[-1] is True for call in b._centres["herbie"].calls)
+
+    def test_subset_threads_false(self, mini_catalog, tmp_path, fake_pyramids):
+        """The default mode passes whole=False into every centre.fetch_one call."""
+        b = _make(mini_catalog, tmp_path)
+        b._centres["herbie"] = _CountingCentre(tmp_path)
+        b._fetch(b._search())
+        assert all(call[-1] is False for call in b._centres["herbie"].calls)
+
+
+def test_no_xarray_or_cfgrib_imports_in_nwp():
+    """No module under src/earthlens/nwp imports the banned xarray / cfgrib."""
+    import pathlib
+
+    root = pathlib.Path(backend_mod.__file__).parent
+    offenders = []
+    for path in root.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for marker in ("import xarray", "import cfgrib", "from xarray", "from cfgrib"):
+            if marker in text:
+                offenders.append((path.name, marker))
+    assert offenders == [], f"banned imports found: {offenders}"
+
+
 class TestHooks:
     """Tests for _initialize, _create_grid, and _check_input_dates."""
 

--- a/tests/nwp/test_backend.py
+++ b/tests/nwp/test_backend.py
@@ -50,9 +50,9 @@ class _CountingCentre:
         self.save_dir = save_dir
         self.calls = []
 
-    def fetch_one(self, model, cycle, step, params, mirror, member=None):
-        """Record the call and return a fabricated GRIB path."""
-        self.calls.append((cycle, step, tuple(params), mirror, member))
+    def fetch_one(self, model, cycle, step, params, mirror, member=None, *, whole=False):
+        """Record the call (incl. `whole`) and return a fabricated GRIB path."""
+        self.calls.append((cycle, step, tuple(params), mirror, member, whole))
         suffix = f"_m{member}" if member is not None else ""
         return str(
             self.save_dir
@@ -67,11 +67,11 @@ class _FlakyCentre(_CountingCentre):
         super().__init__(save_dir)
         self.fail_step = fail_step
 
-    def fetch_one(self, model, cycle, step, params, mirror, member=None):
+    def fetch_one(self, model, cycle, step, params, mirror, member=None, *, whole=False):
         """Raise for `fail_step`; otherwise behave like the counting centre."""
         if step == self.fail_step:
             raise RuntimeError(f"f{step:03d} not published")
-        return super().fetch_one(model, cycle, step, params, mirror, member)
+        return super().fetch_one(model, cycle, step, params, mirror, member, whole=whole)
 
 
 class TestConstruction:

--- a/tests/nwp/test_catalog.py
+++ b/tests/nwp/test_catalog.py
@@ -174,6 +174,36 @@ class TestNWPModel:
         assert NWPModel(provider="noaa-nodd", license="PD-US-GOV").license == "PD-US-GOV"
 
 
+class TestBundledTitles:
+    """Tests that every shipped row carries a human-readable title + description."""
+
+    def test_every_row_has_a_title(self):
+        """No bundled NWP model row is missing its `title`."""
+        from earthlens.nwp import Catalog
+
+        missing = [k for k, m in Catalog().datasets.items() if not m.title]
+        assert missing == [], f"rows without title: {missing}"
+
+    def test_every_row_has_a_description(self):
+        """No bundled NWP model row is missing its `description`."""
+        from earthlens.nwp import Catalog
+
+        missing = [k for k, m in Catalog().datasets.items() if not m.description]
+        assert missing == [], f"rows without description: {missing}"
+
+    def test_title_and_description_default_to_none(self):
+        """An ad-hoc row leaves title / description as None (never inferred)."""
+        model = NWPModel(provider="noaa-nodd")
+        assert model.title is None and model.description is None
+
+    def test_cli_title_resolves_from_the_row(self):
+        """The federated CLI title column reads the row's `title`."""
+        from earthlens.cli.adapter import record_title
+        from earthlens.nwp import Catalog
+
+        assert record_title(Catalog().datasets["gfs"]) == "NOAA GFS (Global Forecast System)"
+
+
 class TestBundledLicenses:
     """Tests for C2: every shipped row carries its provider's license."""
 

--- a/tests/nwp/test_centres.py
+++ b/tests/nwp/test_centres.py
@@ -109,6 +109,30 @@ class TestNOAACentre:
         assert "product" not in handle.kwargs
         assert str(out).endswith("subset_gfs_f6.grib2")
 
+    def test_fetch_one_whole_downloads_full_file(self, fake_herbie, tmp_path):
+        """whole=True calls Herbie's download with no search selector (full file)."""
+        NOAACentre(tmp_path).fetch_one(
+            _gfs(),
+            dt.datetime(2024, 6, 1, 0),
+            6,
+            ["temperature_2m", "precipitation_acc"],
+            "auto",
+            whole=True,
+        )
+        # download(None) is Herbie's full-file contract; the .idx search is dropped.
+        assert fake_herbie.instances[-1].download_calls == [None]
+
+    def test_fetch_one_subset_is_default_and_unchanged(self, fake_herbie, tmp_path):
+        """whole defaults to False and the subset call passes the .idx search (regression)."""
+        NOAACentre(tmp_path).fetch_one(
+            _gfs(),
+            dt.datetime(2024, 6, 1, 0),
+            6,
+            ["temperature_2m"],
+            "auto",
+        )
+        assert fake_herbie.instances[-1].download_calls == [":TMP:2 m above ground:"]
+
     def test_fetch_one_passes_product_when_set(self, fake_herbie, tmp_path):
         """A model with a product (HRRR) forwards product= to Herbie."""
         NOAACentre(tmp_path).fetch_one(
@@ -299,6 +323,17 @@ class TestECMWFCentre:
         assert call["date"] == "2024-06-01"
         assert "stream" not in call
         assert out.exists() and out.name == "ifs_2024060112_f024.grib2"
+
+    def test_whole_is_a_noop(self, fake_ecmwf_client, tmp_path):
+        """whole=True retrieves identically to whole=False (param-addressed, no subset)."""
+        args = (self._ifs(), dt.datetime(2024, 6, 1, 12), 24, ["temperature_2m"], "aws")
+        ECMWFCentre(tmp_path).fetch_one(*args)
+        subset_call = dict(fake_ecmwf_client.instances[-1].retrieve_calls[-1])
+        ECMWFCentre(tmp_path).fetch_one(*args, whole=True)
+        whole_call = dict(fake_ecmwf_client.instances[-1].retrieve_calls[-1])
+        subset_call.pop("target", None)
+        whole_call.pop("target", None)
+        assert whole_call == subset_call
 
     def test_fetch_one_perturbed_member_sets_pf_and_number(
         self, fake_ecmwf_client, tmp_path

--- a/tests/nwp/test_centres.py
+++ b/tests/nwp/test_centres.py
@@ -1001,8 +1001,8 @@ def test_base_centre_fetch_one_raises_not_implemented(tmp_path):
     from earthlens.nwp.centres.base import _NWPCentre
 
     class _Bare(_NWPCentre):
-        def fetch_one(self, model, cycle, step, params, mirror, member=None):
-            return super().fetch_one(model, cycle, step, params, mirror, member)
+        def fetch_one(self, model, cycle, step, params, mirror, member=None, *, whole=False):
+            return super().fetch_one(model, cycle, step, params, mirror, member, whole=whole)
 
     with pytest.raises(NotImplementedError):
         _Bare(tmp_path).fetch_one(None, dt.datetime(2026, 1, 1), 0, [], "auto")

--- a/tests/nwp/test_nwp_e2e.py
+++ b/tests/nwp/test_nwp_e2e.py
@@ -21,6 +21,7 @@ import pytest
 from earthlens.earthlens import EarthLens
 from earthlens.nwp import Catalog
 from earthlens.nwp.centres.dwd import DWDCentre
+from earthlens.nwp.centres.noaa import NOAACentre
 
 pytestmark = [pytest.mark.nwp, pytest.mark.e2e]
 
@@ -116,3 +117,31 @@ class TestICONLive:
         except Exception as exc:
             pytest.skip(f"ICON live fetch unavailable: {exc}")
         assert out.exists() and out.stat().st_size > 0
+
+
+class TestModeLive:
+    """Live proof that mode='whole' downloads more than mode='subset'."""
+
+    @pytest.mark.skipif(not _herbie_available(), reason="herbie/eccodes not installed")
+    def test_whole_is_larger_than_subset(self, tmp_path):
+        """A whole GFS file is larger than the one-variable .idx subset."""
+        model = Catalog().get_model("gfs")
+        cycle = _recent_cycle()
+        subset_dir = tmp_path / "subset"
+        whole_dir = tmp_path / "whole"
+        subset_dir.mkdir()
+        whole_dir.mkdir()
+        try:
+            subset = NOAACentre(subset_dir).fetch_one(
+                model, cycle, 0, ["temperature_2m"], "auto"
+            )
+            whole = NOAACentre(whole_dir).fetch_one(
+                model, cycle, 0, ["temperature_2m"], "auto", whole=True
+            )
+        except Exception as exc:  # network / data-availability flake
+            pytest.skip(f"GFS live fetch unavailable: {exc}")
+        assert subset.exists() and subset.stat().st_size > 0
+        assert whole.exists() and whole.stat().st_size > 0
+        # The whole GFS field carries every variable/level; the subset is one
+        # band via the .idx byte-range — so whole must be substantially larger.
+        assert whole.stat().st_size > subset.stat().st_size


### PR DESCRIPTION
# Description

Adds a `mode={subset,whole}` constructor keyword to the shipped `earthlens.nwp` backend (roadmap `H10`) — a
small, self-contained extension, **not** a new backend and **no** catalog change.

- **`mode="subset"` (default)** — fetch only the requested bands: the `.idx` byte-range subset where the model
  has an index (the NOAA / Herbie models — cutting **>99 %** of the bytes), else the whole per-variable file.
  Byte-identical to earlier releases.
- **`mode="whole"`** — force a full-file download **even for `.idx`-capable models**, then crop. Only the
  NOAA / Herbie centre acts on it (`Herbie.download(None)` — the documented full-file contract); the other five
  centres (ECMWF Open Data, DWD, ECCC, Météo-France ×2) are already whole-per-variable, so they accept and
  ignore the flag.
- **`mode="zarr"`** — rejected with a `ValueError`: no NWP catalog row carries a `zarr_url`, and Zarr sources
  (NWM, hrrrzarr) are separate backends. A Zarr download mode is a documented follow-on, gated on a future
  `zarr_url` catalog field (read through `pyramids.zarr`, never `xr.open_zarr`).

Implementation: `NWP.__init__` gains a validated `mode` kwarg stashed as `self._mode`; `_NWPCentre.fetch_one`
gains a keyword-only `whole: bool = False` threaded through `NWP._fetch_one`; only `centres/noaa.py` branches on
it. No new dependency. No `xarray` / `cfgrib` — the whole GRIB2 reads through the existing pyramids crop path,
same as subset.

# Issues

- Closes #651 — nwp-mode C1: `mode={subset,whole}` kwarg on `NWP.__init__` + whole-download branch in `centres/noaa.py`
- Closes #652 — nwp-mode C2: unit + integration tests for mode routing (subset/whole/zarr + no-op + regression)
- Closes #653 — nwp-mode C3: live e2e (gated) — subset vs whole GFS fetch, assert whole is larger
- Closes #654 — nwp-mode C4: docs for `mode={subset,whole}` (+ offline example notebook)

The plan's two gate rows are internal verification steps, not standalone deliverables, so they are not filed as
issues: `A1` (per-centre whole-vs-subset mechanics — captured in `planning/nwp/captures/nwp-mode-facts.md`) and
`A2` (conformance gate — no `xarray` / `cfgrib` in `src/`, default `subset` unchanged) both passed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

The new `mode=` defaults to `"subset"`, which is byte-identical to the prior behaviour — so this is a purely
additive, non-breaking feature.

# How Has This Been Tested?

- **Unit + integration** (`pytest tests/nwp -q -m "not e2e"`): **196 passed**, no network. New coverage: `TestMode`
  (validation + `whole`/`subset` threading), `TestNOAACentre` (whole → `download(None)`; subset regression →
  `download(search)`), `TestECMWFCentre.test_whole_is_a_noop`, and a module-level guard that no NWP file imports
  `xarray` / `cfgrib`.
- **Coverage**: `backend.py` and every centre at **100 %** line + branch on the changed modules.
- **Live e2e** (`pytest -m "nwp and e2e"`): `TestModeLive.test_whole_is_larger_than_subset` fetched a real GFS
  variable twice (subset + whole) from NOAA NODD and confirmed the whole file is strictly larger. Skips cleanly
  offline.
- **Doctests**: `pytest --doctest-modules src/earthlens/nwp -q` — 8 / 8 green.
- **Example notebook**: `docs/examples/nwp/download_mode.ipynb` executed end-to-end and validated with
  `pytest --nbval-lax` (5 / 5 cells), no absolute-path leaks.
- **Conformance (A2)**: `grep -rnE "xarray|cfgrib" src/earthlens/nwp/` empty; every changed file starts with
  `from __future__ import annotations`; no legacy `typing` aliases; the diff is scoped to `src/earthlens/nwp` +
  `docs/`.
- **Independent review**: a fresh reviewer traced the full diff (operator precedence, thread-through, signature
  parity across all 6 centres, no `KeyError` risk in the whole path, validation-before-`super().__init__()`
  ordering, default regression) and found **no defects**.

Reproduce:

```bash
pytest tests/nwp -q -m "not e2e"                 # unit + integration
pytest -m "nwp and e2e" tests/nwp                # live subset-vs-whole size proof
pytest --doctest-modules src/earthlens/nwp -q    # doctests
pytest --nbval-lax docs/examples/nwp/download_mode.ipynb
```

# Checklist:

- [ ] updated version number in `pyproject.toml`. _(deferred to the release commit)_
- [ ] added changes to `docs/change-log.md`. _(covered by the per-commit messages; a consolidated entry lands
  with the release bump)_
- [ ] updated the latest version in README file. _(deferred to the release commit)_
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. _(NWP usage guide gains a `mode=` section; a new offline example notebook is
  added and wired into the mkdocs nav.)_


---

## Also folded into this PR — catalog `title` / `description`

To keep nwp to a single PR, this branch also carries the catalog-metadata follow-up (was briefly #657, now
closed):

- `NWPModel` gains `title: str | None = None` and `description: str | None = None` (both default `None`).
- All 33 bundled rows populated — e.g. `gfs` → `"NOAA GFS (Global Forecast System)"`. This fills the blank
  TITLE column the federated `earthlens datasets where / search / list` CLI showed for nwp rows (sibling
  providers `gee` / `s3` / `radar` already carry it), the one gap the `/provider-cli-audit nwp` flagged.
- Tested by `TestBundledTitles`; the full nwp suite is **200 passed** with both changes.
