### PR TITLE
feat(base): add HttpClient + region_affinity base primitives (H24, H25)

### DIFF
--- a/docs/reference/base/http-client.md
+++ b/docs/reference/base/http-client.md
@@ -1,0 +1,47 @@
+# HTTP client (`earthlens.base.http`)
+
+`HttpClient` is the shared `requests`-based transport for the REST-style backends. It owns the chores every
+backend used to hand-roll — a pooled session, a sensible `User-Agent`, a per-request timeout, a
+`Retry-After`-aware `429`/`5xx` back-off loop, JSON decoding, and a streamed download with a progress bar — so a
+new backend keeps only the `API`-shaped parts: endpoint paths, query params, pagination, auth-header values, and
+response parsing.
+
+> **Don't hand-roll a session or a retry loop.** If you find yourself writing `requests.Session()`, a
+> `while` loop that inspects `429` / `Retry-After`, or an `iter_content` chunk loop, reach for `HttpClient`
+> instead. Backends that pre-date it are being migrated onto it.
+
+## Consuming it
+
+Construct one client per backend with the default headers it needs, then call the verbs:
+
+```python
+from earthlens.base.http import HttpClient
+
+http = HttpClient(headers={"X-API-Key": api_key}, timeout=60.0)
+
+# JSON GET with automatic 429/5xx retry + Retry-After honouring:
+payload = http.get_json("https://api.example.org/v1/things", params={"bbox": "1,2,3,4"})
+
+# Streamed download to disk with a tqdm bar (sized from Content-Length):
+http.download("https://example.org/big.tif", dest, progress=True)
+```
+
+The default `User-Agent` is `earthlens/{version}` — deliberately **non-Mozilla**, because the DIGITAL.CSIC
+Anubis anti-bot wall (SPEIbase) blocks browser-like agents. Pass `user_agent=` for a descriptive contact string
+(e.g. Overpass / ohsome etiquette).
+
+## Testability
+
+Both the transport and the wait are injectable, so the whole client is unit-testable with a fake session and no
+real delays:
+
+```python
+client = HttpClient(session=fake_session, sleep=captured_waits.append)
+```
+
+Pagination and response-envelope parsing stay in each backend — the client owns only *how bytes move*, never
+the `API` shape.
+
+## API
+
+::: earthlens.base.http.HttpClient

--- a/docs/reference/base/region-affinity.md
+++ b/docs/reference/base/region-affinity.md
@@ -1,0 +1,48 @@
+# Cloud region affinity (`earthlens.base.region`)
+
+`region_affinity(bucket_region)` answers one question: **is this process running in the same cloud region as the
+target bucket?** A backend uses the answer to choose between a cheap **in-region** streaming read and a slow,
+billed **cross-region egress** download.
+
+It returns one of three verdicts:
+
+| Verdict | Meaning |
+|---------|---------|
+| `"in-region"` | the caller region equals `bucket_region` — stream directly |
+| `"egress"` | caller and bucket are in different (known) regions — expect billed, slower transfer |
+| `"unknown"` | the caller region could not be determined — fall back to the safe (HTTPS) path |
+
+## How the caller region is resolved
+
+Resolution is **env-first**, then an optional metadata probe:
+
+1. an explicit `caller_region=` argument, then
+2. `AWS_REGION` / `AWS_DEFAULT_REGION`, then
+3. (only when `probe=True`) an instance-metadata probe — **AWS** IMDSv2, **GCP**
+   `metadata.google.internal`, or **Azure** IMDS — each behind a hard 1 s timeout and cached per process.
+
+Detection **never raises and never blocks**: any failure yields `"unknown"`. Pass `probe=False` to skip all
+network access entirely (tests, air-gapped runs). The earthdata backend deliberately uses `probe=False` so its
+in-region decision never risks hanging an off-cloud caller.
+
+## Warning before large egress
+
+`warn_if_egress(bucket_region, *, size_bytes, threshold_bytes=1<<30)` emits a single `loguru` warning when the
+hint is `"egress"` and the transfer exceeds the threshold (default 1 GiB), and returns the hint. The `s3`
+backend calls it before a bulk pull (using the object sizes the listing already reported), so a cross-region
+transfer is never a silent cost surprise.
+
+```python
+from earthlens.base.region import region_affinity, warn_if_egress
+
+if region_affinity("us-west-2") == "in-region":
+    ...  # stream from S3 in-region
+else:
+    warn_if_egress("us-west-2", size_bytes=total_bytes)  # advise, then HTTPS download
+```
+
+## API
+
+::: earthlens.base.region.region_affinity
+
+::: earthlens.base.region.warn_if_egress

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -589,6 +589,7 @@ nav:
   - API Reference:
     - EarthLens Facade: reference/earthlens.md
     - AbstractDataSource: reference/abstract-datasource.md
+    - HTTP client (base): reference/base/http-client.md
   - About:
     - Change Log: change-log.md
     - License: LICENSE.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -590,6 +590,7 @@ nav:
     - EarthLens Facade: reference/earthlens.md
     - AbstractDataSource: reference/abstract-datasource.md
     - HTTP client (base): reference/base/http-client.md
+    - Region affinity (base): reference/base/region-affinity.md
   - About:
     - Change Log: change-log.md
     - License: LICENSE.md

--- a/src/earthlens/base/__init__.py
+++ b/src/earthlens/base/__init__.py
@@ -21,7 +21,7 @@ from earthlens.base.auth import AbstractAuth, AuthenticationError
 from earthlens.base.http import HttpClient
 from earthlens.base.leaves import FluxableLeaf
 from earthlens.base.providers import Provider, clear_providers_cache, load_providers
