### PR TITLE
feat(nwp): add title + description to NWPModel; populate all 33 rows

### DIFF
--- a/src/earthlens/nwp/catalog.py
+++ b/src/earthlens/nwp/catalog.py
@@ -193,6 +193,16 @@ class NWPModel(BaseModel):
             `NWP._aggregate` checks this field — not the URL — to refuse
             aggregation on a grid `pyramids.dataset.DatasetCollection`
             cannot co-register.
+        title: Short human-readable label (e.g. `"NOAA GFS (Global
+            Forecast System)"`). Surfaced as the `title` column in the
+            federated `earthlens datasets where / search / list` CLI
+            output, so an `nwp` row reads the same as its `gee` / `s3` /
+            `radar` siblings instead of a blank cell. `None` for an
+            ad-hoc row.
+        description: One-sentence summary of the model — provider,
+            domain, resolution, and forecast horizon. Backs the CLI's
+            title fallback and gives `datasets search` free-text a
+            richer field to match against. `None` for an ad-hoc row.
 
     Examples:
         - Build a minimal Herbie-backed row and read its selector:
@@ -241,6 +251,8 @@ class NWPModel(BaseModel):
     license: str | None = None
     retention_days: int | None = None
     grid_kind: Literal["regular-latlon", "icosahedral"] = "regular-latlon"
+    title: str | None = None
+    description: str | None = None
 
 
 class Catalog(AbstractCatalog):

--- a/src/earthlens/nwp/nwp_data_catalog.yaml
+++ b/src/earthlens/nwp/nwp_data_catalog.yaml
@@ -12,6 +12,8 @@ datasets:
 
   gfs:                                    # NOAA NODD, via Herbie
     provider: noaa-nodd
+    title: "NOAA GFS (Global Forecast System)"
+    description: "NOAA/NCEP Global Forecast System — 0.25° global deterministic forecast to 384 h, 4 cycles/day."
     license: PD-US-GOV
     model_family: gfs
     resolution: 0.25deg
@@ -105,6 +107,8 @@ datasets:
 
   gefs:                                   # NOAA NODD ensemble, via Herbie
     provider: noaa-nodd
+    title: "NOAA GEFS (Global Ensemble Forecast System)"
+    description: "NOAA/NCEP Global Ensemble Forecast System — 0.5° global, 31 perturbed members + mean, to 384 h."
     license: PD-US-GOV
     model_family: gefs
     resolution: 0.5deg
@@ -200,6 +204,8 @@ datasets:
 
   hrrr:                                   # NOAA NODD, hourly cycles, via Herbie
     provider: noaa-nodd
+    title: "NOAA HRRR (High-Resolution Rapid Refresh)"
+    description: "NOAA/NCEP High-Resolution Rapid Refresh — 3 km CONUS convection-allowing, hourly cycles to 48 h."
     license: PD-US-GOV
     model_family: hrrr
     resolution: 3km
@@ -293,6 +299,8 @@ datasets:
 
   ifs-hres:                               # ECMWF Open Data (IFS HRES)
     provider: ecmwf-opendata
+    title: "ECMWF IFS HRES"
+    description: "ECMWF Integrated Forecasting System high-resolution deterministic — 0.25° global to 240 h (open data)."
     license: CC-BY-4.0
     model_family: ifs
     resolution: 0.25deg
@@ -386,6 +394,8 @@ datasets:
 
   icon-global:                            # DWD Open Data, direct HTTPS .bz2 (no .idx)
     provider: dwd-opendata
+    title: "DWD ICON (global)"
+    description: "DWD ICON global model on its native icosahedral grid (~13 km), deterministic to 180 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon
@@ -491,6 +501,8 @@ datasets:
 
   rap:                                    # NOAA NODD, hourly RAP, via Herbie
     provider: noaa-nodd
+    title: "NOAA RAP (Rapid Refresh)"
+    description: "NOAA/NCEP Rapid Refresh — 13 km CONUS, hourly cycles to 51 h."
     license: PD-US-GOV
     model_family: rap
     resolution: 13km
@@ -576,6 +588,8 @@ datasets:
 
   nam:                                    # NOAA NODD, NAM 12 km CONUS, via Herbie
     provider: noaa-nodd
