### PR TITLE
test(drought): fix wheel-test failure — use a grid-free CRS in the USDM reproject test

### DIFF
--- a/tests/drought/test_backend.py
+++ b/tests/drought/test_backend.py
@@ -319,13 +319,18 @@ def test_usdm_fetch_clips_to_bbox(monkeypatch, tmp_path):
 
 def test_usdm_honours_payload_crs_member(monkeypatch, tmp_path):
     """A GeoJSON `crs` member is respected (defensive reproject reachable)."""
-    # Build a payload with USA Contiguous Albers Equal-Area metre coords +
-    # the corresponding RFC 7946-style crs member (USDM historical shape).
-    albers_payload = {
+    # Build a payload with projected metre coords + a matching RFC 7946-style
+    # crs member (the non-4326 shape USDM historical files carry). Web Mercator
+    # (EPSG:3857) is used deliberately: its transform to EPSG:4326 is a closed
+    # form needing no PROJ datum grids, so the reproject behaves identically on
+    # minimal PROJ builds (e.g. the conda-forge GDAL the wheel-test job installs)
+    # as on the source env — a datum-shift CRS like EPSG:5070 drops the feature
+    # when the grid is absent.
+    mercator_payload = {
         "type": "FeatureCollection",
         "crs": {
             "type": "name",
-            "properties": {"name": "EPSG:5070"},
+            "properties": {"name": "EPSG:3857"},
         },
         "features": [
             {
@@ -335,11 +340,11 @@ def test_usdm_honours_payload_crs_member(monkeypatch, tmp_path):
                     "coordinates": [
                         [
                             [
-                                [-500_000.0, 1_700_000.0],
-                                [500_000.0, 1_700_000.0],
-                                [500_000.0, 2_300_000.0],
-                                [-500_000.0, 2_300_000.0],
-                                [-500_000.0, 1_700_000.0],
+                                [-10_000_000.0, 4_000_000.0],
+                                [-9_000_000.0, 4_000_000.0],
+                                [-9_000_000.0, 5_000_000.0],
+                                [-10_000_000.0, 5_000_000.0],
+                                [-10_000_000.0, 4_000_000.0],
                             ]
                         ]
                     ],
@@ -354,7 +359,7 @@ def test_usdm_honours_payload_crs_member(monkeypatch, tmp_path):
         ],
     }
     monkeypatch.setattr(
-        backend_module, "_http_get_json", lambda url: albers_payload
+        backend_module, "_http_get_json", lambda url: mercator_payload
     )
     backend = Drought(
         start="2026-06-23",
@@ -366,8 +371,9 @@ def test_usdm_honours_payload_crs_member(monkeypatch, tmp_path):
     fc = backend.download(progress_bar=False)
     assert fc.crs.to_epsg() == 4326
     assert len(fc) == 1
-    # The Albers metre coords map to ~ Texas/Oklahoma — well inside the
-    # CONUS bbox, so the polygon survives the clip (proves the reproject ran).
+    # The Web Mercator metre coords map to ~ the south-eastern US (lon -90..-81,
+    # lat 34..41) — well inside the world bbox, so the polygon survives the clip
+    # (proves the reproject ran).
 
 
 def test_crs_from_geojson_handles_variants():


### PR DESCRIPTION
# Description

`Wheel - Build & Test` is red on `main` (it was already failing before the last
merge — a pre-existing break, not caused by it). The single failing test is
`tests/drought/test_backend.py::test_usdm_honours_payload_crs_member`.

Root cause: the test built its USDM payload in **EPSG:5070** (NAD83 / Conus
Albers). Reprojecting `5070 -> 4326` needs a **datum-shift grid**, which the
minimal conda-forge PROJ the wheel-test job installs does not ship. Without the
grid the feature reprojects to invalid/out-of-range coordinates and is dropped
by the bbox clip, so `len(fc) == 0` and the assertion `len(fc) == 1` fails —
only in the wheel job, not the source `Tests - Suite` (whose PROJ has the grid).

Fix: build the payload in **EPSG:3857** (Web Mercator) instead. Its transform to
EPSG:4326 is a closed form that needs **no PROJ grids**, so the reproject behaves
identically on every GDAL/PROJ build. The box maps to the south-eastern US (lon
-90..-81, lat 34..41), still inside the world bbox, so the feature survives the
clip and the test's intent (a non-4326 `crs` member is honoured; the defensive
reproject path is reachable) is unchanged. Test-only change.

# Issues
- No tracked issue; fixes the red `Wheel - Build & Test` job on `main`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- `pytest tests/drought/test_backend.py` — 49 passed locally.
- Verified the 3857 box reprojects to lon -89.83..-80.85 / lat 33.79..40.92 (inside the world bbox).
- The wheel-test check on this PR exercises the conda-forge PROJ path that was failing.

- [x] Drought suite passes locally
- [x] Wheel - Build & Test check on this PR

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