-from earthlens.base.region import region_affinity
+from earthlens.base.region import clear_region_cache, region_affinity
 from earthlens.base.spatial import (
     METRES_PER_DEGREE,
     crop_to_aoi,
@@ -46,6 +46,7 @@ __all__ = [
     "SpatialExtent",
     "TemporalExtent",
     "clear_providers_cache",
+    "clear_region_cache",
     "crop_to_aoi",
     "mask_to_geometry",
     "estimate_pixel_dims",

--- a/src/earthlens/base/__init__.py
+++ b/src/earthlens/base/__init__.py
@@ -18,6 +18,7 @@ from earthlens.base.abstractdatasource import (
     TemporalExtent,
 )
 from earthlens.base.auth import AbstractAuth, AuthenticationError
+from earthlens.base.http import HttpClient
 from earthlens.base.leaves import FluxableLeaf
 from earthlens.base.providers import Provider, clear_providers_cache, load_providers
 from earthlens.base.spatial import (
@@ -35,6 +36,7 @@ __all__ = [
     "AbstractDataSource",
     "AuthenticationError",
     "FluxableLeaf",
+    "HttpClient",
     "LazyClientMixin",
     "METRES_PER_DEGREE",
     "OutputKind",

--- a/src/earthlens/base/__init__.py
+++ b/src/earthlens/base/__init__.py
@@ -21,7 +21,11 @@ from earthlens.base.auth import AbstractAuth, AuthenticationError
 from earthlens.base.http import HttpClient
 from earthlens.base.leaves import FluxableLeaf
 from earthlens.base.providers import Provider, clear_providers_cache, load_providers
-from earthlens.base.region import clear_region_cache, region_affinity
+from earthlens.base.region import (
+    clear_region_cache,
+    region_affinity,
+    warn_if_egress,
+)
 from earthlens.base.spatial import (
     METRES_PER_DEGREE,
     crop_to_aoi,
@@ -56,4 +60,5 @@ __all__ = [
     "resolve_aoi",
     "split_time",
     "to_datetime",
+    "warn_if_egress",
 ]

--- a/src/earthlens/base/__init__.py
+++ b/src/earthlens/base/__init__.py
@@ -21,6 +21,7 @@ from earthlens.base.auth import AbstractAuth, AuthenticationError
 from earthlens.base.http import HttpClient
 from earthlens.base.leaves import FluxableLeaf
 from earthlens.base.providers import Provider, clear_providers_cache, load_providers
+from earthlens.base.region import region_affinity
 from earthlens.base.spatial import (
     METRES_PER_DEGREE,
     crop_to_aoi,
@@ -50,6 +51,7 @@ __all__ = [
     "estimate_pixel_dims",
     "load_providers",
     "normalize_aoi",
+    "region_affinity",
     "resolve_aoi",
     "split_time",
     "to_datetime",

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -387,10 +387,20 @@ class HttpClient:
                     f"HTTP {response.status_code} on {url!r}; retry "
                     f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"
                 )
+                # Release the (possibly streamed) connection before retrying;
+                # a stream=True body is otherwise never consumed and its socket
+                # leaks out of the pool.
+                response.close()
                 self._sleep(wait)
                 attempt += 1
                 continue
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+            except requests.HTTPError:
+                # Close the final errored response too — for a streamed request
+                # the caller never receives it, so nothing else would.
+                response.close()
+                raise
             return response
 
     def _send(self, method: str, url: str, **kwargs: Any) -> requests.Response:

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -29,6 +29,7 @@ from collections.abc import Callable
 from typing import Any
 
 import requests
+from loguru import logger
 
 #: Per-request timeout (seconds) applied when a call passes no `timeout`.
 DEFAULT_TIMEOUT = 60.0
@@ -44,6 +45,41 @@ DEFAULT_BACKOFF_FACTOR = 1.0
 #: HTTP statuses that trigger a retry. `429` (rate-limited) plus the
 #: transient `5xx` gateway/unavailable family.
 DEFAULT_STATUS_FORCELIST: tuple[int, ...] = (429, 500, 502, 503, 504)
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a `Retry-After` header value into seconds.
+
+    Handles the integer-seconds form servers commonly return (e.g.
+    `Retry-After: 5`). A missing or non-numeric value yields `None` so
+    the caller falls back to exponential back-off. The HTTP-date form is
+    not parsed (no surveyed backend emits it); it also yields `None`.
+
+    Args:
+        value: The raw `Retry-After` header value, or `None`.
+
+    Returns:
+        The delay in seconds, or `None` when absent / unparseable.
+
+    Examples:
+        - A numeric value parses to seconds; junk yields `None`:
+            ```python
+            >>> from earthlens.base.http import _parse_retry_after
+            >>> _parse_retry_after("5")
+            5.0
+            >>> _parse_retry_after(None) is None
+            True
+            >>> _parse_retry_after("soon") is None
+            True
+
+            ```
+    """
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _default_user_agent() -> str:
@@ -206,13 +242,37 @@ class HttpClient:
         """Send a `POST` request. See :meth:`request` for arguments."""
         return self.request("POST", url, **kwargs)
 
+    def get_json(self, url: str, **kwargs: Any) -> Any:
+        """Send a `GET` request and decode the JSON response body.
+
+        Convenience over :meth:`get` for the REST endpoints that return
+        JSON envelopes.
+
+        Args:
+            url: Absolute request URL.
+            **kwargs: Keyword arguments forwarded to :meth:`get`
+                (`params`, `headers`, `timeout`, ...).
+
+        Returns:
+            The parsed JSON body (typically a `dict` or `list`).
+
+        Raises:
+            requests.HTTPError: On a non-retryable error status, or after
+                the retryable status is exhausted.
+        """
+        return self.get(url, **kwargs).json()
+
     def _request_with_retry(
         self, method: str, url: str, **kwargs: Any
     ) -> requests.Response:
-        """Send one request and raise for status (single-shot).
+        """Send one request, retrying retryable statuses with back-off.
 
-        The retry/back-off loop is layered on in `C2`; this base form
-        issues a single request and raises on any error status.
+        Retries while the response status is in `status_forcelist` and
+        the attempt budget is not spent: it waits `Retry-After` seconds
+        when the header is present and numeric, otherwise
+        `backoff_factor * 2**attempt`. Once the status is non-retryable
+        or the retries are exhausted, `raise_for_status` decides success
+        or error.
 
         Args:
             method: HTTP verb.
@@ -221,10 +281,33 @@ class HttpClient:
 
         Returns:
             requests.Response: The response after `raise_for_status`.
+
+        Raises:
+            requests.HTTPError: On a non-retryable error status, or after
+                the retryable status is exhausted.
         """
-        response = self._send(method, url, **kwargs)
-        response.raise_for_status()
-        return response
+        attempt = 0
+        while True:
+            response = self._send(method, url, **kwargs)
+            if (
+                response.status_code in self.status_forcelist
+                and attempt < self.max_retries
+            ):
+                retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+                wait = (
+                    retry_after
+                    if retry_after is not None
+                    else self.backoff_factor * (2**attempt)
+                )
+                logger.warning(
+                    f"HTTP {response.status_code} on {url!r}; retry "
+                    f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"
+                )
+                self._sleep(wait)
+                attempt += 1
+                continue
+            response.raise_for_status()
+            return response
 
     def _send(self, method: str, url: str, **kwargs: Any) -> requests.Response:
         """Dispatch to the session's verb method, falling back to `request`.

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -30,6 +30,7 @@ from collections.abc import Callable
 from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import requests
 from loguru import logger
@@ -111,6 +112,36 @@ def _parse_retry_after(value: str | None) -> float | None:
         return None
     now = dt.datetime.now(tz=target.tzinfo)
     return max(0.0, (target - now).total_seconds())
+
+
+def _redact_url(url: str) -> str:
+    """Return `scheme://host` for logging, hiding any secret in the URL.
+
+    Retry warnings must never echo the full request URL: some backends
+    carry a credential in the URL itself — a path segment (FIRMS
+    `MAP_KEY`) or a query parameter (NREL `api_key`, WDPA `?token=`). The
+    path, query, and fragment are dropped so only the (non-secret) scheme
+    and host reach the log.
+
+    Args:
+        url: The request URL.
+
+    Returns:
+        `"scheme://host"`, or `"<url>"` when the input has no scheme/host.
+
+    Examples:
+        - The path and query — where secrets ride — are stripped:
+            ```python
+            >>> from earthlens.base.http import _redact_url
+            >>> _redact_url("https://firms.example/api/SECRETKEY/area?x=1")
+            'https://firms.example'
+
+            ```
+    """
+    parts = urlsplit(url)
+    if not parts.scheme or not parts.netloc:
+        return "<url>"
+    return f"{parts.scheme}://{parts.netloc}"
 
 
 def _progress_total(headers: Any) -> int | None:
@@ -491,7 +522,7 @@ class HttpClient:
                         )
                         wait = self._backoff_wait(retry_after, attempt)
                         logger.warning(
-                            f"HTTP {response.status_code} on {url!r}; retry "
+                            f"HTTP {response.status_code} on {_redact_url(url)}; retry "
                             f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"
                         )
                         self._sleep(wait)
@@ -509,7 +540,7 @@ class HttpClient:
                     raise
                 wait = self._backoff_wait(None, attempt)
                 logger.warning(
-                    f"{type(exc).__name__} on {url!r}; retry "
+                    f"{type(exc).__name__} on {_redact_url(url)}; retry "
                     f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"
                 )
                 self._sleep(wait)
@@ -606,7 +637,7 @@ class HttpClient:
                     raise
                 wait = self._backoff_wait(None, attempt)
                 logger.warning(
-                    f"{type(exc).__name__} on {url!r}; retry "
+                    f"{type(exc).__name__} on {_redact_url(url)}; retry "
                     f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"
                 )
                 self._sleep(wait)
@@ -619,7 +650,7 @@ class HttpClient:
                 retry_after = _parse_retry_after(response.headers.get("Retry-After"))
                 wait = self._backoff_wait(retry_after, attempt)
                 logger.warning(
-                    f"HTTP {response.status_code} on {url!r}; retry "
+                    f"HTTP {response.status_code} on {_redact_url(url)}; retry "
                     f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"
                 )
                 # Release the (possibly streamed) connection before retrying;

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -166,6 +166,9 @@ class HttpClient:
             `Retry-After` header is present.
         status_forcelist: HTTP statuses that trigger a retry.
         max_backoff: Ceiling in seconds on any single retry wait.
+        retry_on_exceptions: Transport exception types that trigger a retry.
+        raise_for_status: Whether the final response is `raise_for_status`-ed.
+        min_interval: Minimum seconds between consecutive requests.
 
     Examples:
         - The default agent is non-Mozilla and version-stamped:
@@ -188,6 +191,11 @@ class HttpClient:
         backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
         status_forcelist: tuple[int, ...] = DEFAULT_STATUS_FORCELIST,
         max_backoff: float | None = DEFAULT_MAX_BACKOFF,
+        retry_on_exceptions: tuple[type[BaseException], ...] = (),
+        retry_predicate: Callable[[requests.Response], bool] | None = None,
+        raise_for_status: bool = True,
+        min_interval: float = 0.0,
+        clock: Callable[[], float] = time.monotonic,
         sleep: Callable[[float], None] = time.sleep,
     ) -> None:
         """Build a client with default headers, timeout, and retry policy.
@@ -211,9 +219,28 @@ class HttpClient:
             max_backoff: Ceiling in seconds on any single retry wait, so a
                 large `Retry-After` cannot pin the thread indefinitely.
                 `None` disables the cap.
-            sleep: The sleep function used between retries. Defaults to
-                :func:`time.sleep`; injectable so tests run without real
-                delays.
+            retry_on_exceptions: Exception types that also trigger a retry
+                when raised by the transport (e.g.
+                `(requests.ConnectionError, requests.Timeout)`). Empty
+                (the default) retries on status only, never on a raised
+                exception.
+            retry_predicate: An optional callback `(response) -> bool`
+                that, when it returns `True`, marks a response retryable
+                even if its status is not in `status_forcelist` (e.g. a
+                `200` whose body signals a rate-limit).
+            raise_for_status: Whether to call `raise_for_status` on the
+                final response. `False` returns the response unraised so
+                the caller can inspect the status itself (e.g. to redact a
+                secret-bearing URL from the error, or to branch on a
+                `4xx`). Overridable per request.
+            min_interval: Minimum seconds between consecutive requests
+                (a proactive client-side rate limit). `0.0` (default)
+                disables throttling.
+            clock: Monotonic clock used for the `min_interval` throttle.
+                Injectable so tests drive it deterministically.
+            sleep: The sleep function used between retries and for the
+                throttle. Defaults to :func:`time.sleep`; injectable so
+                tests run without real delays.
         """
         self._session = session if session is not None else requests.Session()
         self._user_agent = user_agent or _default_user_agent()
@@ -222,7 +249,13 @@ class HttpClient:
         self.backoff_factor = backoff_factor
         self.status_forcelist = tuple(status_forcelist)
         self.max_backoff = max_backoff
+        self.retry_on_exceptions = tuple(retry_on_exceptions)
+        self._retry_predicate = retry_predicate
+        self.raise_for_status = raise_for_status
+        self.min_interval = min_interval
+        self._clock = clock
         self._sleep = sleep
+        self._last_request: float | None = None
         self._default_headers: dict[str, str] = {
             "User-Agent": self._user_agent,
             "Accept-Encoding": "gzip, deflate",
@@ -254,6 +287,7 @@ class HttpClient:
         *,
         headers: dict[str, str] | None = None,
         timeout: float | None = None,
+        raise_for_status: bool | None = None,
         **kwargs: Any,
     ) -> requests.Response:
         """Send one request with the default headers, timeout, and retry.
@@ -264,21 +298,30 @@ class HttpClient:
             headers: Per-request headers merged over the client defaults.
             timeout: Per-request timeout override (seconds). Defaults to
                 the client's `timeout`.
+            raise_for_status: Per-request override of the client's
+                `raise_for_status` policy. `None` (default) uses the
+                client setting.
             **kwargs: Extra keyword arguments forwarded to `requests`
                 (`params`, `data`, `json`, `stream`, ...).
 
         Returns:
-            requests.Response: The successful response (after
-                `raise_for_status`).
+            requests.Response: The response (after `raise_for_status`
+                unless it is disabled).
 
         Raises:
             requests.HTTPError: On a non-retryable error status, or after
-                the retryable status is exhausted.
+                the retryable status is exhausted (when `raise_for_status`
+                is on).
         """
         merged = self._merge_headers(headers)
         effective_timeout = self.timeout if timeout is None else timeout
         return self._request_with_retry(
-            method, url, headers=merged, timeout=effective_timeout, **kwargs
+            method,
+            url,
+            headers=merged,
+            timeout=effective_timeout,
+            raise_for_status=raise_for_status,
+            **kwargs,
         )
 
     def get(self, url: str, **kwargs: Any) -> requests.Response:
@@ -385,46 +428,102 @@ class HttpClient:
             response.close()
         return dest
 
-    def _request_with_retry(
-        self, method: str, url: str, **kwargs: Any
-    ) -> requests.Response:
-        """Send one request, retrying retryable statuses with back-off.
+    def _throttle(self) -> None:
+        """Sleep so consecutive requests are >= `min_interval` apart.
 
-        Retries while the response status is in `status_forcelist` and
-        the attempt budget is not spent: it waits `Retry-After` seconds
-        when the header is present and numeric, otherwise
-        `backoff_factor * 2**attempt`. Once the status is non-retryable
-        or the retries are exhausted, `raise_for_status` decides success
-        or error.
+        A no-op when `min_interval` is `0`. Uses the injected monotonic
+        `clock`, records the send time, and sleeps via the injected
+        `sleep` so tests drive the rate limit deterministically.
+        """
+        if self.min_interval <= 0:
+            return
+        if self._last_request is not None:
+            remaining = self.min_interval - (self._clock() - self._last_request)
+            if remaining > 0:
+                self._sleep(remaining)
+        self._last_request = self._clock()
+
+    def _backoff_wait(self, retry_after: float | None, attempt: int) -> float:
+        """Compute one retry wait: `Retry-After` else exponential back-off.
+
+        Applies the `max_backoff` ceiling and a non-negative floor.
+
+        Args:
+            retry_after: Parsed `Retry-After` seconds, or `None`.
+            attempt: The zero-based attempt index.
+
+        Returns:
+            The clamped wait in seconds.
+        """
+        wait = (
+            retry_after
+            if retry_after is not None
+            else self.backoff_factor * (2**attempt)
+        )
+        if self.max_backoff is not None:
+            wait = min(wait, self.max_backoff)
+        return max(0.0, wait)
+
+    def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        *,
+        raise_for_status: bool | None = None,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """Send one request, retrying statuses/exceptions with back-off.
+
+        Retries while the attempt budget holds and either the response
+        status is in `status_forcelist`, the `retry_predicate` marks the
+        response retryable, or the transport raised one of
+        `retry_on_exceptions`. Waits `Retry-After` seconds when present
+        and numeric, otherwise `backoff_factor * 2**attempt` (capped by
+        `max_backoff`). Honours the `min_interval` throttle before every
+        send. Once non-retryable or exhausted, the response is
+        `raise_for_status`-ed unless that is disabled, then returned.
 
         Args:
             method: HTTP verb.
             url: Absolute request URL.
+            raise_for_status: Per-request override; `None` uses the
+                client policy.
             **kwargs: Keyword arguments forwarded to the session.
 
         Returns:
-            requests.Response: The response after `raise_for_status`.
+            requests.Response: The final response.
 
         Raises:
-            requests.HTTPError: On a non-retryable error status, or after
-                the retryable status is exhausted.
+            requests.HTTPError: On a non-retryable error status when
+                `raise_for_status` is on.
+            BaseException: The last transport exception, re-raised after
+                the `retry_on_exceptions` budget is exhausted.
         """
+        effective_raise = (
+            self.raise_for_status if raise_for_status is None else raise_for_status
+        )
         attempt = 0
         while True:
-            response = self._send(method, url, **kwargs)
-            if (
-                response.status_code in self.status_forcelist
-                and attempt < self.max_retries
-            ):
-                retry_after = _parse_retry_after(response.headers.get("Retry-After"))
-                wait = (
-                    retry_after
-                    if retry_after is not None
-                    else self.backoff_factor * (2**attempt)
+            self._throttle()
+            try:
+                response = self._send(method, url, **kwargs)
+            except self.retry_on_exceptions as exc:
+                if attempt >= self.max_retries:
+                    raise
+                wait = self._backoff_wait(None, attempt)
+                logger.warning(
+                    f"{type(exc).__name__} on {url!r}; retry "
+                    f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"
                 )
-                if self.max_backoff is not None:
-                    wait = min(wait, self.max_backoff)
-                wait = max(0.0, wait)
+                self._sleep(wait)
+                attempt += 1
+                continue
+            retryable = response.status_code in self.status_forcelist or (
+                self._retry_predicate is not None and self._retry_predicate(response)
+            )
+            if retryable and attempt < self.max_retries:
+                retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+                wait = self._backoff_wait(retry_after, attempt)
                 logger.warning(
                     f"HTTP {response.status_code} on {url!r}; retry "
                     f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"
@@ -436,13 +535,14 @@ class HttpClient:
                 self._sleep(wait)
                 attempt += 1
                 continue
-            try:
-                response.raise_for_status()
-            except requests.HTTPError:
-                # Close the final errored response too — for a streamed request
-                # the caller never receives it, so nothing else would.
-                response.close()
-                raise
+            if effective_raise:
+                try:
+                    response.raise_for_status()
+                except requests.HTTPError:
+                    # Close the final errored response too — for a streamed
+                    # request the caller never receives it, so nothing else would.
+                    response.close()
+                    raise
             return response
 
     def _send(self, method: str, url: str, **kwargs: Any) -> requests.Response:

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -556,7 +556,13 @@ class HttpClient:
                 tmp.unlink(missing_ok=True)
                 raise
             if atomic:
-                tmp.replace(dest)
+                # Guard the rename too, so the "removes the temp on any
+                # failure" promise holds if the final replace fails.
+                try:
+                    tmp.replace(dest)
+                except BaseException:
+                    tmp.unlink(missing_ok=True)
+                    raise
             return dest
 
     def _throttle(self) -> None:

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -87,6 +87,29 @@ def _parse_retry_after(value: str | None) -> float | None:
         return None
 
 
+def _progress_total(headers: Any) -> int | None:
+    """Return the download progress-bar total from response headers.
+
+    Uses `Content-Length` only for an untransformed body: it reports the
+    *compressed* size, but `iter_content` yields *decompressed* bytes, so
+    a `Content-Encoding` (e.g. gzip) response would overshoot the bar. In
+    that case (or when the length is absent / non-numeric) the total is
+    `None` and the bar runs unbounded.
+
+    Args:
+        headers: The response headers mapping.
+
+    Returns:
+        The byte total, or `None` when it cannot be trusted.
+    """
+    if headers.get("Content-Encoding"):
+        return None
+    raw_length = headers.get("Content-Length")
+    if raw_length is not None and raw_length.isdigit():
+        return int(raw_length)
+    return None
+
+
 def _default_user_agent() -> str:
     """Return the default `User-Agent`, `earthlens/{version}`.
 
@@ -323,10 +346,7 @@ class HttpClient:
         dest = Path(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)
         response = self.stream(url, headers=headers, timeout=timeout, **kwargs)
-        raw_length = response.headers.get("Content-Length")
-        total = (
-            int(raw_length) if raw_length is not None and raw_length.isdigit() else None
-        )
+        total = _progress_total(response.headers)
         bar = tqdm(
             total=total,
             unit="B",

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -24,8 +24,10 @@ module adds none. The public import is
 
 from __future__ import annotations
 
+import datetime as dt
 import time
 from collections.abc import Callable
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any
 
@@ -60,12 +62,13 @@ DEFAULT_CHUNK_SIZE = 1 << 20
 def _parse_retry_after(value: str | None) -> float | None:
     """Parse a `Retry-After` header value into seconds.
 
-    Handles the integer-seconds form servers commonly return (e.g.
-    `Retry-After: 5`). A missing, non-numeric, or **negative** value
-    yields `None` so the caller falls back to exponential back-off (the
-    spec mandates a non-negative delay; a negative one is invalid). The
-    HTTP-date form is not parsed (no surveyed backend emits it); it also
-    yields `None`.
+    RFC 9110 §10.2.3 allows either an integer number of seconds (e.g.
+    `Retry-After: 5`) or an HTTP-date
+    (`Retry-After: Fri, 31 Dec 2027 23:59:59 GMT`); both forms are
+    handled. A missing, non-numeric, or **negative** numeric value yields
+    `None` so the caller falls back to exponential back-off (the spec
+    mandates a non-negative delay; a negative one is invalid). A past
+    HTTP-date clamps to `0.0` (never sleep backwards in time).
 
     Args:
         value: The raw `Retry-After` header value, or `None`.
@@ -76,7 +79,7 @@ def _parse_retry_after(value: str | None) -> float | None:
 
     Examples:
         - A numeric value parses to seconds; junk or a negative yields
-          `None`:
+          `None`, and a past HTTP-date clamps to zero:
             ```python
             >>> from earthlens.base.http import _parse_retry_after
             >>> _parse_retry_after("5")
@@ -87,16 +90,27 @@ def _parse_retry_after(value: str | None) -> float | None:
             True
             >>> _parse_retry_after("-1") is None
             True
+            >>> _parse_retry_after("Fri, 31 Dec 1999 23:59:59 GMT")
+            0.0
 
             ```
     """
-    if value is None:
+    if not value:
         return None
     try:
         seconds = float(value)
     except (TypeError, ValueError):
+        pass
+    else:
+        return seconds if seconds >= 0 else None
+    try:
+        target = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
         return None
-    return seconds if seconds >= 0 else None
+    if target is None:
+        return None
+    now = dt.datetime.now(tz=target.tzinfo)
+    return max(0.0, (target - now).total_seconds())
 
 
 def _progress_total(headers: Any) -> int | None:

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -493,12 +493,17 @@ class HttpClient:
             Path: The `dest` path the bytes were written to.
 
         Raises:
-            requests.HTTPError: On a non-retryable error status —
-                `download` **always** raises on an error status (the
-                client's `raise_for_status` flag governs the verb methods,
-                not `download`; a file fetch never keeps an error body) —
-                or the last transport exception after the retry budget is
-                exhausted.
+            requests.HTTPError: On an error status — `download` always
+                calls `raise_for_status` (the client's `raise_for_status`
+                flag governs the verb methods, not `download`; a file
+                fetch never keeps an error body). Note the resulting
+                `HTTPError` is itself subject to `retry_on_exceptions`:
+                a client whose `retry_on_exceptions` includes a supertype
+                of `requests.HTTPError` (e.g. `requests.RequestException`,
+                as ghsl/glaciers pass) will **retry** an error status
+                before raising it, mirroring their old download loops.
+                Also the last transport exception after the retry budget
+                is exhausted.
         """
         dest = Path(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -10,9 +10,9 @@ owns exactly those transport concerns so a backend keeps only the
 auth-header values, and response parsing.
 
 The retry engine is a hand-rolled loop (not `urllib3.util.retry.Retry`
-mounted on an `HTTPAdapter`) generalising the reference
-`earthlens.openaq.client.OpenaqClient._request` loop: `Retry-After`
-first, else `backoff_factor * 2**attempt`. Both the transport
+mounted on an `HTTPAdapter`) generalising the loop the REST backends
+(openaq first) previously hand-rolled: `Retry-After` first, else
+`backoff_factor * 2**attempt`. Both the transport
 (`session=`) and the wait (`sleep=`) are injectable, so the whole client
 is unit-testable with a fake transport — no live network, no real
 delays.

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -324,7 +324,9 @@ class HttpClient:
         dest.parent.mkdir(parents=True, exist_ok=True)
         response = self.stream(url, headers=headers, timeout=timeout, **kwargs)
         raw_length = response.headers.get("Content-Length")
-        total = int(raw_length) if raw_length is not None and raw_length.isdigit() else None
+        total = (
+            int(raw_length) if raw_length is not None and raw_length.isdigit() else None
+        )
         bar = tqdm(
             total=total,
             unit="B",

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -26,10 +26,12 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import requests
 from loguru import logger
+from tqdm import tqdm
 
 #: Per-request timeout (seconds) applied when a call passes no `timeout`.
 DEFAULT_TIMEOUT = 60.0
@@ -45,6 +47,9 @@ DEFAULT_BACKOFF_FACTOR = 1.0
 #: HTTP statuses that trigger a retry. `429` (rate-limited) plus the
 #: transient `5xx` gateway/unavailable family.
 DEFAULT_STATUS_FORCELIST: tuple[int, ...] = (429, 500, 502, 503, 504)
+
+#: Streaming chunk size (bytes) for :meth:`HttpClient.download` — 1 MiB.
+DEFAULT_CHUNK_SIZE = 1 << 20
 
 
 def _parse_retry_after(value: str | None) -> float | None:
@@ -261,6 +266,83 @@ class HttpClient:
                 the retryable status is exhausted.
         """
         return self.get(url, **kwargs).json()
+
+    def stream(self, url: str, **kwargs: Any) -> requests.Response:
+        """Send a streaming `GET` (`stream=True`), retry-wrapped.
+
+        Returns the open response without consuming its body, so the
+        caller can iterate `iter_content`. Retries follow the same
+        `Retry-After`/back-off policy as the other verbs; the retry
+        decision reads only the status line, never the body.
+
+        Args:
+            url: Absolute request URL.
+            **kwargs: Keyword arguments forwarded to :meth:`get`.
+
+        Returns:
+            requests.Response: The open streaming response.
+        """
+        return self.get(url, stream=True, **kwargs)
+
+    def download(
+        self,
+        url: str,
+        dest: str | Path,
+        *,
+        chunk: int = DEFAULT_CHUNK_SIZE,
+        progress: bool = True,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+        **kwargs: Any,
+    ) -> Path:
+        """Stream `url` to `dest`, optionally showing a `tqdm` bar.
+
+        Absorbs the chunk-loop the streamed-download backends each
+        re-implement: streams with `stream=True`, sizes a progress bar
+        from `Content-Length` when present, writes 1 MiB blocks to
+        `dest` (creating parent directories), and returns the path. The
+        initial response is retry-wrapped via :meth:`stream`.
+
+        Args:
+            url: Absolute request URL.
+            dest: Output file path. Parent directories are created.
+            chunk: Streaming block size in bytes (default 1 MiB).
+            progress: Show a `tqdm` progress bar. `False` (or a
+                non-interactive / test context) suppresses it.
+            headers: Per-request headers merged over the client defaults.
+            timeout: Per-request timeout override (seconds).
+            **kwargs: Extra keyword arguments forwarded to `requests`.
+
+        Returns:
+            Path: The `dest` path the bytes were written to.
+
+        Raises:
+            requests.HTTPError: On a non-retryable error status, or after
+                the retryable status is exhausted.
+        """
+        dest = Path(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        response = self.stream(url, headers=headers, timeout=timeout, **kwargs)
+        raw_length = response.headers.get("Content-Length")
+        total = int(raw_length) if raw_length is not None and raw_length.isdigit() else None
+        bar = tqdm(
+            total=total,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
+            disable=not progress,
+            desc=dest.name,
+        )
+        try:
+            with open(dest, "wb") as handle:
+                for block in response.iter_content(chunk_size=chunk):
+                    if block:
+                        handle.write(block)
+                        bar.update(len(block))
+        finally:
+            bar.close()
+            response.close()
+        return dest
 
     def _request_with_retry(
         self, method: str, url: str, **kwargs: Any

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -44,6 +44,11 @@ DEFAULT_MAX_RETRIES = 5
 #: `Retry-After` header (wait = `backoff_factor * 2**attempt`).
 DEFAULT_BACKOFF_FACTOR = 1.0
 
+#: Ceiling (seconds) on any single retry wait, so a hostile or
+#: misconfigured `Retry-After` cannot pin the calling thread for an
+#: unbounded interval. `None` disables the cap.
+DEFAULT_MAX_BACKOFF = 300.0
+
 #: HTTP statuses that trigger a retry. `429` (rate-limited) plus the
 #: transient `5xx` gateway/unavailable family.
 DEFAULT_STATUS_FORCELIST: tuple[int, ...] = (429, 500, 502, 503, 504)
@@ -152,6 +157,7 @@ class HttpClient:
         backoff_factor: Base seconds for exponential back-off when no
             `Retry-After` header is present.
         status_forcelist: HTTP statuses that trigger a retry.
+        max_backoff: Ceiling in seconds on any single retry wait.
 
     Examples:
         - The default agent is non-Mozilla and version-stamped:
@@ -173,6 +179,7 @@ class HttpClient:
         max_retries: int = DEFAULT_MAX_RETRIES,
         backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
         status_forcelist: tuple[int, ...] = DEFAULT_STATUS_FORCELIST,
+        max_backoff: float | None = DEFAULT_MAX_BACKOFF,
         sleep: Callable[[float], None] = time.sleep,
     ) -> None:
         """Build a client with default headers, timeout, and retry policy.
@@ -193,6 +200,9 @@ class HttpClient:
             backoff_factor: Base seconds for exponential back-off when a
                 response carries no `Retry-After` header.
             status_forcelist: HTTP statuses that trigger a retry.
+            max_backoff: Ceiling in seconds on any single retry wait, so a
+                large `Retry-After` cannot pin the thread indefinitely.
+                `None` disables the cap.
             sleep: The sleep function used between retries. Defaults to
                 :func:`time.sleep`; injectable so tests run without real
                 delays.
@@ -203,6 +213,7 @@ class HttpClient:
         self.max_retries = max_retries
         self.backoff_factor = backoff_factor
         self.status_forcelist = tuple(status_forcelist)
+        self.max_backoff = max_backoff
         self._sleep = sleep
         self._default_headers: dict[str, str] = {
             "User-Agent": self._user_agent,
@@ -403,6 +414,8 @@ class HttpClient:
                     if retry_after is not None
                     else self.backoff_factor * (2**attempt)
                 )
+                if self.max_backoff is not None:
+                    wait = min(wait, self.max_backoff)
                 logger.warning(
                     f"HTTP {response.status_code} on {url!r}; retry "
                     f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -369,45 +369,24 @@ class HttpClient:
         """
         return self.get(url, stream=True, **kwargs)
 
-    def download(
+    def _stream_to_file(
         self,
-        url: str,
-        dest: str | Path,
+        response: requests.Response,
+        dest: Path,
         *,
-        chunk: int = DEFAULT_CHUNK_SIZE,
-        progress: bool = True,
-        headers: dict[str, str] | None = None,
-        timeout: float | None = None,
-        **kwargs: Any,
-    ) -> Path:
-        """Stream `url` to `dest`, optionally showing a `tqdm` bar.
-
-        Absorbs the chunk-loop the streamed-download backends each
-        re-implement: streams with `stream=True`, sizes a progress bar
-        from `Content-Length` when present, writes 1 MiB blocks to
-        `dest` (creating parent directories), and returns the path. The
-        initial response is retry-wrapped via :meth:`stream`.
+        chunk: int,
+        progress: bool,
+        desc: str,
+    ) -> None:
+        """Write a streaming response's body to `dest` with a `tqdm` bar.
 
         Args:
-            url: Absolute request URL.
-            dest: Output file path. Parent directories are created.
-            chunk: Streaming block size in bytes (default 1 MiB).
-            progress: Show a `tqdm` progress bar. `False` (or a
-                non-interactive / test context) suppresses it.
-            headers: Per-request headers merged over the client defaults.
-            timeout: Per-request timeout override (seconds).
-            **kwargs: Extra keyword arguments forwarded to `requests`.
-
-        Returns:
-            Path: The `dest` path the bytes were written to.
-
-        Raises:
-            requests.HTTPError: On a non-retryable error status, or after
-                the retryable status is exhausted.
+            response: The open streaming response.
+            dest: The file to write (typically a temp `.part` path).
+            chunk: Streaming block size in bytes.
+            progress: Whether to show the progress bar.
+            desc: The bar label (the final file name).
         """
-        dest = Path(dest)
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        response = self.stream(url, headers=headers, timeout=timeout, **kwargs)
         total = _progress_total(response.headers)
         bar = tqdm(
             total=total,
@@ -415,7 +394,7 @@ class HttpClient:
             unit_scale=True,
             unit_divisor=1024,
             disable=not progress,
-            desc=dest.name,
+            desc=desc,
         )
         try:
             with open(dest, "wb") as handle:
@@ -425,8 +404,109 @@ class HttpClient:
                         bar.update(len(block))
         finally:
             bar.close()
-            response.close()
-        return dest
+
+    def download(
+        self,
+        url: str,
+        dest: str | Path,
+        *,
+        chunk: int = DEFAULT_CHUNK_SIZE,
+        progress: bool = True,
+        atomic: bool = True,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+        **kwargs: Any,
+    ) -> Path:
+        """Stream `url` to `dest` atomically, optionally showing a `tqdm` bar.
+
+        Absorbs the chunk-loop the streamed-download backends each
+        re-implement: streams with `stream=True`, sizes a progress bar
+        from `Content-Length` when present, and writes 1 MiB blocks. When
+        `atomic` (the default) it writes to a sibling `<dest>.part` and
+        renames on success, and it removes the temp on any failure — so a
+        crashed or interrupted download never leaves a truncated `dest`.
+        The whole download is retry-wrapped: a status in `status_forcelist`
+        or an exception in `retry_on_exceptions` retries the attempt (after
+        cleaning the temp), honouring the `Retry-After`/back-off policy.
+
+        Args:
+            url: Absolute request URL.
+            dest: Output file path. Parent directories are created.
+            chunk: Streaming block size in bytes (default 1 MiB).
+            progress: Show a `tqdm` progress bar. `False` (or a
+                non-interactive / test context) suppresses it.
+            atomic: Write to `<dest>.part` then rename on success, cleaning
+                up the temp on failure. `False` writes straight to `dest`.
+            headers: Per-request headers merged over the client defaults.
+            timeout: Per-request timeout override (seconds).
+            **kwargs: Extra keyword arguments forwarded to `requests`.
+
+        Returns:
+            Path: The `dest` path the bytes were written to.
+
+        Raises:
+            requests.HTTPError: On a non-retryable error status (when
+                `raise_for_status` is on), or the last transport exception
+                after the retry budget is exhausted.
+        """
+        dest = Path(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        tmp = dest.with_name(dest.name + ".part") if atomic else dest
+        merged = self._merge_headers(headers)
+        effective_timeout = self.timeout if timeout is None else timeout
+        attempt = 0
+        while True:
+            self._throttle()
+            try:
+                response = self._send(
+                    "GET",
+                    url,
+                    stream=True,
+                    headers=merged,
+                    timeout=effective_timeout,
+                    **kwargs,
+                )
+                try:
+                    retryable = response.status_code in self.status_forcelist or (
+                        self._retry_predicate is not None
+                        and self._retry_predicate(response)
+                    )
+                    if retryable and attempt < self.max_retries:
+                        retry_after = _parse_retry_after(
+                            response.headers.get("Retry-After")
+                        )
+                        wait = self._backoff_wait(retry_after, attempt)
+                        logger.warning(
+                            f"HTTP {response.status_code} on {url!r}; retry "
+                            f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"
+                        )
+                        self._sleep(wait)
+                        attempt += 1
+                        continue
+                    response.raise_for_status()
+                    self._stream_to_file(
+                        response, tmp, chunk=chunk, progress=progress, desc=dest.name
+                    )
+                finally:
+                    response.close()
+            except self.retry_on_exceptions as exc:
+                tmp.unlink(missing_ok=True)
+                if attempt >= self.max_retries:
+                    raise
+                wait = self._backoff_wait(None, attempt)
+                logger.warning(
+                    f"{type(exc).__name__} on {url!r}; retry "
+                    f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"
+                )
+                self._sleep(wait)
+                attempt += 1
+                continue
+            except BaseException:
+                tmp.unlink(missing_ok=True)
+                raise
+            if atomic:
+                tmp.replace(dest)
+            return dest
 
     def _throttle(self) -> None:
         """Sleep so consecutive requests are >= `min_interval` apart.

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -61,18 +61,22 @@ def _parse_retry_after(value: str | None) -> float | None:
     """Parse a `Retry-After` header value into seconds.
 
     Handles the integer-seconds form servers commonly return (e.g.
-    `Retry-After: 5`). A missing or non-numeric value yields `None` so
-    the caller falls back to exponential back-off. The HTTP-date form is
-    not parsed (no surveyed backend emits it); it also yields `None`.
+    `Retry-After: 5`). A missing, non-numeric, or **negative** value
+    yields `None` so the caller falls back to exponential back-off (the
+    spec mandates a non-negative delay; a negative one is invalid). The
+    HTTP-date form is not parsed (no surveyed backend emits it); it also
+    yields `None`.
 
     Args:
         value: The raw `Retry-After` header value, or `None`.
 
     Returns:
-        The delay in seconds, or `None` when absent / unparseable.
+        The delay in seconds, or `None` when absent / unparseable /
+        negative.
 
     Examples:
-        - A numeric value parses to seconds; junk yields `None`:
+        - A numeric value parses to seconds; junk or a negative yields
+          `None`:
             ```python
             >>> from earthlens.base.http import _parse_retry_after
             >>> _parse_retry_after("5")
@@ -81,15 +85,18 @@ def _parse_retry_after(value: str | None) -> float | None:
             True
             >>> _parse_retry_after("soon") is None
             True
+            >>> _parse_retry_after("-1") is None
+            True
 
             ```
     """
     if value is None:
         return None
     try:
-        return float(value)
+        seconds = float(value)
     except (TypeError, ValueError):
         return None
+    return seconds if seconds >= 0 else None
 
 
 def _progress_total(headers: Any) -> int | None:
@@ -107,7 +114,8 @@ def _progress_total(headers: Any) -> int | None:
     Returns:
         The byte total, or `None` when it cannot be trusted.
     """
-    if headers.get("Content-Encoding"):
+    encoding = (headers.get("Content-Encoding") or "").strip().lower()
+    if encoding and encoding != "identity":
         return None
     raw_length = headers.get("Content-Length")
     if raw_length is not None and raw_length.isdigit():
@@ -416,6 +424,7 @@ class HttpClient:
                 )
                 if self.max_backoff is not None:
                     wait = min(wait, self.max_backoff)
+                wait = max(0.0, wait)
                 logger.warning(
                     f"HTTP {response.status_code} on {url!r}; retry "
                     f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -1,0 +1,247 @@
+"""Shared `requests`-based HTTP client for the REST-style backends.
+
+Every REST / event / air-quality / biodiversity backend repeats the
+same transport chores: a pooled `requests.Session`, a sensible default
+`User-Agent` and `Accept-Encoding`, a per-request timeout, a
+`Retry-After`-aware retry/back-off loop for `429`/`5xx`, JSON decoding,
+and a streamed `download()` with a `tqdm` progress bar. `HttpClient`
+owns exactly those transport concerns so a backend keeps only the
+`API`-shaped parts: endpoint paths, query params, pagination envelopes,
+auth-header values, and response parsing.
+
+The retry engine is a hand-rolled loop (not `urllib3.util.retry.Retry`
+mounted on an `HTTPAdapter`) generalising the reference
+`earthlens.openaq.client.OpenaqClient._request` loop: `Retry-After`
+first, else `backoff_factor * 2**attempt`. Both the transport
+(`session=`) and the wait (`sleep=`) are injectable, so the whole client
+is unit-testable with a fake transport — no live network, no real
+delays.
+
+`requests` and `tqdm` are already core earthlens dependencies, so this
+module adds none. The public import is
+`from earthlens.base.http import HttpClient`.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+import requests
+
+#: Per-request timeout (seconds) applied when a call passes no `timeout`.
+DEFAULT_TIMEOUT = 60.0
+
+#: Maximum retries for a retryable status before the last response's
+#: error is raised.
+DEFAULT_MAX_RETRIES = 5
+
+#: Base seconds for exponential back-off when a response carries no
+#: `Retry-After` header (wait = `backoff_factor * 2**attempt`).
+DEFAULT_BACKOFF_FACTOR = 1.0
+
+#: HTTP statuses that trigger a retry. `429` (rate-limited) plus the
+#: transient `5xx` gateway/unavailable family.
+DEFAULT_STATUS_FORCELIST: tuple[int, ...] = (429, 500, 502, 503, 504)
+
+
+def _default_user_agent() -> str:
+    """Return the default `User-Agent`, `earthlens/{version}`.
+
+    The version is read lazily from the installed package metadata so
+    importing this module never triggers a circular import against
+    `earthlens.__init__`. The string is deliberately **non-Mozilla**:
+    the DIGITAL.CSIC Anubis anti-bot wall (SPEIbase) blocks browser-like
+    `User-Agent`s, and several upstreams throttle the bare python-requests
+    default.
+
+    Returns:
+        The default agent string, e.g. `"earthlens/0.38.0"` (or
+        `"earthlens/unknown"` when the package metadata is unavailable).
+    """
+    from earthlens import __version__
+
+    return f"earthlens/{__version__}"
+
+
+class HttpClient:
+    """Reusable HTTP transport: session, headers, timeout, retry, download.
+
+    Wraps a :class:`requests.Session`, attaching default headers (a
+    non-Mozilla `User-Agent` and `Accept-Encoding: gzip, deflate`) to
+    every request and applying a shared timeout. The verbs
+    (:meth:`get`, :meth:`post`, :meth:`request`) route through a
+    `Retry-After`-aware back-off loop; :meth:`get_json` decodes the JSON
+    body and :meth:`download` streams a response to disk. Both the
+    session and the sleep function are injectable so the client is fully
+    unit-testable without a live network.
+
+    Default headers set at construction are merged with (and overridden
+    by) any per-request `headers=`, so a backend expresses its quirks —
+    openaq's `X-API-Key`, a descriptive osm contact `User-Agent` — without
+    subclassing.
+
+    Attributes:
+        timeout: Per-request timeout in seconds.
+        max_retries: Maximum retries on a retryable status before raising.
+        backoff_factor: Base seconds for exponential back-off when no
+            `Retry-After` header is present.
+        status_forcelist: HTTP statuses that trigger a retry.
+
+    Examples:
+        - The default agent is non-Mozilla and version-stamped:
+            ```python
+            >>> from earthlens.base.http import HttpClient
+            >>> HttpClient().default_headers["User-Agent"].startswith("earthlens/")
+            True
+
+            ```
+    """
+
+    def __init__(
+        self,
+        *,
+        session: requests.Session | None = None,
+        user_agent: str | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+        status_forcelist: tuple[int, ...] = DEFAULT_STATUS_FORCELIST,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        """Build a client with default headers, timeout, and retry policy.
+
+        Args:
+            session: An existing :class:`requests.Session` to reuse.
+                Defaults to a fresh session. Injectable so tests can
+                supply a fake transport.
+            user_agent: The default `User-Agent` header value. Defaults
+                to `earthlens/{version}` (non-Mozilla by design; see
+                :func:`_default_user_agent`).
+            headers: Extra default headers merged onto every request
+                (e.g. `{"X-API-Key": ...}`). Override per call with a
+                request-level `headers=`.
+            timeout: Per-request timeout in seconds.
+            max_retries: Maximum retries on a retryable status before the
+                last response's error is raised.
+            backoff_factor: Base seconds for exponential back-off when a
+                response carries no `Retry-After` header.
+            status_forcelist: HTTP statuses that trigger a retry.
+            sleep: The sleep function used between retries. Defaults to
+                :func:`time.sleep`; injectable so tests run without real
+                delays.
+        """
+        self._session = session if session is not None else requests.Session()
+        self._user_agent = user_agent or _default_user_agent()
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.backoff_factor = backoff_factor
+        self.status_forcelist = tuple(status_forcelist)
+        self._sleep = sleep
+        self._default_headers: dict[str, str] = {
+            "User-Agent": self._user_agent,
+            "Accept-Encoding": "gzip, deflate",
+        }
+        if headers:
+            self._default_headers.update(headers)
+
+    @property
+    def default_headers(self) -> dict[str, str]:
+        """Return a copy of the headers merged onto every request."""
+        return dict(self._default_headers)
+
+    @property
+    def session(self) -> requests.Session:
+        """Return the underlying :class:`requests.Session`."""
+        return self._session
+
+    def _merge_headers(self, headers: dict[str, str] | None) -> dict[str, str]:
+        """Merge per-request `headers` over the client's defaults."""
+        merged = dict(self._default_headers)
+        if headers:
+            merged.update(headers)
+        return merged
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """Send one request with the default headers, timeout, and retry.
+
+        Args:
+            method: HTTP verb (`"GET"`, `"POST"`, ...).
+            url: Absolute request URL.
+            headers: Per-request headers merged over the client defaults.
+            timeout: Per-request timeout override (seconds). Defaults to
+                the client's `timeout`.
+            **kwargs: Extra keyword arguments forwarded to `requests`
+                (`params`, `data`, `json`, `stream`, ...).
+
+        Returns:
+            requests.Response: The successful response (after
+                `raise_for_status`).
+
+        Raises:
+            requests.HTTPError: On a non-retryable error status, or after
+                the retryable status is exhausted.
+        """
+        merged = self._merge_headers(headers)
+        effective_timeout = self.timeout if timeout is None else timeout
+        return self._request_with_retry(
+            method, url, headers=merged, timeout=effective_timeout, **kwargs
+        )
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Send a `GET` request. See :meth:`request` for arguments."""
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> requests.Response:
+        """Send a `POST` request. See :meth:`request` for arguments."""
+        return self.request("POST", url, **kwargs)
+
+    def _request_with_retry(
+        self, method: str, url: str, **kwargs: Any
+    ) -> requests.Response:
+        """Send one request and raise for status (single-shot).
+
+        The retry/back-off loop is layered on in `C2`; this base form
+        issues a single request and raises on any error status.
+
+        Args:
+            method: HTTP verb.
+            url: Absolute request URL.
+            **kwargs: Keyword arguments forwarded to the session.
+
+        Returns:
+            requests.Response: The response after `raise_for_status`.
+        """
+        response = self._send(method, url, **kwargs)
+        response.raise_for_status()
+        return response
+
+    def _send(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        """Dispatch to the session's verb method, falling back to `request`.
+
+        Routing `GET` to `session.get` (rather than a generic
+        `session.request`) keeps drop-in fake transports that implement
+        only `get()` working — the shape the migrated backends' tests use.
+
+        Args:
+            method: HTTP verb.
+            url: Absolute request URL.
+            **kwargs: Keyword arguments forwarded to the session call.
+
+        Returns:
+            requests.Response: The raw response (no status check).
+        """
+        verb = getattr(self._session, method.lower(), None)
+        if callable(verb):
+            return verb(url, **kwargs)
+        return self._session.request(method, url, **kwargs)

--- a/src/earthlens/base/http.py
+++ b/src/earthlens/base/http.py
@@ -119,9 +119,9 @@ def _redact_url(url: str) -> str:
 
     Retry warnings must never echo the full request URL: some backends
     carry a credential in the URL itself — a path segment (FIRMS
-    `MAP_KEY`) or a query parameter (NREL `api_key`, WDPA `?token=`). The
-    path, query, and fragment are dropped so only the (non-secret) scheme
-    and host reach the log.
+    `MAP_KEY`), a query parameter (NREL `api_key`, WDPA `?token=`), or
+    userinfo (`user:pass@host`). Everything but the (non-secret) scheme
+    and host is dropped, so only `scheme://host` reaches the log.
 
     Args:
         url: The request URL.
@@ -130,18 +130,21 @@ def _redact_url(url: str) -> str:
         `"scheme://host"`, or `"<url>"` when the input has no scheme/host.
 
     Examples:
-        - The path and query — where secrets ride — are stripped:
+        - The path, query, and userinfo — where secrets ride — are
+          stripped:
             ```python
             >>> from earthlens.base.http import _redact_url
             >>> _redact_url("https://firms.example/api/SECRETKEY/area?x=1")
             'https://firms.example'
+            >>> _redact_url("https://user:pass@host/p")
+            'https://host'
 
             ```
     """
     parts = urlsplit(url)
-    if not parts.scheme or not parts.netloc:
+    if not parts.scheme or not parts.hostname:
         return "<url>"
-    return f"{parts.scheme}://{parts.netloc}"
+    return f"{parts.scheme}://{parts.hostname}"
 
 
 def _progress_total(headers: Any) -> int | None:
@@ -490,9 +493,12 @@ class HttpClient:
             Path: The `dest` path the bytes were written to.
 
         Raises:
-            requests.HTTPError: On a non-retryable error status (when
-                `raise_for_status` is on), or the last transport exception
-                after the retry budget is exhausted.
+            requests.HTTPError: On a non-retryable error status —
+                `download` **always** raises on an error status (the
+                client's `raise_for_status` flag governs the verb methods,
+                not `download`; a file fetch never keeps an error body) —
+                or the last transport exception after the retry budget is
+                exhausted.
         """
         dest = Path(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)

--- a/src/earthlens/base/region.py
+++ b/src/earthlens/base/region.py
@@ -62,7 +62,10 @@ _AZURE_LOCATION_URL = (
 _UNSET: object = object()
 
 #: Per-process cache of the detected caller region (`None` = probed but
-#: undetermined). Reset with :func:`clear_region_cache`.
+#: undetermined). Reset with :func:`clear_region_cache`. Intentionally
+#: lock-free: a first-call race between threads only repeats the fail-safe
+#: probe, and the assignment is atomic under the GIL, so there is no
+#: correctness bug — only (at most) a redundant probe on a cold start.
 _cached_region: str | None | object = _UNSET
 
 
@@ -198,7 +201,7 @@ def _detect_caller_region(*, timeout: float = PROBE_TIMEOUT) -> str | None:
 
 
 def region_affinity(
-    bucket_region: str,
+    bucket_region: str | None,
     *,
     caller_region: str | None = None,
     probe: bool = True,
@@ -213,7 +216,7 @@ def region_affinity(
 
     Args:
         bucket_region: The region the target bucket lives in (e.g.
-            `"us-west-2"`).
+            `"us-west-2"`). `None` or empty yields `"unknown"`.
         caller_region: An explicit override for the caller's region. When
             given, the environment and probe are not consulted.
         probe: Whether to fall back to the instance-metadata probe when
@@ -251,7 +254,7 @@ def region_affinity(
 
 
 def warn_if_egress(
-    bucket_region: str,
+    bucket_region: str | None,
     *,
     size_bytes: int,
     threshold_bytes: int = DEFAULT_EGRESS_THRESHOLD_BYTES,

--- a/src/earthlens/base/region.py
+++ b/src/earthlens/base/region.py
@@ -23,6 +23,7 @@ dependency.
 from __future__ import annotations
 
 import os
+import urllib.request
 
 #: The process runs in the same region as the target bucket.
 IN_REGION = "in-region"
@@ -32,6 +33,39 @@ EGRESS = "egress"
 
 #: The caller region could not be determined.
 UNKNOWN = "unknown"
+
+#: Hard timeout (seconds) for every instance-metadata probe. Keeps the
+#: fallback from ever blocking a download when the endpoint is absent.
+PROBE_TIMEOUT = 1.0
+
+#: AWS IMDSv2 base — a token PUT then a region GET.
+_AWS_TOKEN_URL = "http://169.254.169.254/latest/api/token"
+_AWS_REGION_URL = "http://169.254.169.254/latest/meta-data/placement/region"
+
+#: GCP metadata zone endpoint (needs the `Metadata-Flavor: Google` header).
+_GCP_ZONE_URL = "http://metadata.google.internal/computeMetadata/v1/instance/zone"
+
+#: Azure IMDS location endpoint (needs the `Metadata: true` header).
+_AZURE_LOCATION_URL = (
+    "http://169.254.169.254/metadata/instance/compute/location?api-version=2021-02-01"
+)
+
+#: Sentinel marking the per-process probe cache as not-yet-populated.
+_UNSET: object = object()
+
+#: Per-process cache of the detected caller region (`None` = probed but
+#: undetermined). Reset with :func:`clear_region_cache`.
+_cached_region: str | None | object = _UNSET
+
+
+def clear_region_cache() -> None:
+    """Reset the per-process caller-region probe cache.
+
+    The metadata probe runs at most once per process; call this to force
+    a fresh probe (chiefly in tests that inject different probe results).
+    """
+    global _cached_region
+    _cached_region = _UNSET
 
 
 def _caller_region_from_env() -> str | None:
@@ -47,17 +81,112 @@ def _caller_region_from_env() -> str | None:
     return os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or None
 
 
-def _detect_caller_region() -> str | None:
-    """Detect the caller region from instance metadata (env-only in `C1`).
+def _metadata_request(
+    url: str,
+    *,
+    headers: dict[str, str],
+    method: str = "GET",
+    timeout: float = PROBE_TIMEOUT,
+) -> str | None:
+    """Fetch an instance-metadata endpoint, fail-safe to `None`.
 
-    The metadata-probe fallback (AWS IMDSv2 / GCP / Azure) lands in `C2`;
-    the `C1` env-only cut returns `None` so callers relying purely on the
-    environment resolve deterministically.
+    The single network seam for every probe: any error (no route,
+    timeout, non-200, decode failure) yields `None` rather than raising,
+    so detection never blocks or crashes a download.
+
+    Args:
+        url: The metadata endpoint URL.
+        headers: Request headers required by the endpoint.
+        method: HTTP method (`"GET"`, or `"PUT"` for the AWS token).
+        timeout: Hard timeout in seconds.
 
     Returns:
-        The detected region, or `None` when it cannot be determined.
+        The stripped response body, or `None` on any failure / empty body.
     """
-    return None
+    request = urllib.request.Request(url, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            status = getattr(response, "status", 200) or 200
+            if status != 200:
+                return None
+            body = response.read().decode("utf-8", "replace").strip()
+            return body or None
+    except (OSError, ValueError):
+        return None
+
+
+def _probe_aws(timeout: float) -> str | None:
+    """Probe AWS IMDSv2 for the caller region (token dance, then region)."""
+    token = _metadata_request(
+        _AWS_TOKEN_URL,
+        headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+        method="PUT",
+        timeout=timeout,
+    )
+    if not token:
+        return None
+    return _metadata_request(
+        _AWS_REGION_URL,
+        headers={"X-aws-ec2-metadata-token": token},
+        timeout=timeout,
+    )
+
+
+def _normalize_gcp_zone(zone: str) -> str | None:
+    """Normalise a GCP zone string to a region.
+
+    Turns `projects/123/zones/us-west1-a` (or the bare `us-west1-a`) into
+    `us-west1` by dropping the path prefix and the trailing zone letter.
+
+    Args:
+        zone: The raw zone string from the metadata endpoint.
+
+    Returns:
+        The region, or `None` when the input is empty.
+    """
+    tail = zone.rsplit("/", 1)[-1]
+    if not tail:
+        return None
+    region, _, letter = tail.rpartition("-")
+    return region if region and letter else tail
+
+
+def _probe_gcp(timeout: float) -> str | None:
+    """Probe the GCP metadata server for the caller region."""
+    zone = _metadata_request(
+        _GCP_ZONE_URL, headers={"Metadata-Flavor": "Google"}, timeout=timeout
+    )
+    return _normalize_gcp_zone(zone) if zone else None
+
+
+def _probe_azure(timeout: float) -> str | None:
+    """Probe Azure IMDS for the caller region (a `location` string)."""
+    return _metadata_request(
+        _AZURE_LOCATION_URL, headers={"Metadata": "true"}, timeout=timeout
+    )
+
+
+def _detect_caller_region(*, timeout: float = PROBE_TIMEOUT) -> str | None:
+    """Detect the caller region from instance metadata, cached per process.
+
+    Tries AWS IMDSv2, then GCP, then Azure — each behind the hard
+    `timeout` and each fail-safe to `None`. The first non-empty result
+    wins. The outcome (including `None`) is cached for the process so a
+    cold, off-cloud caller pays the probe cost at most once; reset with
+    :func:`clear_region_cache`.
+
+    Args:
+        timeout: Hard per-probe timeout in seconds.
+
+    Returns:
+        The detected region, or `None` when no cloud metadata answers.
+    """
+    global _cached_region
+    if _cached_region is not _UNSET:
+        return _cached_region  # type: ignore[return-value]
+    region = _probe_aws(timeout) or _probe_gcp(timeout) or _probe_azure(timeout) or None
+    _cached_region = region
+    return region
 
 
 def region_affinity(

--- a/src/earthlens/base/region.py
+++ b/src/earthlens/base/region.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 import os
 import urllib.request
 
+from loguru import logger
+
 #: The process runs in the same region as the target bucket.
 IN_REGION = "in-region"
 
@@ -33,6 +35,11 @@ EGRESS = "egress"
 
 #: The caller region could not be determined.
 UNKNOWN = "unknown"
+
+#: Default size above which a cross-region pull warrants an egress warning
+#: (1 GiB). A parameter of :func:`warn_if_egress`, never hard-coded at a
+#: call site.
+DEFAULT_EGRESS_THRESHOLD_BYTES = 1 << 30
 
 #: Hard timeout (seconds) for every instance-metadata probe. Keeps the
 #: fallback from ever blocking a download when the endpoint is absent.
@@ -240,3 +247,41 @@ def region_affinity(
     if caller is None:
         return UNKNOWN
     return IN_REGION if caller == bucket_region else EGRESS
+
+
+def warn_if_egress(
+    bucket_region: str,
+    *,
+    size_bytes: int,
+    threshold_bytes: int = DEFAULT_EGRESS_THRESHOLD_BYTES,
+    caller_region: str | None = None,
+    probe: bool = True,
+) -> str:
+    """Warn once before a large cross-region pull, returning the hint.
+
+    Computes the region affinity and, when the caller is in a different
+    region than the bucket (`"egress"`) and the transfer exceeds
+    `threshold_bytes`, emits a single `loguru` warning so the user learns
+    about the cross-region cost and latency up front. The hint is
+    returned so a caller can branch on it too.
+
+    Args:
+        bucket_region: The region the target bucket lives in.
+        size_bytes: The size of the pending transfer in bytes.
+        threshold_bytes: The size above which the warning fires (default
+            1 GiB). A parameter, never hard-coded at the call site.
+        caller_region: An explicit override for the caller's region.
+        probe: Whether to allow the instance-metadata probe (see
+            :func:`region_affinity`).
+
+    Returns:
+        The affinity hint — `"in-region"`, `"egress"`, or `"unknown"`.
+    """
+    hint = region_affinity(bucket_region, caller_region=caller_region, probe=probe)
+    if hint == EGRESS and size_bytes > threshold_bytes:
+        logger.warning(
+            f"Cross-region egress: pulling {size_bytes / (1 << 30):.2f} GiB "
+            f"from {bucket_region!r} while running elsewhere — expect slower, "
+            f"billed transfer. Run in {bucket_region!r} to stream in-region."
+        )
+    return hint

--- a/src/earthlens/base/region.py
+++ b/src/earthlens/base/region.py
@@ -1,0 +1,113 @@
+"""Cloud region-affinity helper for the download-orchestration policy.
+
+`region_affinity(bucket_region)` answers one question: *is this process
+running in the same cloud region as the target bucket?* — so a backend
+can prefer a cheap in-region streaming read over slow, billed
+cross-region egress. It generalises the AWS-only decision the earthdata
+backend already ships (stream via `earthaccess.open` only when the caller
+runs in the DAAC's region, else HTTPS `earthaccess.download`) and adds
+GCP + Azure detection.
+
+Resolution is **env-first** (zero-cost, covers most CI / Lambda / EC2
+cases), then an optional **instance-metadata probe** behind a hard short
+timeout and a per-process cache (`C2`). Detection **never raises and
+never blocks**: any failure yields `"unknown"`, and `probe=False`
+disables the network probe entirely.
+
+Detection is stdlib `os.environ` + (in `C2`) a small `urllib.request`
+GET with an explicit timeout — no `boto3` / `google-cloud-*` /
+`azure-*` import merely to read a region, so this module adds no
+dependency.
+"""
+
+from __future__ import annotations
+
+import os
+
+#: The process runs in the same region as the target bucket.
+IN_REGION = "in-region"
+
+#: The process and the target bucket are in different (known) regions.
+EGRESS = "egress"
+
+#: The caller region could not be determined.
+UNKNOWN = "unknown"
+
+
+def _caller_region_from_env() -> str | None:
+    """Return the caller's AWS region from the environment, if set.
+
+    Reads `AWS_REGION` first, then `AWS_DEFAULT_REGION`. This is the
+    zero-cost signal that covers most CI, AWS Lambda, and
+    EC2-with-env-config callers.
+
+    Returns:
+        The region string, or `None` when neither variable is set.
+    """
+    return os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or None
+
+
+def _detect_caller_region() -> str | None:
+    """Detect the caller region from instance metadata (env-only in `C1`).
+
+    The metadata-probe fallback (AWS IMDSv2 / GCP / Azure) lands in `C2`;
+    the `C1` env-only cut returns `None` so callers relying purely on the
+    environment resolve deterministically.
+
+    Returns:
+        The detected region, or `None` when it cannot be determined.
+    """
+    return None
+
+
+def region_affinity(
+    bucket_region: str,
+    *,
+    caller_region: str | None = None,
+    probe: bool = True,
+) -> str:
+    """Classify the caller's region relative to a target bucket.
+
+    Resolves the caller region in order — explicit `caller_region`, then
+    `AWS_REGION` / `AWS_DEFAULT_REGION`, then (when `probe`) an
+    instance-metadata probe — and compares it to `bucket_region`. The
+    result guides a backend's choice between an in-region streaming read
+    and a cross-region egress download.
+
+    Args:
+        bucket_region: The region the target bucket lives in (e.g.
+            `"us-west-2"`).
+        caller_region: An explicit override for the caller's region. When
+            given, the environment and probe are not consulted.
+        probe: Whether to fall back to the instance-metadata probe when
+            the environment carries no region. `False` skips all network
+            access (tests, air-gapped runs, and the earthdata re-point).
+
+    Returns:
+        `"in-region"` when the caller region equals `bucket_region`,
+        `"egress"` when both are known and differ, or `"unknown"` when
+        the caller region cannot be determined (or `bucket_region` is
+        empty).
+
+    Examples:
+        - An explicit caller region drives the verdict without touching
+          the environment:
+            ```python
+            >>> from earthlens.base.region import region_affinity
+            >>> region_affinity("us-west-2", caller_region="us-west-2")
+            'in-region'
+            >>> region_affinity("us-west-2", caller_region="eu-central-1")
+            'egress'
+            >>> region_affinity("", caller_region="us-west-2")
+            'unknown'
+
+            ```
+    """
+    if not bucket_region:
+        return UNKNOWN
+    caller = caller_region or _caller_region_from_env()
+    if caller is None and probe:
+        caller = _detect_caller_region()
+    if caller is None:
+        return UNKNOWN
+    return IN_REGION if caller == bucket_region else EGRESS

--- a/src/earthlens/base/region.py
+++ b/src/earthlens/base/region.py
@@ -10,14 +10,13 @@ GCP + Azure detection.
 
 Resolution is **env-first** (zero-cost, covers most CI / Lambda / EC2
 cases), then an optional **instance-metadata probe** behind a hard short
-timeout and a per-process cache (`C2`). Detection **never raises and
-never blocks**: any failure yields `"unknown"`, and `probe=False`
-disables the network probe entirely.
+timeout and a per-process cache. Detection **never raises and never
+blocks**: any failure yields `"unknown"`, and `probe=False` disables the
+network probe entirely.
 
-Detection is stdlib `os.environ` + (in `C2`) a small `urllib.request`
-GET with an explicit timeout — no `boto3` / `google-cloud-*` /
-`azure-*` import merely to read a region, so this module adds no
-dependency.
+Detection is stdlib `os.environ` plus a small `urllib.request` GET with
+an explicit timeout — no `boto3` / `google-cloud-*` / `azure-*` import
+merely to read a region, so this module adds no dependency.
 """
 
 from __future__ import annotations

--- a/src/earthlens/base/region.py
+++ b/src/earthlens/base/region.py
@@ -148,6 +148,8 @@ def _normalize_gcp_zone(zone: str) -> str | None:
 
     Turns `projects/123/zones/us-west1-a` (or the bare `us-west1-a`) into
     `us-west1` by dropping the path prefix and the trailing zone letter.
+    Only a trailing single-letter suffix is stripped, so a bare region
+    (`us-west1`) passes through unchanged rather than being mangled.
 
     Args:
         zone: The raw zone string from the metadata endpoint.
@@ -158,8 +160,10 @@ def _normalize_gcp_zone(zone: str) -> str | None:
     tail = zone.rsplit("/", 1)[-1]
     if not tail:
         return None
-    region, _, letter = tail.rpartition("-")
-    return region if region and letter else tail
+    region, sep, letter = tail.rpartition("-")
+    if sep and region and len(letter) == 1 and letter.isalpha():
+        return region
+    return tail
 
 
 def _probe_gcp(timeout: float) -> str | None:

--- a/src/earthlens/base/region.py
+++ b/src/earthlens/base/region.py
@@ -22,6 +22,7 @@ dependency.
 
 from __future__ import annotations
 
+import http.client
 import os
 import urllib.request
 
@@ -118,7 +119,7 @@ def _metadata_request(
                 return None
             body = response.read().decode("utf-8", "replace").strip()
             return body or None
-    except (OSError, ValueError):
+    except (OSError, ValueError, http.client.HTTPException):
         return None
 
 

--- a/src/earthlens/drought/backend.py
+++ b/src/earthlens/drought/backend.py
@@ -41,6 +41,7 @@ from earthlens.base import (
     TemporalExtent,
 )
 from earthlens.base._dates import to_datetime
+from earthlens.base.http import HttpClient
 from earthlens.drought._helpers import (
     attribution_for,
     bbox_from_extent,
@@ -780,36 +781,43 @@ def _http_get_json(url: str) -> dict[str, Any]:
     return response.json()
 
 
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps `HttpClient` pointed at the module-level `requests.get` (rather
+    than a private session) so this single-shot download stays a fresh
+    connection per call and the tests that monkeypatch `requests.get` still
+    drive the transport.
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
+
+
 def _http_download(url: str, target: Path) -> None:
     """Stream a binary payload to `target` over HTTP.
 
+    Delegates the transfer to `HttpClient.download`, which streams to a
+    sibling `<target>.part` file and atomically renames it on success,
+    removing the temp on any failure — so an interrupted download never
+    leaves a truncated file (nor a stale temp) behind. Error statuses are
+    raised immediately, not retried (`status_forcelist=()`), matching the
+    previous single-shot behaviour.
+
     Args:
         url: The source URL.
-        target: The destination path. Parent directory must exist.
+        target: The destination path. Parent directory is created.
 
     Raises:
         requests.HTTPError: For non-2xx responses.
     """
-    target.parent.mkdir(parents=True, exist_ok=True)
-    tmp = target.with_suffix(target.suffix + ".partial")
-    try:
-        with requests.get(
-            url,
-            timeout=_HTTP_TIMEOUT,
-            stream=True,
-            headers={"User-Agent": _USER_AGENT},
-        ) as response:
-            response.raise_for_status()
-            with tmp.open("wb") as fh:
-                for chunk in response.iter_content(chunk_size=1 << 16):
-                    if chunk:
-                        fh.write(chunk)
-        tmp.replace(target)
-    except BaseException:
-        # A dropped connection (or interrupt) mid-stream would otherwise
-        # leave a stale `.partial` on disk; remove it before re-raising.
-        tmp.unlink(missing_ok=True)
-        raise
+    HttpClient(
+        session=_RequestsGet(),
+        user_agent=_USER_AGENT,
+        status_forcelist=(),
+        max_backoff=None,
+    ).download(url, target, chunk=1 << 16, progress=False, timeout=_HTTP_TIMEOUT)
 
 
 def _http_download_raster(url: str, target: Path, *, label: str) -> None:

--- a/src/earthlens/earthdata/backend.py
+++ b/src/earthlens/earthdata/backend.py
@@ -33,7 +33,6 @@ in `variables` are informational for a whole-granule fetch.
 from __future__ import annotations
 
 import datetime as dt
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -45,6 +44,7 @@ from earthlens.base import (
     RemoteProduct,
     SpatialExtent,
     TemporalExtent,
+    region_affinity,
 )
 from earthlens.earthdata.auth import EarthdataAuth, EarthdataCredentials
 from earthlens.earthdata.catalog import Catalog, EarthdataDataset
@@ -455,11 +455,12 @@ class Earthdata(AbstractDataSource):
     def _in_region(self, region: str) -> bool:
         """Return whether the caller appears to run in `region`.
 
-        Resolution order: explicit `region=` kwarg → `AWS_REGION` →
-        `AWS_DEFAULT_REGION`. EC2 instance-metadata probing is
-        intentionally **not** used here — it would hang for off-cloud
-        callers; the explicit kwarg / env var is the supported signal
-        (`G4`).
+        Delegates to the shared `earthlens.base.region.region_affinity`
+        helper: the caller region is resolved from the explicit `region=`
+        kwarg, then `AWS_REGION` / `AWS_DEFAULT_REGION`. EC2
+        instance-metadata probing is intentionally **not** used here
+        (`probe=False`) — it would hang for off-cloud callers; the
+        explicit kwarg / env var is the supported signal (`G4`).
 
         Args:
             region: The region to test against (e.g. `"us-west-2"`).
@@ -468,10 +469,10 @@ class Earthdata(AbstractDataSource):
             bool: `True` when the resolved caller region equals
                 `region`.
         """
-        caller = (
-            self._region or os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+        return (
+            region_affinity(region, caller_region=self._region, probe=False)
+            == "in-region"
         )
-        return caller == region
 
     def download(
         self,

--- a/src/earthlens/firms/_helpers.py
+++ b/src/earthlens/firms/_helpers.py
@@ -202,8 +202,8 @@ def firms_get(
     :func:`classify_body` flags as `"quota"` is made retryable via a
     `retry_predicate`. Each retry waits `backoff_factor · 2**attempt`
     seconds — or the server's `Retry-After` when it sends one on a 429,
-    which the client now honours — with no ceiling, up to `max_retries`
-    times.
+    which the client now honours (bounded by the default back-off
+    ceiling) — up to `max_retries` times.
 
     Crucially the client is built with `raise_for_status=False`, so any
     other response — a real CSV, a bad-key body, a generic error body, a

--- a/src/earthlens/firms/_helpers.py
+++ b/src/earthlens/firms/_helpers.py
@@ -201,7 +201,9 @@ def firms_get(
     retryable via `status_forcelist=(429,)`, and an HTTP-200 body that
     :func:`classify_body` flags as `"quota"` is made retryable via a
     `retry_predicate`. Each retry waits `backoff_factor · 2**attempt`
-    seconds (no `Retry-After`, no ceiling), up to `max_retries` times.
+    seconds — or the server's `Retry-After` when it sends one on a 429,
+    which the client now honours — with no ceiling, up to `max_retries`
+    times.
 
     Crucially the client is built with `raise_for_status=False`, so any
     other response — a real CSV, a bad-key body, a generic error body, a

--- a/src/earthlens/firms/_helpers.py
+++ b/src/earthlens/firms/_helpers.py
@@ -234,7 +234,6 @@ def firms_get(
         status_forcelist=(429,),
         retry_predicate=_is_quota_body,
         raise_for_status=False,
-        max_backoff=None,
         sleep=sleep,
     )
     return client.get(url)

--- a/src/earthlens/firms/_helpers.py
+++ b/src/earthlens/firms/_helpers.py
@@ -27,6 +27,8 @@ import datetime as dt
 import time
 from typing import Any, Callable, Literal
 
+from earthlens.base.http import HttpClient
+
 #: A FIRMS area request covers at most this many days (verified live
 #: against the area CSV API, which rejects >5 with "Expects [1..5]").
 MAX_DAY_RANGE = 5
@@ -143,6 +145,45 @@ def classify_body(text: str) -> BodyKind:
     return "error"
 
 
+class _RequestsGet:
+    """Session-like GET adapter routing through an injected getter.
+
+    Wraps the `get` callable handed to :func:`firms_get` in the
+    `session.get(url, **kwargs)` shape :class:`~earthlens.base.http.HttpClient`
+    expects, so the client drives the exact transport the caller supplied
+    (`requests.get` in production, a fake in tests) rather than a private
+    session.
+    """
+
+    def __init__(self, get: Callable[..., Any]) -> None:
+        self._get = get
+
+    def get(self, url: str, **kwargs: Any) -> Any:
+        """Issue a GET via the wrapped getter."""
+        return self._get(url, **kwargs)
+
+
+def _is_quota_body(response: Any) -> bool:
+    """Return `True` when a response *body* classifies as a quota signal.
+
+    The HTTP-429 case is covered by the client's `status_forcelist`; this
+    predicate handles the FIRMS wrinkle where a quota/rate-limit error
+    arrives as HTTP 200 with a plain-text body. `.text` is read
+    defensively (a non-200 response may not carry one), mirroring the
+    guard the reactive back-off loop used before it moved onto
+    :class:`~earthlens.base.http.HttpClient`.
+
+    Args:
+        response: A response object exposing `text`.
+
+    Returns:
+        bool: `True` when :func:`classify_body` flags the body as
+            `"quota"`.
+    """
+    text = getattr(response, "text", "") or ""
+    return classify_body(text) == "quota"
+
+
 def firms_get(
     url: str,
     *,
@@ -154,14 +195,21 @@ def firms_get(
 ) -> Any:
     """GET a FIRMS URL, retrying the quota case with capped back-off.
 
-    Issues `get(url, timeout=timeout)` and, when the response is a quota
-    signal — HTTP 429, or an HTTP-200 body that :func:`classify_body`
-    flags as `"quota"` — waits `backoff_factor · 2**attempt` seconds and
-    retries, up to `max_retries` times. Any other response (a real CSV,
-    a bad-key body, a generic error body, a non-quota HTTP error) is
-    returned to the caller verbatim for classification; this helper does
-    not raise on those. The `sleep` and `get` callables are injected so
-    tests run without real waits or network.
+    Delegates the retry loop to :class:`~earthlens.base.http.HttpClient`:
+    the injected `get` is wrapped as the client's session so the same
+    transport (`requests.get` in production) is used, HTTP 429 is made
+    retryable via `status_forcelist=(429,)`, and an HTTP-200 body that
+    :func:`classify_body` flags as `"quota"` is made retryable via a
+    `retry_predicate`. Each retry waits `backoff_factor · 2**attempt`
+    seconds (no `Retry-After`, no ceiling), up to `max_retries` times.
+
+    Crucially the client is built with `raise_for_status=False`, so any
+    other response — a real CSV, a bad-key body, a generic error body, a
+    non-quota HTTP error (including a `4xx`/`5xx`) — is returned to the
+    caller **unraised** for classification. The MAP_KEY rides in the URL,
+    so `FIRMS._fetch_one` must be the one to raise a redacted error on a
+    `>=400` status; letting the client `raise_for_status` here would leak
+    the secret-bearing URL into the traceback.
 
     Args:
         url: The fully-formed FIRMS request URL (already carries the
@@ -176,28 +224,15 @@ def firms_get(
     Returns:
         The final response object from `get`.
     """
-    response = get(url, timeout=timeout)
-    attempt = 0
-    while attempt < max_retries and _is_quota(response):
-        sleep(backoff_factor * (2**attempt))
-        attempt += 1
-        response = get(url, timeout=timeout)
-    return response
-
-
-def _is_quota(response: Any) -> bool:
-    """Return `True` when a response is a FIRMS quota signal.
-
-    A quota signal is HTTP 429, or an HTTP-200 text body that
-    :func:`classify_body` flags as `"quota"`.
-
-    Args:
-        response: A response object exposing `status_code` and `text`.
-
-    Returns:
-        bool: `True` for a quota/rate-limit response.
-    """
-    if getattr(response, "status_code", None) == 429:
-        return True
-    text = getattr(response, "text", "") or ""
-    return classify_body(text) == "quota"
+    client = HttpClient(
+        session=_RequestsGet(get),
+        timeout=timeout,
+        max_retries=max_retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=(429,),
+        retry_predicate=_is_quota_body,
+        raise_for_status=False,
+        max_backoff=None,
+        sleep=sleep,
+    )
+    return client.get(url)

--- a/src/earthlens/ghsl/_helpers.py
+++ b/src/earthlens/ghsl/_helpers.py
@@ -465,7 +465,8 @@ def _download(
     `zip_path`. The retry policy reproduces the historical loop: an error status
     (`429`/`5xx`, via `raise_for_status`) or a transport `RequestException` /
     `OSError` retries the whole download, waiting `backoff * 2**attempt` between
-    the `retries` attempts (uncapped). When every attempt is exhausted the final
+    the `retries` attempts (bounded by the default back-off ceiling, which the
+    exponential wait never reaches). When every attempt is exhausted the final
     error is wrapped in a `requests.HTTPError` carrying the same message the
     hand-rolled loop raised.
 

--- a/src/earthlens/ghsl/_helpers.py
+++ b/src/earthlens/ghsl/_helpers.py
@@ -488,7 +488,6 @@ def _download(
         raise_for_status=True,
         max_retries=max(retries - 1, 0),
         backoff_factor=backoff,
-        max_backoff=None,
         sleep=time.sleep,
     )
     try:

--- a/src/earthlens/ghsl/_helpers.py
+++ b/src/earthlens/ghsl/_helpers.py
@@ -29,10 +29,12 @@ import time
 import zipfile
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 import requests
 from loguru import logger
 
+from earthlens.base.http import HttpClient
 from earthlens.ghsl.catalog import RES_TO_TOKEN, native_source_crs
 
 #: Root of the JRC open-data GHSL file tree (anonymous HTTPS, no auth).
@@ -432,6 +434,20 @@ def download_and_extract(
     return [dest_dir / m for m in members]
 
 
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the module-level
+    `requests.get` (rather than a private session) when no session is supplied,
+    so an un-pooled download stays a fresh connection per call and tests that
+    monkeypatch `requests.get` still drive the transport.
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
+
+
 def _download(
     url: str,
     zip_path: Path,
@@ -443,6 +459,16 @@ def _download(
 ) -> None:
     """Stream `url` to `zip_path` with retry + exponential backoff.
 
+    Delegates the transfer to `HttpClient.download`, which streams to a sibling
+    `<zip_path>.part` and renames it on success (removing the temp on any
+    failure) — so an interrupted download never leaves a truncated archive at
+    `zip_path`. The retry policy reproduces the historical loop: an error status
+    (`429`/`5xx`, via `raise_for_status`) or a transport `RequestException` /
+    `OSError` retries the whole download, waiting `backoff * 2**attempt` between
+    the `retries` attempts (uncapped). When every attempt is exhausted the final
+    error is wrapped in a `requests.HTTPError` carrying the same message the
+    hand-rolled loop raised.
+
     Args:
         url: The `.zip` URL.
         zip_path: Local path to write.
@@ -453,28 +479,23 @@ def _download(
         chunk_size: Streaming chunk size.
 
     Raises:
-        requests.HTTPError: If every attempt fails (the last error re-raised).
+        requests.HTTPError: If every attempt fails (the last error is wrapped).
     """
-    get = session.get if session is not None else requests.get
-    last_exc: Exception | None = None
-    for attempt in range(1, retries + 1):
-        try:
-            with get(url, stream=True, timeout=timeout) as resp:
-                resp.raise_for_status()
-                with open(zip_path, "wb") as handle:
-                    for chunk in resp.iter_content(chunk_size=chunk_size):
-                        handle.write(chunk)
-            return
-        except (requests.RequestException, OSError) as exc:
-            last_exc = exc
-            zip_path.unlink(missing_ok=True)
-            if attempt < retries:
-                wait = backoff * (2 ** (attempt - 1))
-                logger.warning(
-                    f"GHSL: download {url} failed (attempt {attempt}/{retries}): "
-                    f"{type(exc).__name__}: {exc}; retrying in {wait:.0f}s."
-                )
-                time.sleep(wait)
-    raise requests.HTTPError(
-        f"GHSL: download {url} failed after {retries} attempts: {last_exc}"
+    client = HttpClient(
+        session=session if session is not None else _RequestsGet(),
+        status_forcelist=(429, 500, 502, 503, 504),
+        retry_on_exceptions=(requests.RequestException, OSError),
+        raise_for_status=True,
+        max_retries=max(retries - 1, 0),
+        backoff_factor=backoff,
+        max_backoff=None,
+        sleep=time.sleep,
     )
+    try:
+        client.download(
+            url, zip_path, chunk=chunk_size, progress=False, timeout=timeout
+        )
+    except (requests.RequestException, OSError) as exc:
+        raise requests.HTTPError(
+            f"GHSL: download {url} failed after {retries} attempts: {exc}"
+        ) from exc

--- a/src/earthlens/glaciers/_helpers.py
+++ b/src/earthlens/glaciers/_helpers.py
@@ -175,9 +175,8 @@ def _stream_download(
         retry_on_exceptions=(requests.RequestException, OSError),
         status_forcelist=(429, 500, 502, 503, 504),
         raise_for_status=True,
-        max_retries=retries - 1,
+        max_retries=max(retries - 1, 0),
         backoff_factor=backoff,
-        max_backoff=None,
         sleep=time.sleep,
     )
     try:

--- a/src/earthlens/glaciers/_helpers.py
+++ b/src/earthlens/glaciers/_helpers.py
@@ -28,9 +28,10 @@ from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import requests
-from loguru import logger
 from pyramids.feature.collection import FeatureCollection
 from shapely.geometry import box
+
+from earthlens.base.http import HttpClient
 
 if TYPE_CHECKING:
     from earthlens.base import SpatialExtent
@@ -121,6 +122,21 @@ def download_zip(
     return zip_path
 
 
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the
+    module-level `requests.get` (rather than a private session) when no
+    session is supplied, so an un-shared download stays a fresh connection
+    per call and tests that monkeypatch `requests.get` still drive the
+    transport.
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
+
+
 def _stream_download(
     url: str,
     dest_path: Path,
@@ -131,6 +147,16 @@ def _stream_download(
     chunk_size: int,
 ) -> None:
     """Stream `url` to `dest_path` with retry + exponential backoff.
+
+    Delegates the streamed transfer to :meth:`HttpClient.download`, which
+    writes to a sibling `.part` file, renames it on success, and removes the
+    temp on any failure — so an interrupted download never leaves a truncated
+    file. Retries are configured to mirror the previous hand-rolled loop:
+    `retries` total attempts (`max_retries = retries - 1`), retrying both the
+    transient `429`/`5xx` statuses and any `requests.RequestException` / `OSError`
+    with `backoff * 2**attempt` back-off. When every attempt is exhausted the
+    original transport error is re-raised as a synthesized `requests.HTTPError`
+    (matching the message the glaciers callers expect).
 
     Args:
         url: The source URL.
@@ -144,30 +170,22 @@ def _stream_download(
     Raises:
         requests.HTTPError: If every attempt fails (the last error re-raised).
     """
-    get = session.get if session is not None else requests.get
-    last_exc: Exception | None = None
-    for attempt in range(1, retries + 1):
-        try:
-            with get(url, stream=True, timeout=timeout) as resp:
-                resp.raise_for_status()
-                with open(dest_path, "wb") as handle:
-                    for chunk in resp.iter_content(chunk_size=chunk_size):
-                        handle.write(chunk)
-            return
-        except (requests.RequestException, OSError) as exc:
-            last_exc = exc
-            dest_path.unlink(missing_ok=True)
-            if attempt < retries:
-                wait = backoff * (2 ** (attempt - 1))
-                logger.warning(
-                    f"glaciers: download {url} failed (attempt "
-                    f"{attempt}/{retries}): {type(exc).__name__}: {exc}; "
-                    f"retrying in {wait:.0f}s."
-                )
-                time.sleep(wait)
-    raise requests.HTTPError(
-        f"glaciers: download {url} failed after {retries} attempts: {last_exc}"
+    http = HttpClient(
+        session=session or _RequestsGet(),
+        retry_on_exceptions=(requests.RequestException, OSError),
+        status_forcelist=(429, 500, 502, 503, 504),
+        raise_for_status=True,
+        max_retries=retries - 1,
+        backoff_factor=backoff,
+        max_backoff=None,
+        sleep=time.sleep,
     )
+    try:
+        http.download(url, dest_path, chunk=chunk_size, progress=False, timeout=timeout)
+    except (requests.RequestException, OSError) as exc:
+        raise requests.HTTPError(
+            f"glaciers: download {url} failed after {retries} attempts: {exc}"
+        ) from exc
 
 
 # --------------------------------------------------------------------------

--- a/src/earthlens/glaciers/_helpers.py
+++ b/src/earthlens/glaciers/_helpers.py
@@ -171,7 +171,7 @@ def _stream_download(
         requests.HTTPError: If every attempt fails (the last error re-raised).
     """
     http = HttpClient(
-        session=session or _RequestsGet(),
+        session=session if session is not None else _RequestsGet(),
         retry_on_exceptions=(requests.RequestException, OSError),
         status_forcelist=(429, 500, 502, 503, 504),
         raise_for_status=True,

--- a/src/earthlens/nrel/_helpers.py
+++ b/src/earthlens/nrel/_helpers.py
@@ -209,7 +209,6 @@ def throttled_get(
         status_forcelist=(429,),
         max_retries=max_retries - 1,
         backoff_factor=1.0,
-        max_backoff=None,
         raise_for_status=False,
         sleep=sleep,
         timeout=120,

--- a/src/earthlens/nrel/_helpers.py
+++ b/src/earthlens/nrel/_helpers.py
@@ -199,8 +199,10 @@ def throttled_get(
         sleep(wait)
     # HttpClient owns only the 429 retry/back-off here: `max_retries - 1`
     # additional retries reproduce the old loop's `max_retries` total GETs with
-    # `backoff_factor * 2**attempt` (= `2**attempt`) waits, `raise_for_status`
-    # off so a non-429 4xx flows back to the caller unraised for inspection.
+    # `backoff_factor * 2**attempt` (= `2**attempt`) waits — one fewer than the
+    # old loop only on the all-429 exhaustion path, where it dropped a wasted
+    # trailing sleep before raising. `raise_for_status` is off so a non-429 4xx
+    # flows back to the caller unraised for inspection.
     http = HttpClient(
         session=session,
         status_forcelist=(429,),

--- a/src/earthlens/nrel/_helpers.py
+++ b/src/earthlens/nrel/_helpers.py
@@ -23,6 +23,8 @@ from urllib.parse import urlencode
 
 import pandas as pd
 
+from earthlens.base.http import HttpClient
+
 #: Base host of the keyed NREL/NLR Developer Network REST service. The legacy
 #: `developer.nrel.gov` host was retired 2026-05-29; keep the host here so a
 #: future change is one edit.
@@ -189,18 +191,33 @@ def throttled_get(
         requests.HTTPError: If every attempt returned `429` (the final
             response's `raise_for_status()` is called).
     """
+    # Proactive 1 req/s throttle: kept here (not delegated to HttpClient's
+    # `min_interval`) because it draws on the shared `last_call` list so a whole
+    # batch of points throttles against one timestamp, not per-client.
     wait = MIN_INTERVAL - (monotonic() - last_call[0])
     if wait > 0:
         sleep(wait)
-    resp = None
-    for attempt in range(max_retries):
-        resp = session.get(url, timeout=120)
-        last_call[0] = monotonic()
-        if resp.status_code != 429:
-            return resp
-        sleep(2**attempt)
-    resp.raise_for_status()
-    return resp  # pragma: no cover - raise_for_status always raises on a 429
+    # HttpClient owns only the 429 retry/back-off here: `max_retries - 1`
+    # additional retries reproduce the old loop's `max_retries` total GETs with
+    # `backoff_factor * 2**attempt` (= `2**attempt`) waits, `raise_for_status`
+    # off so a non-429 4xx flows back to the caller unraised for inspection.
+    http = HttpClient(
+        session=session,
+        status_forcelist=(429,),
+        max_retries=max_retries - 1,
+        backoff_factor=1.0,
+        max_backoff=None,
+        raise_for_status=False,
+        sleep=sleep,
+        timeout=120,
+    )
+    resp = http.get(url, raise_for_status=False)
+    last_call[0] = monotonic()
+    if resp.status_code == 429:
+        # Retries exhausted on a persistent 429 — mirror the old loop's final
+        # `raise_for_status()` (an HTTPError).
+        resp.raise_for_status()
+    return resp
 
 
 def _data_header_offset(text: str) -> int:

--- a/src/earthlens/nrel/_helpers.py
+++ b/src/earthlens/nrel/_helpers.py
@@ -22,6 +22,7 @@ from typing import Any, Callable
 from urllib.parse import urlencode
 
 import pandas as pd
+import requests
 
 from earthlens.base.http import HttpClient
 
@@ -216,9 +217,13 @@ def throttled_get(
     resp = http.get(url, raise_for_status=False)
     last_call[0] = monotonic()
     if resp.status_code == 429:
-        # Retries exhausted on a persistent 429 — mirror the old loop's final
-        # `raise_for_status()` (an HTTPError).
-        resp.raise_for_status()
+        # Retries exhausted on a persistent 429. Raise an HTTPError (as the old
+        # loop's raise_for_status() did) but WITHOUT the URL — it carries the
+        # `api_key=` query param, and requests.HTTPError echoes `resp.url`.
+        raise requests.HTTPError(
+            f"NREL returned HTTP 429 after {max_retries} attempts "
+            "(the api_key has been redacted from this error)."
+        )
     return resp
 
 

--- a/src/earthlens/openaq/client.py
+++ b/src/earthlens/openaq/client.py
@@ -100,6 +100,7 @@ class OpenaqClient:
             backoff_factor=backoff_factor,
             timeout=timeout,
             status_forcelist=(429,),
+            max_backoff=None,
             sleep=sleep,
         )
 

--- a/src/earthlens/openaq/client.py
+++ b/src/earthlens/openaq/client.py
@@ -95,9 +95,6 @@ class OpenaqClient:
         """
         self._api_key = api_key
         self._session = session if session is not None else requests.Session()
-        self.max_retries = max_retries
-        self.backoff_factor = backoff_factor
-        self.timeout = timeout
         self._http = HttpClient(
             session=self._session,
             headers={"X-API-Key": api_key},
@@ -107,6 +104,21 @@ class OpenaqClient:
             status_forcelist=(429,),
             sleep=sleep,
         )
+
+    @property
+    def max_retries(self) -> int:
+        """Maximum `429` retries before the last error is raised."""
+        return self._http.max_retries
+
+    @property
+    def backoff_factor(self) -> float:
+        """Base seconds for exponential back-off (no `Retry-After`)."""
+        return self._http.backoff_factor
+
+    @property
+    def timeout(self) -> float:
+        """Per-request timeout in seconds."""
+        return self._http.timeout
 
     def _request(self, path: str, params: dict[str, Any]) -> dict[str, Any]:
         """GET one page of `path`, retrying on `429`.

--- a/src/earthlens/openaq/client.py
+++ b/src/earthlens/openaq/client.py
@@ -8,11 +8,12 @@ rate-limits (historically ~60 req/min, ~2000/hour), and the
 locations -> sensors -> measurements fan-out makes a continental bbox
 hundreds-to-thousands of requests, so back-off is not optional.
 
-This is the local `_request_with_backoff` substrate the plan's `R2`
-finding settled on: the shared `earthlens.base.http.HttpClient` (the
-planned foundation task) does not exist yet, so the client owns its
-own retry loop. If that primitive lands later, this client can be
-re-pointed at it without changing the backend.
+The transport — session, `X-API-Key` header, and the `Retry-After`-aware
+`429` back-off loop — is delegated to the shared
+`earthlens.base.http.HttpClient`; this module keeps only the `API`-shaped
+concerns (endpoint paths, the v3 pagination envelope, and the raw-vs-rollup
+date-filter routing). The `429`-only retry policy is preserved exactly by
+constructing the client with `status_forcelist=(429,)`.
 
 `requests` is already a core earthlens dependency, so this client adds
 none. The session is injectable (`session=`) so tests can drive the
@@ -27,7 +28,8 @@ from collections.abc import Callable, Iterator
 from typing import Any
 
 import requests
-from loguru import logger
+
+from earthlens.base.http import HttpClient
 
 #: OpenAQ v3 API base URL. All endpoint paths are joined onto this.
 BASE_URL = "https://api.openaq.org/v3"
@@ -131,6 +133,15 @@ class OpenaqClient:
         self.backoff_factor = backoff_factor
         self.timeout = timeout
         self._sleep = sleep
+        self._http = HttpClient(
+            session=self._session,
+            headers={"X-API-Key": api_key},
+            max_retries=max_retries,
+            backoff_factor=backoff_factor,
+            timeout=timeout,
+            status_forcelist=(429,),
+            sleep=sleep,
+        )
 
     def _request(self, path: str, params: dict[str, Any]) -> dict[str, Any]:
         """GET one page of `path`, retrying on `429`.
@@ -154,29 +165,7 @@ class OpenaqClient:
             requests.HTTPError: On a non-`429` error status, or after
                 `max_retries` exhausted `429` responses.
         """
-        url = f"{BASE_URL}/{path}"
-        headers = {"X-API-Key": self._api_key}
-        attempt = 0
-        while True:
-            response = self._session.get(
-                url, params=params, headers=headers, timeout=self.timeout
-            )
-            if response.status_code == 429 and attempt < self.max_retries:
-                retry_after = _parse_retry_after(response.headers.get("Retry-After"))
-                wait = (
-                    retry_after
-                    if retry_after is not None
-                    else self.backoff_factor * (2**attempt)
-                )
-                logger.warning(
-                    f"OpenAQ rate-limited (429) on {path!r}; retry "
-                    f"{attempt + 1}/{self.max_retries} after {wait:.1f}s"
-                )
-                self._sleep(wait)
-                attempt += 1
-                continue
-            response.raise_for_status()
-            return response.json()
+        return self._http.get_json(f"{BASE_URL}/{path}", params=params)
 
     def paginate(
         self,

--- a/src/earthlens/openaq/client.py
+++ b/src/earthlens/openaq/client.py
@@ -93,10 +93,8 @@ class OpenaqClient:
                 :func:`time.sleep`; injectable so tests run without
                 real delays.
         """
-        self._api_key = api_key
-        self._session = session if session is not None else requests.Session()
         self._http = HttpClient(
-            session=self._session,
+            session=session if session is not None else requests.Session(),
             headers={"X-API-Key": api_key},
             max_retries=max_retries,
             backoff_factor=backoff_factor,

--- a/src/earthlens/openaq/client.py
+++ b/src/earthlens/openaq/client.py
@@ -50,40 +50,6 @@ _MAX_PAGE_SIZE = 1000
 _DATE_FILTER_ROLLUPS = frozenset({"days", "months", "years"})
 
 
-def _parse_retry_after(value: str | None) -> float | None:
-    """Parse a `Retry-After` header value into seconds.
-
-    OpenAQ returns `Retry-After` as an integer number of seconds. A
-    missing or non-numeric value yields `None` so the caller falls
-    back to exponential back-off.
-
-    Args:
-        value: The raw `Retry-After` header value, or `None`.
-
-    Returns:
-        The delay in seconds, or `None` when absent / unparseable.
-
-    Examples:
-        - A numeric value parses to seconds; junk yields `None`:
-            ```python
-            >>> from earthlens.openaq.client import _parse_retry_after
-            >>> _parse_retry_after("5")
-            5.0
-            >>> _parse_retry_after(None) is None
-            True
-            >>> _parse_retry_after("soon") is None
-            True
-
-            ```
-    """
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
-
-
 class OpenaqClient:
     """Minimal OpenAQ v3 client: auth header, pagination, back-off.
 
@@ -132,7 +98,6 @@ class OpenaqClient:
         self.max_retries = max_retries
         self.backoff_factor = backoff_factor
         self.timeout = timeout
-        self._sleep = sleep
         self._http = HttpClient(
             session=self._session,
             headers={"X-API-Key": api_key},

--- a/src/earthlens/pvgis/_helpers.py
+++ b/src/earthlens/pvgis/_helpers.py
@@ -18,6 +18,8 @@ from urllib.parse import urlencode
 
 import pandas as pd
 
+from earthlens.base.http import HttpClient
+
 #: Base URL of the keyless PVGIS 5.3 non-interactive REST service.
 BASE = "https://re.jrc.ec.europa.eu/api/v5_3"
 
@@ -143,15 +145,26 @@ def throttled_get(
     wait = MIN_INTERVAL - (monotonic() - last_call[0])
     if wait > 0:
         sleep(wait)
-    resp = None
-    for attempt in range(max_retries):
-        resp = session.get(url, timeout=60)
-        last_call[0] = monotonic()
-        if resp.status_code != 429:
-            return resp
-        sleep(2**attempt)
-    resp.raise_for_status()
-    return resp  # pragma: no cover - raise_for_status always raises on a 429
+    # The proactive throttle above is kept here; `HttpClient` owns only the
+    # 429 retry/back-off. `raise_for_status=False` lets a non-429 4xx flow back
+    # to the caller (which inspects the out-of-coverage error body), and
+    # `max_backoff=None` leaves the `2**attempt` back-off uncapped to match the
+    # previous hand-rolled loop.
+    http = HttpClient(
+        session=session,
+        status_forcelist=(429,),
+        max_retries=max_retries - 1,
+        backoff_factor=1.0,
+        max_backoff=None,
+        raise_for_status=False,
+        sleep=sleep,
+        timeout=60,
+    )
+    resp = http.get(url, raise_for_status=False)
+    last_call[0] = monotonic()
+    if resp.status_code == 429:
+        resp.raise_for_status()
+    return resp
 
 
 def _records_to_frame(rows: list[dict[str, Any]], time_key: str) -> pd.DataFrame:

--- a/src/earthlens/pvgis/_helpers.py
+++ b/src/earthlens/pvgis/_helpers.py
@@ -147,15 +147,15 @@ def throttled_get(
         sleep(wait)
     # The proactive throttle above is kept here; `HttpClient` owns only the
     # 429 retry/back-off. `raise_for_status=False` lets a non-429 4xx flow back
-    # to the caller (which inspects the out-of-coverage error body), and
-    # `max_backoff=None` leaves the `2**attempt` back-off uncapped to match the
-    # previous hand-rolled loop.
+    # to the caller (which inspects the out-of-coverage error body). The
+    # `2**attempt` back-off keeps the default `max_backoff` ceiling: the old
+    # loop's exponential wait never reached it, and it now bounds a server
+    # `Retry-After` the old loop ignored.
     http = HttpClient(
         session=session,
         status_forcelist=(429,),
         max_retries=max_retries - 1,
         backoff_factor=1.0,
-        max_backoff=None,
         raise_for_status=False,
         sleep=sleep,
         timeout=60,

--- a/src/earthlens/s3/backend.py
+++ b/src/earthlens/s3/backend.py
@@ -36,6 +36,7 @@ from earthlens.base import (
     TemporalExtent,
     crop_to_aoi,
     to_datetime,
+    warn_if_egress,
 )
 from earthlens.s3.auth import S3Auth, S3Credentials
 from earthlens.s3.catalog import Catalog, Dataset
@@ -315,6 +316,7 @@ class S3(AbstractDataSource):
         """
         client = self._auth.client()
         raw_dir = self._raw_dir()
+        self._warn_cross_region_egress(products)
         written: list[Path] = []
         missing = 0
         for product in tqdm(products, desc="amazon-s3", disable=not products):
@@ -329,6 +331,29 @@ class S3(AbstractDataSource):
                 "request; check the bbox / date window / variables."
             )
         return written
+
+    def _warn_cross_region_egress(self, products: list[RemoteProduct]) -> None:
+        """Warn once before a large cross-region pull, when sizes are known.
+
+        Sums the object sizes the listing already recorded on the planned
+        products (`size_bytes` metadata) and defers to
+        `earthlens.base.region.warn_if_egress`: it emits a single warning
+        only when the caller runs outside the bucket's region and the
+        total exceeds the default threshold. Datasets whose keys are
+        planned deterministically (no listing, no known size) contribute
+        nothing and never warn. The warning is advisory — the download
+        proceeds unchanged.
+
+        Args:
+            products: The planned products about to be fetched.
+        """
+        known = [
+            product.metadata["size_bytes"]
+            for product in products
+            if "size_bytes" in product.metadata
+        ]
+        if known:
+            warn_if_egress(self._dataset.region, size_bytes=sum(known))
 
     def _localise(self, raw: Path, product: RemoteProduct) -> Path:
         """Crop a downloaded granule to the AOI and write it.

--- a/src/earthlens/s3/backend.py
+++ b/src/earthlens/s3/backend.py
@@ -344,6 +344,11 @@ class S3(AbstractDataSource):
         nothing and never warn. The warning is advisory — the download
         proceeds unchanged.
 
+        `probe=False` keeps this advisory check off the network: the
+        caller region is taken from `AWS_REGION` / `AWS_DEFAULT_REGION`
+        only, so a warning never blocks the first download on the
+        instance-metadata probe chain (matching earthdata's re-point).
+
         Args:
             products: The planned products about to be fetched.
         """
@@ -353,7 +358,7 @@ class S3(AbstractDataSource):
             if "size_bytes" in product.metadata
         ]
         if known:
-            warn_if_egress(self._dataset.region, size_bytes=sum(known))
+            warn_if_egress(self._dataset.region, size_bytes=sum(known), probe=False)
 
     def _localise(self, raw: Path, product: RemoteProduct) -> Path:
         """Crop a downloaded granule to the AOI and write it.

--- a/src/earthlens/s3/layouts.py
+++ b/src/earthlens/s3/layouts.py
@@ -195,15 +195,22 @@ def _payer(request_payer: bool) -> dict[str, str]:
 
 def _list_keys(
     client: Any, bucket: str, prefix: str, request_payer: bool = False
-) -> list[str]:
-    """List object keys under `prefix` (paginated)."""
-    keys: list[str] = []
+) -> list[tuple[str, int]]:
+    """List `(object key, size in bytes)` under `prefix` (paginated).
+
+    Zero-size objects (directory placeholders) are skipped. The size is
+    carried alongside the key so callers can record it on the planned
+    product for the cross-region egress warning, at no extra request.
+    """
+    keys: list[tuple[str, int]] = []
     paginator = client.get_paginator("list_objects_v2")
     for page in paginator.paginate(
         Bucket=bucket, Prefix=prefix, **_payer(request_payer)
     ):
         keys.extend(
-            obj["Key"] for obj in page.get("Contents", []) if obj.get("Size", 0)
+            (obj["Key"], obj["Size"])
+            for obj in page.get("Contents", [])
+            if obj.get("Size", 0)
         )
     return keys
 
@@ -235,7 +242,7 @@ def _era5_products(dataset, variables, bbox, dates, client) -> list[RemoteProduc
         for year, month in _year_months(dates):
             prefix = f"{stream}/{year}{month:02d}/"
             token = f".{var.native}."
-            for key in _list_keys(
+            for key, size in _list_keys(
                 client, dataset.bucket, prefix, dataset.requester_pays
             ):
                 if token in key.rsplit("/", 1)[-1] and key.endswith(".nc"):
@@ -248,6 +255,7 @@ def _era5_products(dataset, variables, bbox, dates, client) -> list[RemoteProduc
                                 "variable": var.native,
                                 "year": year,
                                 "month": month,
+                                "size_bytes": size,
                             },
                         )
                     )
@@ -316,12 +324,12 @@ def _goes_products(dataset, variables, bbox, dates, client) -> list[RemoteProduc
             continue
         # One frame per day: the first frame of the first hour. The day has many
         # frames (every ~10-15 min); the rest are intentionally not planned.
-        keys = _list_keys(
-            client, dataset.bucket, hour_prefixes[0], dataset.requester_pays
+        sizes = dict(
+            _list_keys(client, dataset.bucket, hour_prefixes[0], dataset.requester_pays)
         )
         for var in variables:
             token = f"{var.native}_G"
-            match = next((k for k in keys if token in k.rsplit("/", 1)[-1]), None)
+            match = next((k for k in sizes if token in k.rsplit("/", 1)[-1]), None)
             if match is not None:
                 logger.info(
                     f"goes: selected frame {match.rsplit('/', 1)[-1]} for "
@@ -336,6 +344,7 @@ def _goes_products(dataset, variables, bbox, dates, client) -> list[RemoteProduc
                             "variable": var.native,
                             "year": date.year,
                             "doy": doy,
+                            "size_bytes": sizes[match],
                         },
                     )
                 )

--- a/src/earthlens/solar_wind_atlas/_helpers.py
+++ b/src/earthlens/solar_wind_atlas/_helpers.py
@@ -19,9 +19,12 @@ import math
 import os
 import zipfile
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlsplit
 
 import requests
+
+from earthlens.base.http import HttpClient
 
 #: GDAL `/vsicurl` HTTP settings applied (via `setdefault`) before the first
 #: remote read. `GDAL_DISABLE_READDIR_ON_OPEN` stops GDAL listing the "directory"
@@ -204,11 +207,29 @@ def zip_cache_path(url: str, cache_dir: Path) -> Path:
     return cache_dir / name
 
 
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the
+    module-level `requests.get` (rather than a private session) so this
+    single-shot download stays a fresh connection per call and tests that
+    monkeypatch `requests.get` still drive the transport.
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
+
+
 def download_zip(url: str, cache_dir: Path, *, timeout: float = 600.0) -> Path:
     """Download a ZIP archive into the cache once, reusing it if present.
 
     A present, non-empty cached file is returned without a network call, so the
-    multi-GB Global Solar Atlas archives are fetched at most once.
+    multi-GB Global Solar Atlas archives are fetched at most once. The transfer
+    is delegated to `HttpClient.download`, which streams to a sibling `.part`
+    file and renames it on success (removing the temp on any failure), so an
+    interrupted download never leaves a truncated archive. An error status
+    raises immediately — these single-file archives are not retried.
 
     Args:
         url: The `*.zip` download URL.
@@ -225,20 +246,10 @@ def download_zip(url: str, cache_dir: Path, *, timeout: float = 600.0) -> Path:
     target = zip_cache_path(url, cache_dir)
     if target.exists() and target.stat().st_size > 0:
         return target
-    partial = target.with_suffix(target.suffix + ".part")
-    try:
-        with requests.get(url, stream=True, timeout=timeout) as response:
-            response.raise_for_status()
-            with partial.open("wb") as handle:
-                for chunk in response.iter_content(chunk_size=_DOWNLOAD_CHUNK):
-                    if chunk:
-                        handle.write(chunk)
-    except BaseException:
-        # Don't leave a truncated .part behind for a failed / interrupted fetch.
-        partial.unlink(missing_ok=True)
-        raise
-    partial.replace(target)
-    return target
+    client = HttpClient(session=_RequestsGet(), status_forcelist=(), max_backoff=None)
+    return client.download(
+        url, target, chunk=_DOWNLOAD_CHUNK, progress=False, timeout=timeout
+    )
 
 
 def inner_tif(zip_path: Path) -> str:

--- a/src/earthlens/wdpa/_rest.py
+++ b/src/earthlens/wdpa/_rest.py
@@ -28,9 +28,9 @@ from typing import Any
 import geopandas as gpd
 import pandas as pd
 import requests
-from loguru import logger
 from shapely.geometry import shape
 
+from earthlens.base.http import HttpClient
 from earthlens.biodiversity import parse_retry_after
 from earthlens.wdpa.auth import AuthenticationError
 
@@ -86,13 +86,17 @@ _parse_retry_after = parse_retry_after
 def _get(session: requests.Session, path: str, params: dict[str, Any]) -> dict:
     """GET a v4 endpoint and return the parsed JSON, with retries on transient failure.
 
-    Retries on `429` (honouring `Retry-After`) and on `500`/`502`/`503`/`504` using
-    capped exponential back-off (`BACKOFF_FACTOR * 2**attempt`). A 401 maps to
-    :class:`AuthenticationError` immediately (never retried). Any non-401 HTTP
-    error that exhausts retries — or any other status — is re-raised as a
-    :class:`RuntimeError` whose message names the path and status but **never**
-    the URL or query parameters, because the WDPA token rides as a `?token=`
-    query param and a raw `requests.HTTPError` would echo it.
+    Transport is the shared :class:`~earthlens.base.http.HttpClient`, configured
+    to retry `429` (honouring `Retry-After`) and `500`/`502`/`503`/`504` with
+    exponential back-off (`BACKOFF_FACTOR * 2**attempt`, uncapped) and to retry
+    transport-layer `requests.RequestException`s the same way. The client is run
+    with `raise_for_status=False` — it **never** calls `raise_for_status`, so the
+    token-bearing URL is never echoed by a `requests.HTTPError`. `_get` keeps its
+    own terminal handling: a `401` maps to :class:`AuthenticationError`
+    immediately; any other non-2xx status — or a transport error that exhausts
+    the retry budget (re-raised by the client) — becomes a :class:`RuntimeError`
+    whose message names the path and status but **never** the URL or query
+    parameters, because the WDPA token rides as a `?token=` query param.
 
     Args:
         session: The HTTP session.
@@ -109,57 +113,39 @@ def _get(session: requests.Session, path: str, params: dict[str, Any]) -> dict:
             or on a non-recoverable transport error. The token is never echoed.
     """
     url = f"{BASE_URL}/{path}"
-    last_status: int | None = None
-    for attempt in range(MAX_RETRIES + 1):
-        try:
-            response = session.get(url, params=params, timeout=60)
-        except requests.RequestException as exc:
-            if attempt < MAX_RETRIES:
-                wait = BACKOFF_FACTOR * (2**attempt)
-                logger.warning(
-                    f"WDPA transport error on {path!r}: {type(exc).__name__}; "
-                    f"retry {attempt + 1}/{MAX_RETRIES} after {wait:.1f}s"
-                )
-                time.sleep(wait)
-                continue
-            raise RuntimeError(
-                f"Protected Planet transport error on /{path} "
-                f"({type(exc).__name__}); the WDPA token has been redacted."
-            ) from None
-        status = getattr(response, "status_code", None)
-        if status == 401:
-            raise AuthenticationError(
-                "Protected Planet rejected the WDPA token (HTTP 401). Check "
-                "WDPA_TOKEN / the token= argument, or request one at "
-                "https://api.protectedplanet.net/request."
-            )
-        last_status = status
-        if status in _RETRY_STATUSES and attempt < MAX_RETRIES:
-            retry_after = parse_retry_after(response.headers.get("Retry-After"))
-            wait = (
-                retry_after
-                if retry_after is not None
-                else BACKOFF_FACTOR * (2**attempt)
-            )
-            logger.warning(
-                f"Protected Planet returned HTTP {status} on {path!r}; "
-                f"retry {attempt + 1}/{MAX_RETRIES} after {wait:.1f}s"
-            )
-            time.sleep(wait)
-            continue
-        if status is None or status >= 400:
-            raise RuntimeError(
-                f"Protected Planet returned HTTP {status} for /{path} "
-                "(the WDPA token has been redacted from this error)."
-            )
-        return response.json()
-    # Defensive: unreachable today (every iteration above returns or raises).
-    # Kept so a future edit that breaks the invariant fails loudly instead of
-    # silently exiting the loop.
-    raise RuntimeError(  # pragma: no cover
-        f"Protected Planet exhausted {MAX_RETRIES} retries on /{path} "
-        f"(last status {last_status}); the WDPA token has been redacted."
+    client = HttpClient(
+        session=session,
+        status_forcelist=tuple(_RETRY_STATUSES),
+        retry_on_exceptions=(requests.RequestException,),
+        backoff_factor=BACKOFF_FACTOR,
+        max_retries=MAX_RETRIES,
+        max_backoff=None,
+        raise_for_status=False,
+        sleep=lambda seconds: time.sleep(seconds),
     )
+    try:
+        response = client.get(url, params=params, timeout=60)
+    except requests.RequestException as exc:
+        # The client re-raises the original transport exception once the retry
+        # budget is exhausted; convert it to the token-redacted RuntimeError so
+        # the `?token=` in the request URL can never surface in the error.
+        raise RuntimeError(
+            f"Protected Planet transport error on /{path} "
+            f"({type(exc).__name__}); the WDPA token has been redacted."
+        ) from None
+    status = getattr(response, "status_code", None)
+    if status == 401:
+        raise AuthenticationError(
+            "Protected Planet rejected the WDPA token (HTTP 401). Check "
+            "WDPA_TOKEN / the token= argument, or request one at "
+            "https://api.protectedplanet.net/request."
+        )
+    if status is None or status >= 400:
+        raise RuntimeError(
+            f"Protected Planet returned HTTP {status} for /{path} "
+            "(the WDPA token has been redacted from this error)."
+        )
+    return response.json()
 
 
 def _row(area: dict) -> dict[str, Any] | None:

--- a/src/earthlens/worldpop/backend.py
+++ b/src/earthlens/worldpop/backend.py
@@ -39,6 +39,7 @@ from earthlens.base.abstractdatasource import (
     SpatialExtent,
     TemporalExtent,
 )
+from earthlens.base.http import HttpClient
 from earthlens.base.spatial import crop_to_aoi, resolve_aoi
 from earthlens.worldpop._helpers import (
     cohort_of,
@@ -81,6 +82,20 @@ _RESOLUTIONS: frozenset[str] = frozenset({"100m", "1km"})
 _SCOPES: frozenset[str] = frozenset({"countries", "global"})
 #: Allowed values for the `level=` selector (only `pwd` offers both).
 _LEVELS: frozenset[str] = frozenset({"national", "subnational"})
+
+
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the
+    module-level `requests.get` (rather than a private session) so each
+    per-file download stays a fresh connection and the transport can be
+    driven by swapping `requests.get`.
+    """
+
+    def get(self, url: str, **kwargs: object) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
 
 
 class WorldPop(AbstractDataSource):
@@ -513,17 +528,19 @@ class WorldPop(AbstractDataSource):
         """
         if dest.exists() and dest.stat().st_size > 0:
             return dest
-        for attempt in range(_MAX_RETRIES):
-            try:
-                resp = requests.get(url, timeout=_HTTP_TIMEOUT)
-                resp.raise_for_status()
-                dest.write_bytes(resp.content)
-                return dest
-            except (requests.ConnectionError, requests.Timeout):
-                if attempt == _MAX_RETRIES - 1:
-                    raise
-                time.sleep(_BACKOFF_BASE * (2**attempt))
-        return dest  # unreachable; the loop returns or raises
+        http = HttpClient(
+            session=_RequestsGet(),
+            retry_on_exceptions=(requests.ConnectionError, requests.Timeout),
+            status_forcelist=(),
+            max_retries=_MAX_RETRIES - 1,
+            backoff_factor=_BACKOFF_BASE,
+            max_backoff=None,
+            timeout=_HTTP_TIMEOUT,
+            sleep=lambda seconds: time.sleep(seconds),
+        )
+        resp = http.get(url)
+        dest.write_bytes(resp.content)
+        return dest
 
     def _group_for_mosaic(
         self, products: list[RemoteProduct]

--- a/tests/base/test_http.py
+++ b/tests/base/test_http.py
@@ -228,6 +228,21 @@ class TestRetry:
             client.get("http://x")
         assert len(session.calls) == 1
 
+    def test_retried_response_is_closed(self):
+        """A retried response is closed before the next attempt (no leak)."""
+        first = _Resp(status=503, headers={"Retry-After": "0"})
+        session = _RecordingSession([first, _Resp(body={"ok": 1})])
+        HttpClient(session=session, sleep=lambda _: None).get("http://x")
+        assert first.closed is True
+
+    def test_errored_response_is_closed(self):
+        """The final errored response is closed before the error propagates."""
+        errored = _Resp(status=404)
+        session = _RecordingSession([errored])
+        with pytest.raises(requests.HTTPError):
+            HttpClient(session=session).get("http://x")
+        assert errored.closed is True
+
 
 @pytest.mark.unit
 class TestDownload:

--- a/tests/base/test_http.py
+++ b/tests/base/test_http.py
@@ -13,6 +13,7 @@ from earthlens.base.http import (
     _default_user_agent,
     _parse_retry_after,
     _progress_total,
+    _redact_url,
 )
 
 
@@ -149,6 +150,44 @@ class TestParseRetryAfter:
             "earthlens.base.http.parsedate_to_datetime", lambda value: None
         )
         assert _parse_retry_after("not-a-real-date") is None
+
+
+@pytest.mark.unit
+class TestRedactUrl:
+    """URL redaction for retry logs (secrets can ride in path or query)."""
+
+    @pytest.mark.parametrize(
+        "url, expected",
+        [
+            ("https://firms.example/api/SECRETKEY/area?x=1", "https://firms.example"),
+            ("https://host/p?api_key=SECRET", "https://host"),
+            ("not-a-url", "<url>"),
+            ("", "<url>"),
+        ],
+    )
+    def test_redact(self, url: str, expected: str):
+        """The path and query are stripped to scheme://host."""
+        assert _redact_url(url) == expected
+
+    def test_retry_log_omits_url_path_and_query(self):
+        """A retry warning logs only the host — never a path/query secret."""
+        from loguru import logger
+
+        messages: list[str] = []
+        sink = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+        try:
+            session = _RecordingSession(
+                [_Resp(status=429, headers={"Retry-After": "0"}), _Resp(body={})]
+            )
+            HttpClient(session=session, sleep=lambda _: None).get(
+                "https://h/api/SECRETKEY/x?api_key=TOPSECRET"
+            )
+        finally:
+            logger.remove(sink)
+        joined = " ".join(messages)
+        assert "SECRETKEY" not in joined
+        assert "TOPSECRET" not in joined
+        assert "https://h" in joined
 
 
 @pytest.mark.unit

--- a/tests/base/test_http.py
+++ b/tests/base/test_http.py
@@ -258,6 +258,24 @@ class TestRetry:
             client.get("http://x")
         assert len(session.calls) == 1
 
+    def test_retry_after_is_capped_by_max_backoff(self):
+        """A large Retry-After is clamped to max_backoff, not honoured raw."""
+        client, _, waits = _client(
+            [_Resp(status=429, headers={"Retry-After": "86400"}), _Resp(body={})],
+            max_backoff=30.0,
+        )
+        client.get("http://x")
+        assert waits == [30.0]
+
+    def test_max_backoff_none_leaves_wait_uncapped(self):
+        """max_backoff=None honours the raw Retry-After wait."""
+        client, _, waits = _client(
+            [_Resp(status=429, headers={"Retry-After": "120"}), _Resp(body={})],
+            max_backoff=None,
+        )
+        client.get("http://x")
+        assert waits == [120.0]
+
     def test_retried_response_is_closed(self):
         """A retried response is closed before the next attempt (no leak)."""
         first = _Resp(status=503, headers={"Retry-After": "0"})

--- a/tests/base/test_http.py
+++ b/tests/base/test_http.py
@@ -135,6 +135,21 @@ class TestParseRetryAfter:
         """Numeric non-negative values parse; missing/junk/negative yield None."""
         assert _parse_retry_after(value) == expected
 
+    def test_future_http_date_yields_positive_delay(self):
+        """A future HTTP-date Retry-After parses to a positive delay."""
+        assert _parse_retry_after("Fri, 31 Dec 2099 23:59:59 GMT") > 0
+
+    def test_past_http_date_clamps_to_zero(self):
+        """A past HTTP-date never sleeps backwards — it clamps to zero."""
+        assert _parse_retry_after("Fri, 31 Dec 1999 23:59:59 GMT") == 0.0
+
+    def test_http_date_parsing_none_result_is_none(self, monkeypatch):
+        """A parsedate result of None yields None (defensive guard)."""
+        monkeypatch.setattr(
+            "earthlens.base.http.parsedate_to_datetime", lambda value: None
+        )
+        assert _parse_retry_after("not-a-real-date") is None
+
 
 @pytest.mark.unit
 class TestDefaults:

--- a/tests/base/test_http.py
+++ b/tests/base/test_http.py
@@ -91,10 +91,17 @@ class TestParseRetryAfter:
 
     @pytest.mark.parametrize(
         "value, expected",
-        [("5", 5.0), ("0", 0.0), (None, None), ("soon", None), ("", None)],
+        [
+            ("5", 5.0),
+            ("0", 0.0),
+            (None, None),
+            ("soon", None),
+            ("", None),
+            ("-1", None),
+        ],
     )
     def test_parse(self, value: str | None, expected: float | None):
-        """Numeric values parse to seconds; missing/junk yield None."""
+        """Numeric non-negative values parse; missing/junk/negative yield None."""
         assert _parse_retry_after(value) == expected
 
 
@@ -212,6 +219,13 @@ class TestProgressTotal:
         assert _progress_total({}) is None
         assert _progress_total({"Content-Length": "big"}) is None
 
+    def test_identity_encoding_is_treated_as_unencoded(self):
+        """Content-Encoding: identity is a no-op, so Content-Length is trusted."""
+        assert (
+            _progress_total({"Content-Length": "512", "Content-Encoding": "identity"})
+            == 512
+        )
+
 
 @pytest.mark.unit
 class TestRetry:
@@ -275,6 +289,15 @@ class TestRetry:
         )
         client.get("http://x")
         assert waits == [120.0]
+
+    def test_negative_retry_after_falls_back_to_backoff(self):
+        """A negative Retry-After is ignored and never reaches sleep(negative)."""
+        client, _, waits = _client(
+            [_Resp(status=429, headers={"Retry-After": "-1"}), _Resp(body={})],
+            backoff_factor=2.0,
+        )
+        client.get("http://x")
+        assert waits == [2.0]
 
     def test_retried_response_is_closed(self):
         """A retried response is closed before the next attempt (no leak)."""

--- a/tests/base/test_http.py
+++ b/tests/base/test_http.py
@@ -75,6 +75,33 @@ class _RequestOnlySession:
         return self._response
 
 
+class _FlakySession:
+    """Raises `exc` on the first `fail_times` calls, then returns `response`."""
+
+    def __init__(self, fail_times: int, exc: BaseException, response: _Resp) -> None:
+        self._remaining = fail_times
+        self._exc = exc
+        self._response = response
+        self.calls = 0
+
+    def get(self, url: str, **kwargs: Any) -> _Resp:
+        self.calls += 1
+        if self._remaining > 0:
+            self._remaining -= 1
+            raise self._exc
+        return self._response
+
+
+class _Clock:
+    """Deterministic monotonic clock returning scripted values in order."""
+
+    def __init__(self, values: list[float]) -> None:
+        self._values = list(values)
+
+    def __call__(self) -> float:
+        return self._values.pop(0)
+
+
 def _client(
     responses: list[_Resp], **kwargs: Any
 ) -> tuple[HttpClient, _RecordingSession, list[float]]:
@@ -313,6 +340,145 @@ class TestRetry:
         with pytest.raises(requests.HTTPError):
             HttpClient(session=session).get("http://x")
         assert errored.closed is True
+
+
+@pytest.mark.unit
+class TestRetryOnExceptions:
+    """Retrying on configured transport exceptions."""
+
+    def test_retries_configured_exception_then_succeeds(self):
+        """A configured exception is retried with back-off, then succeeds."""
+        session = _FlakySession(
+            2, requests.ConnectionError("boom"), _Resp(body={"ok": 1})
+        )
+        waits: list[float] = []
+        client = HttpClient(
+            session=session,
+            sleep=waits.append,
+            backoff_factor=2.0,
+            retry_on_exceptions=(requests.ConnectionError,),
+        )
+        assert client.get_json("http://x") == {"ok": 1}
+        assert session.calls == 3
+        assert waits == [2.0, 4.0]
+
+    def test_unconfigured_exception_propagates_immediately(self):
+        """An exception not in retry_on_exceptions is not retried."""
+        session = _FlakySession(1, requests.ConnectionError("boom"), _Resp(body={}))
+        client = HttpClient(session=session)
+        with pytest.raises(requests.ConnectionError):
+            client.get("http://x")
+        assert session.calls == 1
+
+    def test_exhausted_exception_reraises(self):
+        """A persistent configured exception re-raises after the budget."""
+        session = _FlakySession(10, requests.Timeout("t"), _Resp(body={}))
+        waits: list[float] = []
+        client = HttpClient(
+            session=session,
+            sleep=waits.append,
+            max_retries=2,
+            retry_on_exceptions=(requests.Timeout,),
+        )
+        with pytest.raises(requests.Timeout):
+            client.get("http://x")
+        assert session.calls == 3
+        assert len(waits) == 2
+
+
+@pytest.mark.unit
+class TestRetryPredicate:
+    """Retrying a response the predicate marks retryable."""
+
+    def test_predicate_retries_a_2xx_then_returns(self):
+        """A 200 the predicate flags is retried until it clears."""
+        session = _RecordingSession(
+            [_Resp(body={"status": "quota"}), _Resp(body={"status": "ok"})]
+        )
+        waits: list[float] = []
+        client = HttpClient(
+            session=session,
+            sleep=waits.append,
+            retry_predicate=lambda r: r.json().get("status") == "quota",
+        )
+        assert client.get_json("http://x") == {"status": "ok"}
+        assert len(session.calls) == 2
+
+    def test_predicate_exhaustion_returns_last_response(self):
+        """When the predicate never clears, the last response is returned."""
+        session = _RecordingSession([_Resp(body={"status": "quota"})] * 5)
+        client = HttpClient(
+            session=session,
+            sleep=lambda _: None,
+            max_retries=2,
+            retry_predicate=lambda r: r.json().get("status") == "quota",
+        )
+        assert client.get("http://x").json() == {"status": "quota"}
+        assert len(session.calls) == 3
+
+
+@pytest.mark.unit
+class TestRaiseForStatus:
+    """The raise_for_status policy and per-request override."""
+
+    def test_disabled_returns_error_response(self):
+        """raise_for_status=False returns a 4xx response unraised."""
+        session = _RecordingSession([_Resp(status=404, body={"e": 1})])
+        assert (
+            HttpClient(session=session, raise_for_status=False)
+            .get("http://x")
+            .status_code
+            == 404
+        )
+
+    def test_default_still_raises(self):
+        """The default policy raises on an error status."""
+        session = _RecordingSession([_Resp(status=400)])
+        with pytest.raises(requests.HTTPError):
+            HttpClient(session=session).get("http://x")
+
+    def test_per_request_override_disables(self):
+        """A per-request raise_for_status=False overrides the client default."""
+        session = _RecordingSession([_Resp(status=400, body={})])
+        assert (
+            HttpClient(session=session)
+            .get("http://x", raise_for_status=False)
+            .status_code
+            == 400
+        )
+
+
+@pytest.mark.unit
+class TestThrottle:
+    """The min_interval proactive rate limit."""
+
+    def test_min_interval_sleeps_between_requests(self):
+        """A second request within the interval sleeps the remainder."""
+        session = _RecordingSession([_Resp(body={}), _Resp(body={})])
+        waits: list[float] = []
+        client = HttpClient(
+            session=session,
+            sleep=waits.append,
+            clock=_Clock([0.0, 0.4, 1.0]),
+            min_interval=1.0,
+        )
+        client.get("http://x")
+        client.get("http://x")
+        assert waits == [pytest.approx(0.6)]
+
+    def test_no_throttle_when_interval_elapsed(self):
+        """No sleep when more than the interval has already passed."""
+        session = _RecordingSession([_Resp(body={}), _Resp(body={})])
+        waits: list[float] = []
+        client = HttpClient(
+            session=session,
+            sleep=waits.append,
+            clock=_Clock([0.0, 2.0, 2.0]),
+            min_interval=1.0,
+        )
+        client.get("http://x")
+        client.get("http://x")
+        assert waits == []
 
 
 @pytest.mark.unit

--- a/tests/base/test_http.py
+++ b/tests/base/test_http.py
@@ -161,12 +161,13 @@ class TestRedactUrl:
         [
             ("https://firms.example/api/SECRETKEY/area?x=1", "https://firms.example"),
             ("https://host/p?api_key=SECRET", "https://host"),
+            ("https://user:SECRET@host/p", "https://host"),
             ("not-a-url", "<url>"),
             ("", "<url>"),
         ],
     )
     def test_redact(self, url: str, expected: str):
-        """The path and query are stripped to scheme://host."""
+        """Path, query, and userinfo are stripped to scheme://host."""
         assert _redact_url(url) == expected
 
     def test_retry_log_omits_url_path_and_query(self):

--- a/tests/base/test_http.py
+++ b/tests/base/test_http.py
@@ -12,6 +12,7 @@ from earthlens.base.http import (
     HttpClient,
     _default_user_agent,
     _parse_retry_after,
+    _progress_total,
 )
 
 
@@ -117,9 +118,10 @@ class TestDefaults:
 
     def test_custom_user_agent_overrides_default(self):
         """A user_agent= argument replaces the default agent string."""
-        assert HttpClient(user_agent="osm-contact/1.0").default_headers[
-            "User-Agent"
-        ] == "osm-contact/1.0"
+        assert (
+            HttpClient(user_agent="osm-contact/1.0").default_headers["User-Agent"]
+            == "osm-contact/1.0"
+        )
 
     def test_extra_headers_merge_into_defaults(self):
         """Construction headers= merge onto the defaults (e.g. X-API-Key)."""
@@ -181,6 +183,34 @@ class TestRequest:
         client = HttpClient(session=session)
         assert client.get_json("http://x") == {"ok": 1}
         assert session.calls[0][0] == "GET"
+
+    def test_stream_requests_stream_and_returns_response(self):
+        """stream() issues a stream=True GET and returns the open response."""
+        resp = _Resp(body={})
+        session = _RecordingSession([resp])
+        assert HttpClient(session=session).stream("http://x") is resp
+        assert session.calls[0][2]["stream"] is True
+
+
+@pytest.mark.unit
+class TestProgressTotal:
+    """Progress-bar total derivation from response headers."""
+
+    def test_plain_content_length(self):
+        """A numeric Content-Length with no encoding is the total."""
+        assert _progress_total({"Content-Length": "1024"}) == 1024
+
+    def test_gzip_encoded_is_unbounded(self):
+        """A Content-Encoding body yields no total (compressed length lies)."""
+        assert (
+            _progress_total({"Content-Length": "1024", "Content-Encoding": "gzip"})
+            is None
+        )
+
+    def test_missing_or_non_numeric_is_none(self):
+        """Absent or non-numeric Content-Length yields no total."""
+        assert _progress_total({}) is None
+        assert _progress_total({"Content-Length": "big"}) is None
 
 
 @pytest.mark.unit
@@ -263,18 +293,14 @@ class TestDownload:
     def test_download_requests_stream(self, tmp_path):
         """download issues a streaming GET (stream=True)."""
         session = _RecordingSession([_Resp(blocks=[b"a"])])
-        HttpClient(session=session).download(
-            "http://x", tmp_path / "f", progress=False
-        )
+        HttpClient(session=session).download("http://x", tmp_path / "f", progress=False)
         assert session.calls[0][2]["stream"] is True
 
     def test_download_closes_response(self, tmp_path):
         """download closes the streaming response when finished."""
         response = _Resp(blocks=[b"a", b"b"])
         session = _RecordingSession([response])
-        HttpClient(session=session).download(
-            "http://x", tmp_path / "f", progress=False
-        )
+        HttpClient(session=session).download("http://x", tmp_path / "f", progress=False)
         assert response.closed is True
 
     def test_download_without_content_length(self, tmp_path):

--- a/tests/base/test_http.py
+++ b/tests/base/test_http.py
@@ -26,11 +26,13 @@ class _Resp:
         headers: dict[str, str] | None = None,
         body: Any = None,
         blocks: list[bytes] | None = None,
+        stream_error: BaseException | None = None,
     ) -> None:
         self.status_code = status
         self.headers = headers or {}
         self._body = body
         self._blocks = blocks or []
+        self._stream_error = stream_error
         self.closed = False
 
     def json(self) -> Any:
@@ -42,6 +44,8 @@ class _Resp:
 
     def iter_content(self, chunk_size: int | None = None) -> Any:
         yield from self._blocks
+        if self._stream_error is not None:
+            raise self._stream_error
 
     def close(self) -> None:
         self.closed = True
@@ -534,3 +538,65 @@ class TestDownload:
         client.download("http://x", dest, progress=False)
         assert dest.read_bytes() == b"ok"
         assert len(session.calls) == 2
+
+    def test_download_is_atomic_no_part_left(self, tmp_path):
+        """A successful download renames the temp and leaves no .part."""
+        session = _RecordingSession([_Resp(blocks=[b"data"])])
+        dest = tmp_path / "out.bin"
+        HttpClient(session=session).download("http://x", dest, progress=False)
+        assert dest.read_bytes() == b"data"
+        assert not dest.with_name("out.bin.part").exists()
+
+    def test_download_cleans_partial_on_stream_failure(self, tmp_path):
+        """A mid-stream failure removes the temp and leaves no dest."""
+        session = _RecordingSession(
+            [_Resp(blocks=[b"partial"], stream_error=OSError("mid-stream"))]
+        )
+        dest = tmp_path / "out.bin"
+        with pytest.raises(OSError):
+            HttpClient(session=session).download("http://x", dest, progress=False)
+        assert not dest.exists()
+        assert not dest.with_name("out.bin.part").exists()
+
+    def test_download_retries_on_exception_then_succeeds(self, tmp_path):
+        """A configured transport exception retries the whole download."""
+        session = _FlakySession(
+            2, requests.ConnectionError("boom"), _Resp(blocks=[b"ok"])
+        )
+        client = HttpClient(
+            session=session,
+            sleep=lambda _: None,
+            retry_on_exceptions=(requests.ConnectionError,),
+        )
+        dest = tmp_path / "out.bin"
+        client.download("http://x", dest, progress=False)
+        assert dest.read_bytes() == b"ok"
+        assert session.calls == 3
+        assert not dest.with_name("out.bin.part").exists()
+
+    def test_download_exhausts_exception_retries_and_reraises(self, tmp_path):
+        """A persistent transport exception re-raises after the budget."""
+        session = _FlakySession(
+            10, requests.ConnectionError("boom"), _Resp(blocks=[b"ok"])
+        )
+        client = HttpClient(
+            session=session,
+            sleep=lambda _: None,
+            max_retries=2,
+            retry_on_exceptions=(requests.ConnectionError,),
+        )
+        dest = tmp_path / "out.bin"
+        with pytest.raises(requests.ConnectionError):
+            client.download("http://x", dest, progress=False)
+        assert session.calls == 3
+        assert not dest.with_name("out.bin.part").exists()
+
+    def test_download_non_atomic_writes_dest_directly(self, tmp_path):
+        """atomic=False streams straight to dest with no temp file."""
+        session = _RecordingSession([_Resp(blocks=[b"data"])])
+        dest = tmp_path / "out.bin"
+        HttpClient(session=session).download(
+            "http://x", dest, progress=False, atomic=False
+        )
+        assert dest.read_bytes() == b"data"
+        assert not dest.with_name("out.bin.part").exists()

--- a/tests/base/test_http.py
+++ b/tests/base/test_http.py
@@ -1,0 +1,288 @@
+"""Unit tests for `earthlens.base.http` (headers, retry, download)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import requests
+
+from earthlens.base.http import (
+    DEFAULT_STATUS_FORCELIST,
+    HttpClient,
+    _default_user_agent,
+    _parse_retry_after,
+)
+
+
+class _Resp:
+    """Canned response: json/raise_for_status/iter_content/close."""
+
+    def __init__(
+        self,
+        *,
+        status: int = 200,
+        headers: dict[str, str] | None = None,
+        body: Any = None,
+        blocks: list[bytes] | None = None,
+    ) -> None:
+        self.status_code = status
+        self.headers = headers or {}
+        self._body = body
+        self._blocks = blocks or []
+        self.closed = False
+
+    def json(self) -> Any:
+        return self._body
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+    def iter_content(self, chunk_size: int | None = None) -> Any:
+        yield from self._blocks
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _RecordingSession:
+    """Returns queued responses in order, recording each verb call."""
+
+    def __init__(self, responses: list[_Resp]) -> None:
+        self._responses = list(responses)
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def get(self, url: str, **kwargs: Any) -> _Resp:
+        self.calls.append(("GET", url, kwargs))
+        return self._responses.pop(0)
+
+    def post(self, url: str, **kwargs: Any) -> _Resp:
+        self.calls.append(("POST", url, kwargs))
+        return self._responses.pop(0)
+
+
+class _RequestOnlySession:
+    """Implements only `request()` — exercises the `_send` fallback."""
+
+    def __init__(self, response: _Resp) -> None:
+        self._response = response
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def request(self, method: str, url: str, **kwargs: Any) -> _Resp:
+        self.calls.append((method, url, kwargs))
+        return self._response
+
+
+def _client(
+    responses: list[_Resp], **kwargs: Any
+) -> tuple[HttpClient, _RecordingSession, list[float]]:
+    """Build a client over a recording session with captured sleeps."""
+    session = _RecordingSession(responses)
+    waits: list[float] = []
+    client = HttpClient(session=session, sleep=waits.append, **kwargs)
+    return client, session, waits
+
+
+@pytest.mark.unit
+class TestParseRetryAfter:
+    """Retry-After header parsing."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [("5", 5.0), ("0", 0.0), (None, None), ("soon", None), ("", None)],
+    )
+    def test_parse(self, value: str | None, expected: float | None):
+        """Numeric values parse to seconds; missing/junk yield None."""
+        assert _parse_retry_after(value) == expected
+
+
+@pytest.mark.unit
+class TestDefaults:
+    """Construction defaults: user-agent, headers, forcelist."""
+
+    def test_default_user_agent_is_version_stamped(self):
+        """The default agent is the earthlens/{version} string."""
+        assert _default_user_agent().startswith("earthlens/")
+
+    def test_default_user_agent_is_not_mozilla(self):
+        """The default agent is non-Mozilla (DIGITAL.CSIC Anubis pass)."""
+        assert "mozilla" not in _default_user_agent().lower()
+
+    def test_default_headers_carry_ua_and_gzip(self):
+        """The default headers set User-Agent and gzip Accept-Encoding."""
+        headers = HttpClient().default_headers
+        assert headers["User-Agent"].startswith("earthlens/")
+        assert headers["Accept-Encoding"] == "gzip, deflate"
+
+    def test_custom_user_agent_overrides_default(self):
+        """A user_agent= argument replaces the default agent string."""
+        assert HttpClient(user_agent="osm-contact/1.0").default_headers[
+            "User-Agent"
+        ] == "osm-contact/1.0"
+
+    def test_extra_headers_merge_into_defaults(self):
+        """Construction headers= merge onto the defaults (e.g. X-API-Key)."""
+        headers = HttpClient(headers={"X-API-Key": "k"}).default_headers
+        assert headers["X-API-Key"] == "k"
+        assert "User-Agent" in headers
+
+    def test_default_forcelist_includes_429_and_5xx(self):
+        """The default retry set covers 429 and the transient 5xx family."""
+        assert DEFAULT_STATUS_FORCELIST == (429, 500, 502, 503, 504)
+        assert HttpClient().status_forcelist == (429, 500, 502, 503, 504)
+
+    def test_session_property_exposes_injected_session(self):
+        """The session property returns the injected transport."""
+        session = _RecordingSession([])
+        assert HttpClient(session=session).session is session
+
+
+@pytest.mark.unit
+class TestRequest:
+    """Verb dispatch, header merge, and JSON decode."""
+
+    def test_get_sends_merged_headers(self):
+        """Per-request headers merge over (and override) the defaults."""
+        client, session, _ = _client([_Resp(body={})], headers={"X-API-Key": "k"})
+        client.get("http://x", headers={"X-Extra": "v", "User-Agent": "override"})
+        sent = session.calls[0][2]["headers"]
+        assert sent["X-API-Key"] == "k"
+        assert sent["X-Extra"] == "v"
+        assert sent["User-Agent"] == "override"
+        assert sent["Accept-Encoding"] == "gzip, deflate"
+
+    def test_get_applies_default_timeout(self):
+        """A request with no timeout uses the client's default timeout."""
+        client, session, _ = _client([_Resp(body={})], timeout=12.0)
+        client.get("http://x")
+        assert session.calls[0][2]["timeout"] == 12.0
+
+    def test_get_timeout_override(self):
+        """A per-request timeout overrides the client default."""
+        client, session, _ = _client([_Resp(body={})], timeout=12.0)
+        client.get("http://x", timeout=3.0)
+        assert session.calls[0][2]["timeout"] == 3.0
+
+    def test_post_dispatches_to_session_post(self):
+        """post() routes to the session's post verb."""
+        client, session, _ = _client([_Resp(body={})])
+        client.post("http://x", data={"a": 1})
+        assert session.calls[0][0] == "POST"
+
+    def test_get_json_decodes_body(self):
+        """get_json returns the decoded JSON body."""
+        client, _, _ = _client([_Resp(body={"results": [1, 2]})])
+        assert client.get_json("http://x") == {"results": [1, 2]}
+
+    def test_send_falls_back_to_request(self):
+        """A session without a verb method is driven via request()."""
+        session = _RequestOnlySession(_Resp(body={"ok": 1}))
+        client = HttpClient(session=session)
+        assert client.get_json("http://x") == {"ok": 1}
+        assert session.calls[0][0] == "GET"
+
+
+@pytest.mark.unit
+class TestRetry:
+    """The Retry-After-aware retry/back-off loop."""
+
+    def test_retry_after_is_honoured(self):
+        """A retryable status waits the Retry-After seconds, then succeeds."""
+        client, session, waits = _client(
+            [_Resp(status=429, headers={"Retry-After": "7"}), _Resp(body={"ok": 1})]
+        )
+        assert client.get_json("http://x") == {"ok": 1}
+        assert waits == [7.0]
+        assert len(session.calls) == 2
+
+    def test_backoff_maths_without_retry_after(self):
+        """No Retry-After backs off as backoff_factor * 2**attempt."""
+        client, _, waits = _client(
+            [_Resp(status=500), _Resp(status=500), _Resp(body={"ok": 1})],
+            backoff_factor=3.0,
+        )
+        client.get("http://x")
+        assert waits == [3.0, 6.0]
+
+    def test_default_forcelist_retries_500(self):
+        """A 500 is retried under the default forcelist."""
+        client, session, _ = _client([_Resp(status=500), _Resp(body={"ok": 1})])
+        client.get("http://x")
+        assert len(session.calls) == 2
+
+    def test_exhaustion_raises(self):
+        """Exhausted retries raise the final response's HTTPError."""
+        client, session, waits = _client(
+            [_Resp(status=429, headers={"Retry-After": "0"})] * 4, max_retries=2
+        )
+        with pytest.raises(requests.HTTPError):
+            client.get("http://x")
+        assert len(waits) == 2
+        assert len(session.calls) == 3
+
+    def test_status_outside_forcelist_raises_immediately(self):
+        """A status not in the forcelist raises without retrying."""
+        client, session, _ = _client([_Resp(status=500)], status_forcelist=(429,))
+        with pytest.raises(requests.HTTPError):
+            client.get("http://x")
+        assert len(session.calls) == 1
+
+
+@pytest.mark.unit
+class TestDownload:
+    """Streamed download to disk."""
+
+    def test_download_writes_bytes_and_returns_path(self, tmp_path):
+        """download streams the blocks to dest and returns the path."""
+        payload = b"earthlens" * 50
+        session = _RecordingSession(
+            [_Resp(headers={"Content-Length": str(len(payload))}, blocks=[payload])]
+        )
+        client = HttpClient(session=session)
+        dest = tmp_path / "nested" / "out.bin"
+        result = client.download("http://x/file", dest, progress=False)
+        assert result == dest
+        assert dest.read_bytes() == payload
+
+    def test_download_requests_stream(self, tmp_path):
+        """download issues a streaming GET (stream=True)."""
+        session = _RecordingSession([_Resp(blocks=[b"a"])])
+        HttpClient(session=session).download(
+            "http://x", tmp_path / "f", progress=False
+        )
+        assert session.calls[0][2]["stream"] is True
+
+    def test_download_closes_response(self, tmp_path):
+        """download closes the streaming response when finished."""
+        response = _Resp(blocks=[b"a", b"b"])
+        session = _RecordingSession([response])
+        HttpClient(session=session).download(
+            "http://x", tmp_path / "f", progress=False
+        )
+        assert response.closed is True
+
+    def test_download_without_content_length(self, tmp_path):
+        """A missing Content-Length still writes every block."""
+        session = _RecordingSession([_Resp(blocks=[b"x", b"y", b"z"])])
+        dest = tmp_path / "f"
+        HttpClient(session=session).download("http://x", dest, progress=False)
+        assert dest.read_bytes() == b"xyz"
+
+    def test_download_skips_empty_keepalive_chunks(self, tmp_path):
+        """Empty keep-alive chunks are skipped, real blocks written."""
+        session = _RecordingSession([_Resp(blocks=[b"", b"data", b""])])
+        dest = tmp_path / "f"
+        HttpClient(session=session).download("http://x", dest, progress=False)
+        assert dest.read_bytes() == b"data"
+
+    def test_download_retries_before_streaming(self, tmp_path):
+        """A retryable status on the initial response is retried."""
+        session = _RecordingSession(
+            [_Resp(status=503, headers={"Retry-After": "0"}), _Resp(blocks=[b"ok"])]
+        )
+        client = HttpClient(session=session, sleep=lambda _: None)
+        dest = tmp_path / "f"
+        client.download("http://x", dest, progress=False)
+        assert dest.read_bytes() == b"ok"
+        assert len(session.calls) == 2

--- a/tests/base/test_http.py
+++ b/tests/base/test_http.py
@@ -646,6 +646,30 @@ class TestDownload:
         assert session.calls == 3
         assert not dest.with_name("out.bin.part").exists()
 
+    def test_download_cleans_temp_when_rename_fails(self, tmp_path):
+        """A failed atomic rename still removes the .part temp."""
+        session = _RecordingSession([_Resp(blocks=[b"data"])])
+        dest = tmp_path / "out.bin"
+        dest.mkdir()  # a directory target makes tmp.replace(dest) fail
+        with pytest.raises(OSError):
+            HttpClient(session=session).download("http://x", dest, progress=False)
+        assert not dest.with_name("out.bin.part").exists()
+
+    def test_download_retries_on_predicate(self, tmp_path):
+        """download retries a response the predicate flags before streaming."""
+        session = _RecordingSession(
+            [_Resp(body={"retry": True}), _Resp(blocks=[b"ok"])]
+        )
+        client = HttpClient(
+            session=session,
+            sleep=lambda _: None,
+            retry_predicate=lambda r: r.json() == {"retry": True},
+        )
+        dest = tmp_path / "f"
+        client.download("http://x", dest, progress=False)
+        assert dest.read_bytes() == b"ok"
+        assert len(session.calls) == 2
+
     def test_download_non_atomic_writes_dest_directly(self, tmp_path):
         """atomic=False streams straight to dest with no temp file."""
         session = _RecordingSession([_Resp(blocks=[b"data"])])

--- a/tests/base/test_region_affinity.py
+++ b/tests/base/test_region_affinity.py
@@ -189,6 +189,16 @@ class TestMetadataRequest:
         monkeypatch.setattr(region_mod.urllib.request, "urlopen", _raise)
         assert region_mod._metadata_request("http://x", headers={}) is None
 
+    def test_none_on_http_exception(self, monkeypatch: pytest.MonkeyPatch):
+        """A non-OSError HTTPException (e.g. BadStatusLine) yields None."""
+        import http.client
+
+        def _raise(*args: Any, **kwargs: Any):
+            raise http.client.BadStatusLine("garbage from an intercepting proxy")
+
+        monkeypatch.setattr(region_mod.urllib.request, "urlopen", _raise)
+        assert region_mod._metadata_request("http://x", headers={}) is None
+
 
 @pytest.mark.unit
 class TestNormalizeGcpZone:

--- a/tests/base/test_region_affinity.py
+++ b/tests/base/test_region_affinity.py
@@ -1,0 +1,280 @@
+"""Unit tests for `earthlens.base.region` (affinity, probe, egress warning)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from loguru import logger
+
+from earthlens.base import region as region_mod
+from earthlens.base.region import (
+    _normalize_gcp_zone,
+    region_affinity,
+    warn_if_egress,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_probe_cache():
+    """Reset the per-process probe cache around every test."""
+    region_mod.clear_region_cache()
+    yield
+    region_mod.clear_region_cache()
+
+
+@pytest.fixture
+def no_aws_env(monkeypatch: pytest.MonkeyPatch):
+    """Remove ambient AWS region env vars so the probe path is exercised."""
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+
+@pytest.fixture
+def warnings_sink():
+    """Capture WARNING-level loguru messages into a list."""
+    messages: list[str] = []
+    sink_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    yield messages
+    logger.remove(sink_id)
+
+
+def _fake_metadata(mapping: dict[str, str | None]):
+    """Build a _metadata_request stand-in over a url -> body mapping."""
+
+    def _request(url: str, **kwargs: Any) -> str | None:
+        return mapping.get(url)
+
+    return _request
+
+
+@pytest.mark.unit
+class TestEnvResolution:
+    """Caller-region resolution from explicit arg and environment."""
+
+    def test_aws_region_env_is_in_region(self, monkeypatch: pytest.MonkeyPatch):
+        """AWS_REGION supplies the caller region for an in-region match."""
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        assert region_affinity("us-west-2", probe=False) == "in-region"
+
+    def test_aws_default_region_env_is_used(self, monkeypatch: pytest.MonkeyPatch):
+        """AWS_DEFAULT_REGION is the fallback when AWS_REGION is unset."""
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-1")
+        assert region_affinity("eu-west-1", probe=False) == "in-region"
+
+    def test_env_mismatch_is_egress(self, monkeypatch: pytest.MonkeyPatch):
+        """A known caller region differing from the bucket is egress."""
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        assert region_affinity("eu-west-1", probe=False) == "egress"
+
+    def test_explicit_caller_overrides_env(self, monkeypatch: pytest.MonkeyPatch):
+        """An explicit caller_region takes precedence over the environment."""
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        assert region_affinity("eu-west-1", caller_region="eu-west-1") == "in-region"
+
+    def test_empty_bucket_is_unknown(self):
+        """An empty bucket_region yields unknown regardless of caller."""
+        assert region_affinity("", caller_region="us-west-2") == "unknown"
+
+    def test_no_signal_is_unknown(self, no_aws_env):
+        """No explicit caller, no env, and no probe yields unknown."""
+        assert region_affinity("us-west-2", probe=False) == "unknown"
+
+
+@pytest.mark.unit
+class TestProbe:
+    """The instance-metadata probe fallback and its cache."""
+
+    def test_aws_probe_hit(self, monkeypatch: pytest.MonkeyPatch, no_aws_env):
+        """The AWS IMDSv2 token+region probe resolves the caller region."""
+        monkeypatch.setattr(
+            region_mod,
+            "_metadata_request",
+            _fake_metadata(
+                {
+                    region_mod._AWS_TOKEN_URL: "token",
+                    region_mod._AWS_REGION_URL: "us-west-2",
+                }
+            ),
+        )
+        assert region_affinity("us-west-2") == "in-region"
+
+    def test_gcp_probe_hit_normalises_zone(
+        self, monkeypatch: pytest.MonkeyPatch, no_aws_env
+    ):
+        """A GCP zone is normalised to its region before comparison."""
+        monkeypatch.setattr(
+            region_mod,
+            "_metadata_request",
+            _fake_metadata(
+                {region_mod._GCP_ZONE_URL: "projects/9/zones/europe-west4-b"}
+            ),
+        )
+        assert region_affinity("europe-west4") == "in-region"
+
+    def test_azure_probe_hit(self, monkeypatch: pytest.MonkeyPatch, no_aws_env):
+        """The Azure IMDS location probe resolves the caller region."""
+        monkeypatch.setattr(
+            region_mod,
+            "_metadata_request",
+            _fake_metadata({region_mod._AZURE_LOCATION_URL: "westus2"}),
+        )
+        assert region_affinity("westus2") == "in-region"
+
+    def test_probe_all_fail_is_unknown(
+        self, monkeypatch: pytest.MonkeyPatch, no_aws_env
+    ):
+        """When no metadata endpoint answers, the caller stays unknown."""
+        monkeypatch.setattr(region_mod, "_metadata_request", _fake_metadata({}))
+        assert region_affinity("us-west-2") == "unknown"
+
+    def test_probe_false_skips_network(
+        self, monkeypatch: pytest.MonkeyPatch, no_aws_env
+    ):
+        """probe=False never touches the metadata seam."""
+
+        def _boom(*args: Any, **kwargs: Any) -> str | None:
+            raise AssertionError("probe must not run when probe=False")
+
+        monkeypatch.setattr(region_mod, "_metadata_request", _boom)
+        assert region_affinity("us-west-2", probe=False) == "unknown"
+
+    def test_probe_result_is_cached(self, monkeypatch: pytest.MonkeyPatch, no_aws_env):
+        """The probe runs once; a second call reuses the cached region."""
+        calls: list[str] = []
+
+        def _counting(url: str, **kwargs: Any) -> str | None:
+            calls.append(url)
+            return "westus2" if url == region_mod._AZURE_LOCATION_URL else None
+
+        monkeypatch.setattr(region_mod, "_metadata_request", _counting)
+        assert region_affinity("westus2") == "in-region"
+        first = len(calls)
+        assert region_affinity("westus2") == "in-region"
+        assert len(calls) == first
+
+
+@pytest.mark.unit
+class TestMetadataRequest:
+    """The single network seam's fail-safe branches."""
+
+    def test_returns_body_on_200(self, monkeypatch: pytest.MonkeyPatch):
+        """A 200 response returns its stripped body."""
+        monkeypatch.setattr(
+            region_mod.urllib.request, "urlopen", _fake_urlopen(200, b"us-west-2 ")
+        )
+        assert region_mod._metadata_request("http://x", headers={}) == "us-west-2"
+
+    def test_none_on_non_200(self, monkeypatch: pytest.MonkeyPatch):
+        """A non-200 status yields None."""
+        monkeypatch.setattr(
+            region_mod.urllib.request, "urlopen", _fake_urlopen(404, b"nope")
+        )
+        assert region_mod._metadata_request("http://x", headers={}) is None
+
+    def test_none_on_empty_body(self, monkeypatch: pytest.MonkeyPatch):
+        """An empty body yields None."""
+        monkeypatch.setattr(
+            region_mod.urllib.request, "urlopen", _fake_urlopen(200, b"  ")
+        )
+        assert region_mod._metadata_request("http://x", headers={}) is None
+
+    def test_none_on_oserror(self, monkeypatch: pytest.MonkeyPatch):
+        """A transport error (OSError/timeout) yields None, not a raise."""
+
+        def _raise(*args: Any, **kwargs: Any):
+            raise OSError("no route")
+
+        monkeypatch.setattr(region_mod.urllib.request, "urlopen", _raise)
+        assert region_mod._metadata_request("http://x", headers={}) is None
+
+
+@pytest.mark.unit
+class TestNormalizeGcpZone:
+    """GCP zone-string to region normalisation."""
+
+    @pytest.mark.parametrize(
+        "zone, expected",
+        [
+            ("projects/9/zones/us-west1-a", "us-west1"),
+            ("us-west1-a", "us-west1"),
+            ("westus2", "westus2"),
+            ("", None),
+        ],
+    )
+    def test_normalise(self, zone: str, expected: str | None):
+        """Path and trailing zone letter are stripped to the region."""
+        assert _normalize_gcp_zone(zone) == expected
+
+
+@pytest.mark.unit
+class TestWarnIfEgress:
+    """The egress warning helper."""
+
+    def test_warns_above_threshold(self, warnings_sink):
+        """A large cross-region pull emits one egress warning."""
+        hint = warn_if_egress(
+            "us-west-2", size_bytes=2 << 30, caller_region="eu-central-1"
+        )
+        assert hint == "egress"
+        assert any("egress" in m.lower() for m in warnings_sink)
+
+    def test_no_warn_below_threshold(self, warnings_sink):
+        """A small egress transfer does not warn."""
+        hint = warn_if_egress(
+            "us-west-2", size_bytes=1024, caller_region="eu-central-1"
+        )
+        assert hint == "egress"
+        assert warnings_sink == []
+
+    def test_no_warn_when_in_region(self, warnings_sink):
+        """An in-region transfer never warns, regardless of size."""
+        hint = warn_if_egress(
+            "us-west-2", size_bytes=5 << 30, caller_region="us-west-2"
+        )
+        assert hint == "in-region"
+        assert warnings_sink == []
+
+    def test_custom_threshold_fires(self, warnings_sink):
+        """A custom threshold below the size triggers the warning."""
+        hint = warn_if_egress(
+            "us-west-2",
+            size_bytes=200,
+            threshold_bytes=100,
+            caller_region="eu-central-1",
+        )
+        assert hint == "egress"
+        assert len(warnings_sink) == 1
+
+    def test_returns_unknown_without_signal(self, warnings_sink, no_aws_env):
+        """No caller signal yields unknown and no warning."""
+        hint = warn_if_egress("us-west-2", size_bytes=5 << 30, probe=False)
+        assert hint == "unknown"
+        assert warnings_sink == []
+
+
+class _FakeResp:
+    """Context-manager stand-in for a urlopen response."""
+
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self._body = body
+
+    def __enter__(self) -> _FakeResp:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _fake_urlopen(status: int, body: bytes):
+    """Build a urlopen stand-in returning a canned response."""
+
+    def _open(request: Any, timeout: float | None = None) -> _FakeResp:
+        return _FakeResp(status, body)
+
+    return _open

--- a/tests/base/test_region_affinity.py
+++ b/tests/base/test_region_affinity.py
@@ -210,11 +210,12 @@ class TestNormalizeGcpZone:
             ("projects/9/zones/us-west1-a", "us-west1"),
             ("us-west1-a", "us-west1"),
             ("westus2", "westus2"),
+            ("europe-west4", "europe-west4"),
             ("", None),
         ],
     )
     def test_normalise(self, zone: str, expected: str | None):
-        """Path and trailing zone letter are stripped to the region."""
+        """Path and a trailing single zone letter are stripped to the region."""
         assert _normalize_gcp_zone(zone) == expected
 
 

--- a/tests/drought/test_backend.py
+++ b/tests/drought/test_backend.py
@@ -898,6 +898,9 @@ class _FakeResponse:
         for offset in range(0, len(view), chunk_size):
             yield bytes(view[offset : offset + chunk_size])
 
+    def close(self) -> None:
+        """No-op — the fake holds no socket (HttpClient closes the stream)."""
+
     def __enter__(self) -> _FakeResponse:
         return self
 

--- a/tests/firms/conftest.py
+++ b/tests/firms/conftest.py
@@ -37,6 +37,7 @@ class _FakeResponse:
         self.text = text
         self.status_code = status_code
         self.url = url
+        self.headers: dict[str, str] = {}
 
     def raise_for_status(self) -> None:
         import requests
@@ -45,6 +46,9 @@ class _FakeResponse:
             raise requests.HTTPError(
                 f"{self.status_code} Client Error for url: {self.url}"
             )
+
+    def close(self) -> None:
+        """No-op — the fake holds no socket (closed by HttpClient on retry)."""
 
 
 class _FakeFirms:
@@ -61,7 +65,7 @@ class _FakeFirms:
         self.status_code: int = 200
         self.responses: list[_FakeResponse] | None = None
 
-    def __call__(self, url: str, timeout: float) -> _FakeResponse:
+    def __call__(self, url: str, **kwargs: object) -> _FakeResponse:
         self.calls.append(url)
         if self.responses is not None:
             resp = self.responses.pop(0)

--- a/tests/firms/test_helpers.py
+++ b/tests/firms/test_helpers.py
@@ -16,11 +16,15 @@ pytestmark = pytest.mark.firms
 
 
 class _Resp:
-    """Minimal fake response exposing status_code and text."""
+    """Minimal fake response with the HttpClient-driven shape."""
 
     def __init__(self, text: str = "", status_code: int = 200):
         self.text = text
         self.status_code = status_code
+        self.headers: dict[str, str] = {}
+
+    def close(self) -> None:
+        """No-op — the fake holds no socket."""
 
 
 def test_single_day_window_is_day_range_one():
@@ -87,7 +91,7 @@ def test_firms_get_returns_csv_without_retry():
     waits: list[float] = []
     calls = {"n": 0}
 
-    def _get(url, timeout):
+    def _get(url, **kwargs):
         calls["n"] += 1
         return _Resp("latitude,longitude\n1,2")
 
@@ -102,7 +106,7 @@ def test_firms_get_retries_on_429_then_succeeds():
     waits: list[float] = []
     responses = [_Resp("rate limit", 429), _Resp("latitude,longitude\n1,2")]
 
-    def _get(url, timeout):
+    def _get(url, **kwargs):
         return responses.pop(0)
 
     resp = firms_get("u", timeout=1, get=_get, sleep=waits.append, backoff_factor=2.0)
@@ -118,7 +122,7 @@ def test_firms_get_retries_on_quota_body_200():
         _Resp("latitude,longitude\n1,2"),
     ]
 
-    def _get(url, timeout):
+    def _get(url, **kwargs):
         return responses.pop(0)
 
     resp = firms_get("u", timeout=1, get=_get, sleep=waits.append)
@@ -130,7 +134,7 @@ def test_firms_get_gives_up_after_max_retries():
     """A persistent quota body returns the last response after the cap."""
     waits: list[float] = []
 
-    def _get(url, timeout):
+    def _get(url, **kwargs):
         return _Resp("transaction limit reached", 200)
 
     resp = firms_get("u", timeout=1, get=_get, sleep=waits.append, max_retries=3)

--- a/tests/ghsl/conftest.py
+++ b/tests/ghsl/conftest.py
@@ -56,6 +56,8 @@ class _FakeResponse:
         self._content = content
         self.text = text
         self._status = status
+        self.status_code = status
+        self.headers: dict[str, str] = {}
 
     def raise_for_status(self) -> None:
         """Raise `HTTPError` when the route is marked as a 4xx/5xx."""
@@ -66,6 +68,9 @@ class _FakeResponse:
         """Yield the payload in `chunk_size` slices."""
         for start in range(0, len(self._content), max(chunk_size, 1)):
             yield self._content[start : start + chunk_size]
+
+    def close(self) -> None:
+        """No-op close (parity with `requests.Response`)."""
 
     def __enter__(self) -> _FakeResponse:
         return self
@@ -81,7 +86,7 @@ class FakeSession:
         self.routes: dict[str, _FakeResponse] = routes or {}
         self.requested: list[str] = []
 
-    def get(self, url: str, stream: bool = False, timeout: float | None = None):
+    def get(self, url: str, **kwargs: Any):
         """Return the canned response for `url` (404 when unrouted)."""
         self.requested.append(url)
         return self.routes.get(url, _FakeResponse(status=404))

--- a/tests/glaciers/conftest.py
+++ b/tests/glaciers/conftest.py
@@ -21,6 +21,9 @@ DATA = Path(__file__).parent / "data"
 class _FakeStreamResponse:
     """A streaming `requests.Response` stand-in backed by local bytes."""
 
+    status_code = 200
+    headers: dict[str, str] = {}
+
     def __init__(self, payload: bytes) -> None:
         self._payload = payload
 
@@ -38,6 +41,9 @@ class _FakeStreamResponse:
         """Yield the payload in `chunk_size` chunks."""
         for start in range(0, len(self._payload), chunk_size):
             yield self._payload[start : start + chunk_size]
+
+    def close(self) -> None:
+        """No-op: the fake holds no socket."""
 
 
 class _FakeTextResponse:
@@ -65,6 +71,7 @@ class FakeHttp:
         params: dict | None = None,
         stream: bool = False,
         timeout: float | None = None,
+        **kwargs: Any,
     ) -> Any:
         """Route a GET to the streaming zip or the WFS text fixture.
 
@@ -73,6 +80,7 @@ class FakeHttp:
             params: Query parameters (recorded so tests can assert the bbox).
             stream: `True` for a download (zip), `False` for the WFS query.
             timeout: Ignored.
+            **kwargs: Extra transport kwargs (e.g. `HttpClient`'s `headers=`).
 
         Returns:
             A fake streaming or text response.

--- a/tests/glaciers/test_edges.py
+++ b/tests/glaciers/test_edges.py
@@ -25,6 +25,9 @@ DATA = Path(__file__).parent / "data"
 class _StreamResp:
     """A streaming response stand-in over fixed bytes."""
 
+    status_code = 200
+    headers: dict[str, str] = {}
+
     def __init__(self, payload: bytes) -> None:
         self._payload = payload
 
@@ -39,6 +42,9 @@ class _StreamResp:
 
     def iter_content(self, chunk_size: int = 1 << 20):
         yield self._payload
+
+    def close(self):
+        return None
 
 
 class _TextResp:
@@ -59,7 +65,7 @@ class _FlakySession:
         self._fails = fails
         self.attempts = 0
 
-    def get(self, url, stream=False, timeout=None):
+    def get(self, url, **kwargs):
         self.attempts += 1
         if self.attempts <= self._fails:
             raise requests.ConnectionError("boom")

--- a/tests/nrel/conftest.py
+++ b/tests/nrel/conftest.py
@@ -35,6 +35,7 @@ class FakeResponse:
         self.text = text
         self.status_code = status_code
         self._payload = payload
+        self.headers: dict[str, str] = {}
 
     def json(self) -> Any:
         """Return the JSON payload, raising `ValueError` when there is none."""
@@ -47,6 +48,10 @@ class FakeResponse:
         import requests
 
         raise requests.HTTPError(f"HTTP {self.status_code}")
+
+    def close(self) -> None:
+        """Release the response (no-op; nothing to release)."""
+        return None
 
 
 class FakeSession:
@@ -64,7 +69,7 @@ class FakeSession:
         """Exit the context manager (no-op; nothing to release)."""
         return None
 
-    def get(self, url: str, timeout: int = 120) -> FakeResponse:
+    def get(self, url: str, timeout: int = 120, **kwargs: Any) -> FakeResponse:
         """Record the URL and return the next (or only) configured response."""
         self.calls.append(url)
         if isinstance(self._responses, list):

--- a/tests/nrel/test_helpers.py
+++ b/tests/nrel/test_helpers.py
@@ -134,6 +134,20 @@ class TestThrottledGet:
                 monotonic=lambda: 0.0,
             )
 
+    def test_exhausted_429_error_omits_the_api_key(self):
+        """The persistent-429 HTTPError never embeds the api_key-bearing URL."""
+        session = FakeSession(FakeResponse(status_code=429))
+        with pytest.raises(requests.HTTPError) as excinfo:
+            h.throttled_get(
+                session,
+                "https://developer.nrel.gov/api/x?api_key=SUPERSECRETKEY",
+                last_call=[0.0],
+                max_retries=2,
+                sleep=lambda s: None,
+                monotonic=lambda: 0.0,
+            )
+        assert "SUPERSECRETKEY" not in str(excinfo.value)
+
 
 class TestParseCsv:
     """Tests for `parse_psm3_csv` and the header-offset detector."""

--- a/tests/openaq/conftest.py
+++ b/tests/openaq/conftest.py
@@ -79,6 +79,9 @@ class _FakeResponse:
 
             raise requests.HTTPError(f"HTTP {self.status_code}")
 
+    def close(self) -> None:
+        return None
+
 
 class _FakeOpenaq:
     """Recording transport state shared by the patched session.

--- a/tests/openaq/test_client.py
+++ b/tests/openaq/test_client.py
@@ -96,6 +96,13 @@ class TestRequest:
         assert user_agent.startswith("earthlens/")
         assert "mozilla" not in user_agent.lower()
 
+    def test_retry_attrs_reflect_the_http_client_config(self):
+        """max_retries/backoff_factor/timeout read back the delegated config."""
+        client = OpenaqClient("key", max_retries=3, backoff_factor=2.0, timeout=42.0)
+        assert client.max_retries == 3
+        assert client.backoff_factor == 2.0
+        assert client.timeout == 42.0
+
     def test_429_then_success(self):
         """A 429 with Retry-After is retried, then succeeds."""
         client, session = _client(

--- a/tests/openaq/test_client.py
+++ b/tests/openaq/test_client.py
@@ -88,6 +88,14 @@ class TestRequest:
         assert session.calls[0]["headers"]["X-API-Key"] == "key"
         assert session.calls[0]["url"] == f"{BASE_URL}/locations"
 
+    def test_sends_earthlens_user_agent(self):
+        """The HttpClient migration sends the non-Mozilla earthlens UA (G4)."""
+        client, session = _client([_Resp({"results": []})])
+        client._request("locations", {"limit": 10})
+        user_agent = session.calls[0]["headers"]["User-Agent"]
+        assert user_agent.startswith("earthlens/")
+        assert "mozilla" not in user_agent.lower()
+
     def test_429_then_success(self):
         """A 429 with Retry-After is retried, then succeeds."""
         client, session = _client(

--- a/tests/openaq/test_client.py
+++ b/tests/openaq/test_client.py
@@ -30,6 +30,9 @@ class _Resp:
         if self.status_code >= 400:
             raise requests.HTTPError(f"HTTP {self.status_code}")
 
+    def close(self) -> None:
+        return None
+
 
 class _SeqSession:
     """Returns queued responses in order, recording each GET's args."""

--- a/tests/openaq/test_client.py
+++ b/tests/openaq/test_client.py
@@ -7,7 +7,8 @@ from typing import Any
 import pytest
 import requests
 
-from earthlens.openaq.client import BASE_URL, OpenaqClient, _parse_retry_after
+from earthlens.base.http import _parse_retry_after
+from earthlens.openaq.client import BASE_URL, OpenaqClient
 
 
 class _Resp:

--- a/tests/openaq/test_client.py
+++ b/tests/openaq/test_client.py
@@ -123,6 +123,14 @@ class TestRequest:
         client._request("locations", {})
         assert client._waits == [2.0]  # type: ignore[attr-defined]
 
+    def test_large_retry_after_is_uncapped(self):
+        """A Retry-After above the default cap is honoured (openaq is uncapped)."""
+        client, session = _client(
+            [_Resp({}, 429, {"Retry-After": "600"}), _Resp({"results": []})]
+        )
+        client._request("locations", {})
+        assert client._waits == [600.0]  # type: ignore[attr-defined]
+
     def test_raises_after_max_retries(self):
         """Exhausted 429s raise the final HTTPError."""
         client, _ = _client([_Resp({}, 429, {"Retry-After": "0"})] * 3, max_retries=2)

--- a/tests/pvgis/conftest.py
+++ b/tests/pvgis/conftest.py
@@ -31,6 +31,7 @@ class FakeResponse:
         self._payload = payload
         self.status_code = status_code
         self.text = text
+        self.headers: dict[str, str] = {}
 
     def json(self) -> Any:
         """Return the JSON payload, raising `ValueError` when there is none."""
@@ -43,6 +44,10 @@ class FakeResponse:
         import requests
 
         raise requests.HTTPError(f"HTTP {self.status_code}")
+
+    def close(self) -> None:
+        """Release the response (a no-op for the fake, mirrors requests)."""
+        return None
 
 
 class FakeSession:
@@ -60,7 +65,7 @@ class FakeSession:
         """Exit the context manager (no-op; nothing to release)."""
         return None
 
-    def get(self, url: str, timeout: int = 60) -> FakeResponse:
+    def get(self, url: str, timeout: int = 60, **kwargs: Any) -> FakeResponse:
         """Record the URL and return the next (or only) configured response."""
         self.calls.append(url)
         if isinstance(self._responses, list):

--- a/tests/s3/test_backend.py
+++ b/tests/s3/test_backend.py
@@ -92,10 +92,10 @@ def test_egress_warning_sums_known_sizes(tmp_path, monkeypatch):
     """The egress check sums size_bytes across products that carry one."""
     from earthlens.base import RemoteProduct
 
-    calls: list[tuple[str | None, int]] = []
+    calls: list[tuple[str | None, int, bool]] = []
     monkeypatch.setattr(
         "earthlens.s3.backend.warn_if_egress",
-        lambda region, *, size_bytes: calls.append((region, size_bytes)),
+        lambda region, *, size_bytes, probe: calls.append((region, size_bytes, probe)),
     )
     source = _dem_source(tmp_path)
     products = [
@@ -104,7 +104,7 @@ def test_egress_warning_sums_known_sizes(tmp_path, monkeypatch):
         RemoteProduct(id="c", href="c.tif", metadata={"bucket": "b"}),
     ]
     source._warn_cross_region_egress(products)
-    assert calls == [(source._dataset.region, 30)]
+    assert calls == [(source._dataset.region, 30, False)]
 
 
 def test_no_egress_warning_when_no_sizes(tmp_path, monkeypatch):

--- a/tests/s3/test_backend.py
+++ b/tests/s3/test_backend.py
@@ -88,6 +88,41 @@ def test_all_missing_raises(tmp_path, fake_client_factory, patch_auth):
         source.download(progress_bar=False)
 
 
+def test_egress_warning_sums_known_sizes(tmp_path, monkeypatch):
+    """The egress check sums size_bytes across products that carry one."""
+    from earthlens.base import RemoteProduct
+
+    calls: list[tuple[str | None, int]] = []
+    monkeypatch.setattr(
+        "earthlens.s3.backend.warn_if_egress",
+        lambda region, *, size_bytes: calls.append((region, size_bytes)),
+    )
+    source = _dem_source(tmp_path)
+    products = [
+        RemoteProduct(id="a", href="a.tif", metadata={"bucket": "b", "size_bytes": 10}),
+        RemoteProduct(id="b", href="b.tif", metadata={"bucket": "b", "size_bytes": 20}),
+        RemoteProduct(id="c", href="c.tif", metadata={"bucket": "b"}),
+    ]
+    source._warn_cross_region_egress(products)
+    assert calls == [(source._dataset.region, 30)]
+
+
+def test_no_egress_warning_when_no_sizes(tmp_path, monkeypatch):
+    """No product carries a size, so the egress helper is not consulted."""
+    from earthlens.base import RemoteProduct
+
+    calls: list[int] = []
+    monkeypatch.setattr(
+        "earthlens.s3.backend.warn_if_egress",
+        lambda *args, **kwargs: calls.append(1),
+    )
+    source = _dem_source(tmp_path)
+    source._warn_cross_region_egress(
+        [RemoteProduct(id="a", href="a.tif", metadata={"bucket": "b"})]
+    )
+    assert calls == []
+
+
 def test_cog_dataset_rejects_aggregate(tmp_path, fake_client_factory, patch_auth):
     """aggregate= is rejected for a COG dataset with a clear message."""
     patch_auth(fake_client_factory())

--- a/tests/solar_wind_atlas/conftest.py
+++ b/tests/solar_wind_atlas/conftest.py
@@ -103,16 +103,13 @@ def fake_pyramids(monkeypatch: pytest.MonkeyPatch) -> type[FakeDataset]:
 
 
 class FakeResponse:
-    """Context-manager stand-in for a streaming requests response."""
+    """Stand-in for a streaming requests response (HttpClient shape)."""
+
+    status_code = 200
+    headers: dict[str, str] = {}
 
     def __init__(self, body: bytes) -> None:
         self._body = body
-
-    def __enter__(self) -> FakeResponse:
-        return self
-
-    def __exit__(self, *exc: object) -> None:
-        return None
 
     def raise_for_status(self) -> None:
         """No-op — the fake always succeeds."""
@@ -121,15 +118,15 @@ class FakeResponse:
         """Yield the body, plus an empty chunk to exercise the skip guard."""
         return [self._body, b""]
 
+    def close(self) -> None:
+        """No-op — the fake holds no socket."""
+
 
 class FailingResponse:
     """A streaming response whose body iteration raises mid-download."""
 
-    def __enter__(self) -> FailingResponse:
-        return self
-
-    def __exit__(self, *exc: object) -> None:
-        return None
+    status_code = 200
+    headers: dict[str, str] = {}
 
     def raise_for_status(self) -> None:
         """No-op — the failure happens during streaming, not at the status."""
@@ -138,13 +135,14 @@ class FailingResponse:
         """Raise to simulate a dropped connection mid-stream."""
         raise OSError("connection dropped mid-stream")
 
+    def close(self) -> None:
+        """No-op — the fake holds no socket."""
+
 
 class FailingGet:
     """Callable `requests.get` stand-in that fails partway through the body."""
 
-    def __call__(
-        self, url: str, *, stream: bool = False, timeout: float = 0.0
-    ) -> FailingResponse:
+    def __call__(self, url: str, **kwargs: object) -> FailingResponse:
         return FailingResponse()
 
 
@@ -154,9 +152,7 @@ class FakeGet:
     def __init__(self) -> None:
         self.calls = 0
 
-    def __call__(
-        self, url: str, *, stream: bool = False, timeout: float = 0.0
-    ) -> FakeResponse:
+    def __call__(self, url: str, **kwargs: object) -> FakeResponse:
         self.calls += 1
         return FakeResponse(zip_bytes("World_GHI.tif"))
 

--- a/tests/wdpa/conftest.py
+++ b/tests/wdpa/conftest.py
@@ -28,6 +28,9 @@ class _FakeResponse:
         """Return the canned JSON body."""
         return self._payload
 
+    def close(self) -> None:
+        """No-op close (HttpClient releases the connection between retries)."""
+
     def raise_for_status(self) -> None:
         """Mimic `requests.Response.raise_for_status` for ≥400 statuses.
 
@@ -49,7 +52,7 @@ class _FakeSession:
         """Bind the shared state holding queued responses and calls."""
         self._state = state
 
-    def get(self, url, params=None, timeout=None):
+    def get(self, url, params=None, timeout=None, **kwargs):
         """Record the call and either raise the queued exception or return the next response."""
         self._state.calls.append({"url": url, "params": params or {}})
         index = min(len(self._state.calls) - 1, len(self._state.responses) - 1)

--- a/tests/worldpop/conftest.py
+++ b/tests/worldpop/conftest.py
@@ -87,6 +87,9 @@ def age_records(iso3: str = "ken", years=(2020,)) -> list[dict]:
 class _FakeResponse:
     """Minimal stand-in for `requests.Response` returning canned data."""
 
+    status_code = 200
+    headers: dict[str, str] = {}
+
     def __init__(self, *, json_data: object | None = None, content: bytes = b""):
         self._json = json_data
         self.content = content
@@ -100,6 +103,9 @@ class _FakeResponse:
         if self._json is None and not self.content:
             raise requests.HTTPError("404 Not Found")
 
+    def close(self) -> None:
+        """No-op — the fake holds no socket."""
+
 
 @pytest.fixture
 def patch_http(monkeypatch, tiny_tif_bytes):
@@ -110,7 +116,7 @@ def patch_http(monkeypatch, tiny_tif_bytes):
     """
 
     def _install(records: list[dict]) -> None:
-        def fake_get(url, params=None, timeout=None):
+        def fake_get(url, params=None, timeout=None, **kwargs):
             if "/rest/data/" in url:
                 return _FakeResponse(json_data={"data": records})
             if url.endswith(".tif"):

--- a/tests/worldpop/test_backend.py
+++ b/tests/worldpop/test_backend.py
@@ -91,7 +91,7 @@ def _make_zip(tif_bytes, names):
 def _patch_archive_http(monkeypatch, title, archive_url, archive_bytes):
     """Serve a global listing + `?id=` detail (archive url) + the archive bytes."""
 
-    def fake_get(url, params=None, timeout=None):
+    def fake_get(url, params=None, timeout=None, **kwargs):
         if url.endswith((".7z", ".zip")):
             return _FakeResponse(content=archive_bytes)
         if params and "id" in params:
@@ -246,7 +246,7 @@ def test_year_singular(wp_kwargs):
 def _patch_global_http(monkeypatch, tiny_tif_bytes, files):
     """Patch requests.get to serve a global listing + `?id=` detail + tiny tifs."""
 
-    def fake_get(url, params=None, timeout=None):
+    def fake_get(url, params=None, timeout=None, **kwargs):
         if url.endswith(".tif"):
             return _FakeResponse(content=tiny_tif_bytes)
         if params and "id" in params:
@@ -404,7 +404,7 @@ def test_404_propagates(wp_kwargs, monkeypatch):
     from tests.worldpop.conftest import _FakeResponse
     from tests.worldpop.conftest import pop_records as _pr
 
-    def fake_get(url, params=None, timeout=None):
+    def fake_get(url, params=None, timeout=None, **kwargs):
         if "/rest/data/" in url:
             return _FakeResponse(json_data={"data": _pr()})
         return _FakeResponse()  # 404 for the .tif
@@ -424,7 +424,7 @@ def test_http_get_retries_transient_then_succeeds(
     monkeypatch.setattr(backend_mod.time, "sleep", lambda *_: None)
     calls = {"n": 0}
 
-    def flaky_get(url, timeout=None):
+    def flaky_get(url, timeout=None, **kwargs):
         calls["n"] += 1
         if calls["n"] < 3:
             raise requests.ConnectionError("dropped")
@@ -455,7 +455,7 @@ def test_http_get_raises_after_retries_exhausted(wp_kwargs, monkeypatch):
 
     monkeypatch.setattr(backend_mod.time, "sleep", lambda *_: None)
 
-    def always_drop(url, timeout=None):
+    def always_drop(url, timeout=None, **kwargs):
         raise requests.ConnectionError("dropped")
 
     monkeypatch.setattr(requests, "get", always_drop)
@@ -487,7 +487,7 @@ def test_http_get_does_not_retry_http_error(wp_kwargs, monkeypatch):
     monkeypatch.setattr(backend_mod.time, "sleep", lambda *_: None)
     calls = {"n": 0}
 
-    def not_found(url, timeout=None):
+    def not_found(url, timeout=None, **kwargs):
         calls["n"] += 1
         return _FakeResponse()  # raise_for_status -> HTTPError
 


### PR DESCRIPTION
# Description

Adds two shared `earthlens.base` primitives, extends the HTTP one to express the fleet's real transport
patterns, and migrates the hand-rolled backends onto it.

**Primitives**
- **`earthlens.base.http.HttpClient`** — a reusable `requests` transport: pooled session, non-Mozilla
  `earthlens/{version}` UA + gzip, per-request timeout, a `Retry-After`-aware (integer **and** HTTP-date form)
  `429`/`5xx` back-off loop with injectable `session=`/`sleep=`, `get`/`get_json`/`post`/`request`/`stream`, and
  an **atomic, retryable** `download()` (streams to `<dest>.part`, renames on success, cleans up on failure).
  Extended with `retry_on_exceptions`, `retry_predicate`, a per-client/per-request `raise_for_status` toggle,
  and a `min_interval` throttle so backends' divergent retry semantics are expressible without per-backend loops.
  Retried/errored responses are closed; a `max_backoff` cap and negative-`Retry-After` guard prevent a hostile
  server pinning the thread.
- **`earthlens.base.region.region_affinity()` / `warn_if_egress()`** — decide `in-region` / `egress` / `unknown`
  for a target bucket (env-first, then a fail-safe AWS/GCP/Azure metadata probe behind a hard timeout, cached,
  never raises/blocks) so a backend can prefer in-region streaming over billed cross-region egress.

**Backends migrated onto `HttpClient`** (one behaviour-preserving commit each; existing suites green, only the
test doubles gained the client's response shape): `openaq`, `solar_wind_atlas`, `firms` (body-predicate retry +
no-raise MAP_KEY redaction), `nrel` / `pvgis` (proactive throttle kept in-backend, 429-retry delegated,
return-4xx), `worldpop` (transport-exception retry), `glaciers` / `ghsl` (exception-retry + atomic download),
`drought` (streamed download), `wdpa` (exception-retry + no-raise `?token=` redaction). Reference consumers of
`region_affinity`: `earthdata` (`probe=False`, no behaviour change) and `s3` (opt-in egress warning).

**Deferred with documented reasons** (not forced — see `planning/base/http-client-completion.md`): `iucn`
(process-global, lock-protected, interleaved throttle), `nwp` (multi-URL→one-file concat, no retry loop), and
the SDK-only backends `eumetsat` / `hdx` / `usgs_water` / `overture` + gee's `io.py` (no `requests` transport to
migrate).

**Motivation.** Implements `planning/base/http-client-completion.md` (H24, incl. `C5`) and
`planning/base/region-affinity-completion.md` (H25). Consolidates the 14 hand-rolled session+retry loops the
2026-07-01 survey found into one primitive.

**Dependencies.** None — `requests`/`tqdm` are already core; region detection is stdlib `urllib`.
`pyproject.toml` / `pixi.lock` unchanged.

# Issues

- Closes #668 — migrate the hand-rolled backends onto `HttpClient` (10 migrated; iucn / nwp / SDK-only documented
  as deferred, no `requests` retry loop to consolidate).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- New offline unit suites for both primitives at 100 % line + branch coverage (`tests/base/test_http.py`,
  `tests/base/test_region_affinity.py`) — retry (status / exception / predicate), `Retry-After` (numeric +
  HTTP-date), back-off + `max_backoff` cap, throttle, `raise_for_status` toggle, atomic/retrying `download()`,
  and the region probes / egress-warning matrix.
- Each backend migration keeps its existing suite green with the **same assertions** (redaction, exception
  types, call counts, sleep sequences) — only the test doubles gained the `HttpClient` response shape.
- Full non-e2e suite: **5418 passed, 134 deselected**. Doctests green.
- Two `/review-rounds` passes applied to the primitive work.

Reproduce: `pytest -m "not e2e" -q` · `pytest --doctest-modules src/earthlens/base/http.py src/earthlens/base/region.py -q`

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