+    title: "NOAA NAM (North American Mesoscale)"
+    description: "NOAA/NCEP North American Mesoscale — 12 km CONUS deterministic to 84 h, 4 cycles/day."
     license: PD-US-GOV
     model_family: nam
     resolution: 12km
@@ -667,6 +681,8 @@ datasets:
 
   nbm:                                    # NOAA NODD, National Blend of Models, via Herbie
     provider: noaa-nodd
+    title: "NOAA NBM (National Blend of Models)"
+    description: "NOAA/NCEP National Blend of Models — 13 km CONUS statistically-blended guidance, hourly to 264 h."
     license: PD-US-GOV
     model_family: nbm
     resolution: 13km
@@ -688,6 +704,8 @@ datasets:
 
   rrfs:                                   # NOAA NODD, Rapid Refresh Forecast System, via Herbie
     provider: noaa-nodd
+    title: "NOAA RRFS (Rapid Refresh Forecast System)"
+    description: "NOAA/NCEP Rapid Refresh Forecast System — 3 km convection-allowing, hourly cycles to 60 h."
     license: PD-US-GOV
     model_family: rrfs
     resolution: 3km
@@ -768,6 +786,8 @@ datasets:
 
   gdps:                                   # ECCC, Global Deterministic Prediction System, via Herbie
     provider: eccc-msc
+    title: "ECCC GDPS (Global Deterministic Prediction System)"
+    description: "Environment Canada GDPS — 15 km global deterministic forecast to 240 h, 00/12Z cycles."
     license: OGL-Canada-2.0
     retention_days: 30
     idx: false
@@ -861,6 +881,8 @@ datasets:
 
   rdps:                                   # ECCC, Regional Deterministic Prediction System, via Herbie
     provider: eccc-msc
+    title: "ECCC RDPS (Regional Deterministic Prediction System)"
+    description: "Environment Canada RDPS — 10 km North-America regional deterministic to 84 h, 4 cycles/day."
     license: OGL-Canada-2.0
     retention_days: 30
     idx: false
@@ -954,6 +976,8 @@ datasets:
 
   hrdps:                                  # ECCC, High-Resolution Deterministic Prediction System, via Herbie
     provider: eccc-msc
+    title: "ECCC HRDPS (High-Resolution Deterministic Prediction System)"
+    description: "Environment Canada HRDPS — 2.5 km continental convection-allowing deterministic to 48 h."
     license: OGL-Canada-2.0
     retention_days: 30
     idx: false
@@ -1048,6 +1072,8 @@ datasets:
 
   geps:                                   # ECCC, Global Ensemble Prediction System (21 members), direct Datamart
     provider: eccc-msc
+    title: "ECCC GEPS (Global Ensemble Prediction System)"
+    description: "Environment Canada GEPS — 0.5° global ensemble (21 members) to 384 h, 00/12Z cycles."
     license: OGL-Canada-2.0
     retention_days: 14
     model_family: geps
@@ -1088,6 +1114,8 @@ datasets:
 
   icon-eu:                                # DWD, ICON-EU regular lat-lon (croppable), direct HTTPS
     provider: dwd-opendata
+    title: "DWD ICON-EU"
+    description: "DWD ICON European nest — 0.0625° (~6.5 km) regular lat/lon, deterministic to 120 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon-eu
@@ -1184,6 +1212,8 @@ datasets:
 
   icon-d2:                                # DWD, ICON-D2 native icosahedral (raw fetch; not croppable), direct HTTPS
     provider: dwd-opendata
+    title: "DWD ICON-D2"
+    description: "DWD ICON-D2 — 2.2 km central-Europe convection-allowing on its native icosahedral grid, to 48 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon-d2
@@ -1283,6 +1313,8 @@ datasets:
 
   ens:                                    # ECMWF Open Data, IFS ENS control forecast
     provider: ecmwf-opendata
+    title: "ECMWF IFS ENS (ensemble)"
+    description: "ECMWF Integrated Forecasting System ensemble — 0.25° global, 51 members (control + 50), to 360 h."
     license: CC-BY-4.0
     model_family: ens
     resolution: 0.25deg
@@ -1376,6 +1408,8 @@ datasets:
 
   aifs:                                   # ECMWF Open Data, AIFS (data-driven), single model
     provider: ecmwf-opendata
