### PR TITLE
docs: drop CAMS from firms/openaq backend lists (not a shipped backend)

### DIFF
--- a/docs/reference/firms/introduction.md
+++ b/docs/reference/firms/introduction.md
@@ -45,7 +45,7 @@ with pyramids, …).
 
 ## Why it matters here
 
-The raster backends (ERA5 / CAMS via CDS, MODIS/VIIRS imagery and the
+The raster backends (ERA5 via CDS, MODIS/VIIRS imagery and the
 burned-area products via Google Earth Engine) give you gridded fields
 with full spatial coverage. FIRMS is the complementary **event feed**:
 sparse but direct per-pixel fire detections, refreshed within hours.

--- a/docs/reference/openaq/introduction.md
+++ b/docs/reference/openaq/introduction.md
@@ -41,7 +41,7 @@ own server-side rollups via `temporal_resolution` (see
 
 ## Why it matters here
 
-The satellite and reanalysis backends (CAMS / ERA5 via CDS, TROPOMI and
+The satellite and reanalysis backends (ERA5 via CDS, TROPOMI and
 other atmospheric collections via Google Earth Engine) give you
 **modelled or remotely-sensed** air-quality fields with full spatial
 coverage but indirect measurements. OpenAQ is the complementary


### PR DESCRIPTION
# Description

Two provider "why it matters" intros list **CAMS as a shipped raster/reanalysis backend "via CDS"**, but that is
inaccurate on two counts: `earthlens` curates **no CAMS datasets** (the ecmwf catalog is CDS-only — ERA5 / CARRA /
CERRA / seasonal / CMIP5 / CORDEX / derived), and CAMS is served by the **Atmosphere Data Store (ADS)**, not CDS.
This drops the bogus `CAMS` from both lists, leaving `ERA5 via CDS`.

- `docs/reference/firms/introduction.md` — `ERA5 / CAMS via CDS` -> `ERA5 via CDS`
- `docs/reference/openaq/introduction.md` — `CAMS / ERA5 via CDS` -> `ERA5 via CDS`

Docs-only; no code or behaviour change.

# Issues
- No tracked issue; a small documentation-accuracy fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Documentation-only change; no tests affected. Verified the two edited lists now name only shipped backends and
  that no `CAMS` dataset exists in the ecmwf catalog.

- [x] Confirmed no CAMS rows in the ecmwf catalog / `available_datasets` index

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