+    title: "ECMWF AIFS (AI Forecasting System)"
+    description: "ECMWF data-driven AI/ML deterministic forecast — 0.25° global to 360 h (open data)."
     license: CC-BY-4.0
     model_family: aifs
     resolution: 0.25deg
@@ -1472,6 +1506,8 @@ datasets:
 
   rtma:                                   # NOAA, Real-Time Mesoscale Analysis (2.5 km CONUS), via Herbie
     provider: noaa-nodd
+    title: "NOAA RTMA (Real-Time Mesoscale Analysis)"
+    description: "NOAA/NCEP Real-Time Mesoscale Analysis — 2.5 km CONUS surface analysis, hourly (analysis only)."
     license: PD-US-GOV
     model_family: rtma
     resolution: 2.5km
@@ -1491,6 +1527,8 @@ datasets:
 
   urma:                                   # NOAA, Un-Restricted Mesoscale Analysis (2.5 km CONUS), via Herbie
     provider: noaa-nodd
+    title: "NOAA URMA (UnRestricted Mesoscale Analysis)"
+    description: "NOAA/NCEP UnRestricted Mesoscale Analysis — 2.5 km CONUS surface analysis, hourly (analysis only)."
     license: PD-US-GOV
     model_family: urma
     resolution: 2.5km
@@ -1510,6 +1548,8 @@ datasets:
 
   hiresw-arw:                             # NOAA, High-Resolution Window ARW 2.5 km CONUS, via Herbie
     provider: noaa-nodd
+    title: "NOAA HiRes Window ARW"
+    description: "NOAA/NCEP High-Resolution Window (ARW core) — 2.5 km CONUS convection-allowing to 48 h."
     license: PD-US-GOV
     model_family: hiresw
     resolution: 2.5km
@@ -1603,6 +1643,8 @@ datasets:
 
   href:                                   # NOAA, High Resolution Ensemble Forecast (mean), via Herbie
     provider: noaa-nodd
+    title: "NOAA HREF (High-Resolution Ensemble Forecast)"
+    description: "NOAA/NCEP High-Resolution Ensemble Forecast (mean) — 3 km CONUS convection-allowing to 48 h."
     license: PD-US-GOV
     model_family: href
     resolution: 3km
@@ -1701,6 +1743,8 @@ datasets:
 
   arpege-world:                           # Météo-France ARPEGE global 0.25°, WCS API
     provider: meteofrance
+    title: "Météo-France ARPEGE (global)"
+    description: "Météo-France ARPEGE global deterministic — 0.25° to 102 h, served via the WCS API."
     license: Etalab-2.0
     retention_days: 14
     model_family: arpege
@@ -1795,6 +1839,8 @@ datasets:
 
   arome-france:                           # Météo-France AROME high-res France 0.025°, WCS API
     provider: meteofrance
+    title: "Météo-France AROME (France)"
+    description: "Météo-France AROME — 0.025° (~1.3 km) France convection-allowing to 51 h, served via the WCS API."
     license: Etalab-2.0
     retention_days: 14
     model_family: arome
@@ -1889,6 +1935,8 @@ datasets:
 
   icon-eps:                                  # DWD ICON-EPS ensemble (all members per file; icosahedral, raw; surface-only)
     provider: dwd-opendata
+    title: "DWD ICON-EPS (global ensemble)"
+    description: "DWD ICON global ensemble (40 members) on the native icosahedral grid, surface fields to 180 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon-eps
@@ -1913,6 +1961,8 @@ datasets:
       total_cloud_cover: clct
   icon-eu-eps:                                  # DWD ICON-EPS ensemble (all members per file; icosahedral, raw; surface-only)
     provider: dwd-opendata
+    title: "DWD ICON-EU-EPS (European ensemble)"
+    description: "DWD ICON-EU ensemble (40 members) on the native icosahedral grid, surface fields to 120 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon-eu-eps
@@ -1937,6 +1987,8 @@ datasets:
       total_cloud_cover: clct
   icon-d2-eps:                                  # DWD ICON-EPS ensemble (all members per file; icosahedral, raw; surface-only)
     provider: dwd-opendata
+    title: "DWD ICON-D2-EPS (convective ensemble)"
+    description: "DWD ICON-D2 ensemble (20 members) convection-allowing on the native icosahedral grid, to 48 h."
     license: CC-BY-4.0
     retention_days: 1
     model_family: icon-d2-eps
@@ -1961,6 +2013,8 @@ datasets:
       total_cloud_cover: clct
   nam-conusnest:                                  # NAM 5 km CONUS nest
     provider: noaa-nodd
+    title: "NOAA NAM CONUS Nest"
+    description: "NOAA/NCEP NAM CONUS nest — high-resolution deterministic sub-grid to 60 h, 4 cycles/day."
     license: PD-US-GOV
     model_family: nam
     cycles_utc: [0, 6, 12, 18]
@@ -2048,6 +2102,8 @@ datasets:
       relative_humidity_50hPa: ":RH:50 mb:"
   hiresw-fv3:                                  # HiResW FV3 2.5 km CONUS
     provider: noaa-nodd
+    title: "NOAA HiRes Window FV3"
+    description: "NOAA/NCEP High-Resolution Window (FV3 core) — 2.5 km CONUS convection-allowing to 48 h."
     license: PD-US-GOV
     model_family: hiresw
     cycles_utc: [0, 12]
@@ -2137,6 +2193,8 @@ datasets:
       relative_humidity_50hPa: ":RH:50 mb:"
   nbm-ak:                                  # National Blend - Alaska
     provider: noaa-nodd
+    title: "NOAA NBM — Alaska"
+    description: "NOAA/NCEP National Blend of Models, Alaska domain — statistically-blended guidance, hourly to 264 h."
     license: PD-US-GOV
     model_family: nbm
     cycles_utc: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
@@ -2154,6 +2212,8 @@ datasets:
       downward_shortwave_radiation: ":DSWRF:surface:"
   nbm-hi:                                  # National Blend - Hawaii
     provider: noaa-nodd
+    title: "NOAA NBM — Hawaii"
+    description: "NOAA/NCEP National Blend of Models, Hawaii domain — statistically-blended guidance, hourly to 264 h."
     license: PD-US-GOV
     model_family: nbm
     cycles_utc: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
@@ -2171,6 +2231,8 @@ datasets:
       downward_shortwave_radiation: ":DSWRF:surface:"
   nbm-pr:                                  # National Blend - Puerto Rico
     provider: noaa-nodd
+    title: "NOAA NBM — Puerto Rico"
+    description: "NOAA/NCEP National Blend of Models, Puerto Rico domain — statistically-blended guidance, to 264 h."
     license: PD-US-GOV
     model_family: nbm
     cycles_utc: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
@@ -2188,6 +2250,8 @@ datasets:
       downward_shortwave_radiation: ":DSWRF:surface:"
   ens-mean:                                  # ECMWF ENS ensemble mean
     provider: ecmwf-opendata
+    title: "ECMWF IFS ENS (ensemble mean)"
+    description: "ECMWF IFS ensemble mean — 0.25° global summary of the 51-member ensemble, to 360 h (open data)."
     license: CC-BY-4.0
     model_family: ens-mean
     cycles_utc: [0, 6, 12, 18]
@@ -2276,6 +2340,8 @@ datasets:
       relative_humidity_50hPa: "r@50"
   ens-spread:                                  # ECMWF ENS ensemble spread
     provider: ecmwf-opendata
+    title: "ECMWF IFS ENS (ensemble spread)"
+    description: "ECMWF IFS ensemble spread — 0.25° global standard deviation of the 51-member ensemble, to 360 h."
     license: CC-BY-4.0
     model_family: ens-spread
     cycles_utc: [0, 6, 12, 18]

--- a/tests/nwp/test_catalog.py
+++ b/tests/nwp/test_catalog.py
@@ -174,6 +174,36 @@ class TestNWPModel:
         assert NWPModel(provider="noaa-nodd", license="PD-US-GOV").license == "PD-US-GOV"
 
 
+class TestBundledTitles:
+    """Tests that every shipped row carries a human-readable title + description."""
+
+    def test_every_row_has_a_title(self):
+        """No bundled NWP model row is missing its `title`."""
+        from earthlens.nwp import Catalog
+
+        missing = [k for k, m in Catalog().datasets.items() if not m.title]
+        assert missing == [], f"rows without title: {missing}"
+
+    def test_every_row_has_a_description(self):
+        """No bundled NWP model row is missing its `description`."""
+        from earthlens.nwp import Catalog
+
+        missing = [k for k, m in Catalog().datasets.items() if not m.description]
+        assert missing == [], f"rows without description: {missing}"
+
+    def test_title_and_description_default_to_none(self):
+        """An ad-hoc row leaves title / description as None (never inferred)."""
+        model = NWPModel(provider="noaa-nodd")
+        assert model.title is None and model.description is None
+
+    def test_cli_title_resolves_from_the_row(self):
+        """The federated CLI title column reads the row's `title`."""
+        from earthlens.cli.adapter import record_title
+        from earthlens.nwp import Catalog
+
+        assert record_title(Catalog().datasets["gfs"]) == "NOAA GFS (Global Forecast System)"
+
+
 class TestBundledLicenses:
     """Tests for C2: every shipped row carries its provider's license."""
 


### PR DESCRIPTION
# Description

Adds `title` and `description` fields to `NWPModel` and populates all 33 bundled catalog rows.

The federated CLI (`earthlens datasets where` / `search` / `list`) reads a row's human-readable label from
`record_title()` in `cli/adapter.py`, which takes the first non-empty of
`("title", "long_name", "description", "name", "site_name")`. `NWPModel` carried **none** of those fields, so
every `nwp` row rendered a **blank TITLE column** in the cross-provider views — while sibling providers (`gee`,
`s3`, `radar`) showed text. This was the one cross-provider catalog-style inconsistency the
`/provider-cli-audit` flagged.

- `NWPModel` gains `title: str | None = None` and `description: str | None = None` — both default to `None`
  (never inferred from the URL / key).
- All 33 rows populated with a short title (e.g. `"NOAA GFS (Global Forecast System)"`,
  `"ECMWF IFS ENS (ensemble)"`, `"ECCC HRDPS (High-Resolution Deterministic Prediction System)"`) and a
  one-sentence description (provider, domain, resolution, forecast horizon).

After the change, `earthlens datasets where gfs` shows the `nwp` row's title instead of a blank cell — matching
the sibling catalogs — and `datasets search` free-text has the richer `description` field to match against.

No new dependency, no facade change; purely additive catalog metadata.

# Issues

- No tracking issue — this is a follow-up polish item surfaced by the `/provider-cli-audit nwp` run (the single
  cosmetic gap it flagged). Happy to open one if you'd prefer it tracked.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

The two new fields default to `None`, so existing rows and any external catalog stay valid — purely additive,
non-breaking.

# How Has This Been Tested?

- **Unit** (`pytest tests/nwp -q -m "not e2e"`): **190 passed**. New `TestBundledTitles` asserts every shipped
  row has a non-empty `title` + `description`, that an ad-hoc row defaults both to `None`, and that
  `record_title()` resolves the CLI label from the row (`gfs` → `"NOAA GFS (Global Forecast System)"`).
- **Doctests**: `pytest --doctest-modules src/earthlens/nwp/catalog.py -q` — green.
- **CLI adapter**: `pytest tests/cli -q -k "adapter or title or where"` — **45 passed** (the `record_title`
  field-fallback path is unchanged and still green).
- **CLI smoke**: `earthlens datasets where gfs` now prints `NOAA GFS (Global Forecast System)` (was blank);
  `earthlens datasets validate nwp` → still `ok, 33 checked, 0 issues`.
- **Encoding**: the YAML keeps proper UTF-8 (degree signs, em-dashes) — no mojibake.

Reproduce:

```bash
pytest tests/nwp -q -m "not e2e"
pytest --doctest-modules src/earthlens/nwp/catalog.py -q
earthlens datasets where gfs            # nwp row now carries a title
earthlens datasets validate nwp         # ok, 33, 0 issues
```

# Checklist:

- [ ] updated version number in `pyproject.toml`. _(deferred to the release commit)_
- [ ] added changes to `docs/change-log.md`. _(covered by the commit message; consolidated entry lands with the
  release bump)_
- [ ] updated the latest version in README file. _(deferred to the release commit)_
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. _(the new fields carry Google-style docstrings; the API reference auto-documents
  them via mkdocstrings — no separate docs page needed for two additive metadata fields.)_
