### PR TITLE
feat(nwp,ecmwf): aifs-ens catalog row, optional [ecmwf-modern] extra, deferred-providers docs

### DIFF
--- a/docs/reference/deferred-providers.md
+++ b/docs/reference/deferred-providers.md
@@ -17,7 +17,7 @@ time, not a legal guarantee.
 | **GRDC** (Global Runoff Data Centre) | River discharge (in-situ) | **Restricted access** — data requires a formal request/agreement; no anonymous bulk download; redistribution limited | Submit a data request via the [GRDC portal](https://grdc.bafg.de/) and download the granted station files manually |
 | **IBAT** (Integrated Biodiversity Assessment Tool) | Protected areas / KBA / Red List | **Commercial / subscription** for most access tiers; free tier is limited and NC | Use an [IBAT](https://www.ibat-alliance.org/) subscription; for the underlying open layers use `earthlens.wdpa` (Protected Planet) and `earthlens.iucn` instead |
 | **Map of Life** (MoL) | Species range maps | Per-dataset licensing; many layers are **NC / research-only** | Use the [Map of Life](https://mol.org/) portal / its API under the specific dataset's terms; for open occurrences use `earthlens.gbif` / `earthlens.obis` |
-| **IQAir** (AirVisual) | Air quality (ground) | **Commercial API** with paid tiers; free tier heavily rate-limited; redistribution restricted | Use the paid [IQAir/AirVisual API](https://www.iqair.com/air-pollution-data-api); for open AQ use `earthlens.openaq` / `earthlens.airnow` / `earthlens.eea_aq` |
+| **IQAir** (AirVisual) | Air quality (ground) | **Commercial API** with paid tiers; free tier heavily rate-limited; redistribution restricted | Use the paid [IQAir/AirVisual API](https://www.iqair.com/air-pollution-data-api); for open AQ use `earthlens.openaq` |
 | **Renewables.ninja** | Solar / wind power time series | **CC-BY-NC** (non-commercial) + rate-limited; academic use | Register at [renewables.ninja](https://www.renewables.ninja/) and pull per-site series under the NC licence; for open solar/wind resource use `earthlens.pvgis` / `earthlens.nrel` / `earthlens.solar_wind_atlas` |
 
 ## Notes
@@ -25,7 +25,7 @@ time, not a legal guarantee.
 - **NC (non-commercial) sources** — MoL (many layers), Renewables.ninja, and IBAT's free tier — are excluded from
   the default integration path because earthlens makes no assumption about a user's commercial status. Where an
   **open-licensed** alternative covers the same need, it is named in the table (e.g. WDPA/IUCN for protected areas,
-  GBIF/OBIS for occurrences, OpenAQ/AirNow/EEA for air quality, PVGIS/NREL for renewables).
+  GBIF/OBIS for occurrences, OpenAQ for air quality, PVGIS/NREL for renewables).
 - **Restricted-access sources** — GRDC — cannot be wrapped behind an anonymous `download()` because access is
   gated by an individual agreement; a backend would only ever hold a per-user credential with redistribution
   constraints, which does not fit earthlens's "fetch and hand back the data" contract.

--- a/docs/reference/deferred-providers.md
+++ b/docs/reference/deferred-providers.md
@@ -1,0 +1,36 @@
+# Deferred providers
+
+Some data sources were **evaluated and deliberately not integrated** into earthlens. They are listed here so the
+project surface stays honest: these are *known and considered*, not overlooked. The usual reasons are a **licence
+trap** (non-commercial / restricted redistribution), **no stable programmatic access** (no API or no maintained
+Python client), or **commercial-only** access.
+
+If you need one of these datasets, follow the manual route in its row. Always **confirm the current licence and
+terms** on the provider's own site before use — terms change, and the notes below reflect the state at evaluation
+time, not a legal guarantee.
+
+## Summary
+
+| Provider | Domain | Why deferred | How to get the data |
+|---|---|---|---|
+| **GVP** (Smithsonian Global Volcanism Program) | Volcanoes / eruptions | Reference database, no stable bulk API / maintained Python client; reuse is attribution-bound | Browse or export from the [Volcanoes of the World](https://volcano.si.edu/) site; a WFS/GeoServer endpoint exists for one-off pulls |
+| **GRDC** (Global Runoff Data Centre) | River discharge (in-situ) | **Restricted access** — data requires a formal request/agreement; no anonymous bulk download; redistribution limited | Submit a data request via the [GRDC portal](https://grdc.bafg.de/) and download the granted station files manually |
+| **IBAT** (Integrated Biodiversity Assessment Tool) | Protected areas / KBA / Red List | **Commercial / subscription** for most access tiers; free tier is limited and NC | Use an [IBAT](https://www.ibat-alliance.org/) subscription; for the underlying open layers use `earthlens.wdpa` (Protected Planet) and `earthlens.iucn` instead |
+| **Map of Life** (MoL) | Species range maps | Per-dataset licensing; many layers are **NC / research-only** | Use the [Map of Life](https://mol.org/) portal / its API under the specific dataset's terms; for open occurrences use `earthlens.gbif` / `earthlens.obis` |
+| **IQAir** (AirVisual) | Air quality (ground) | **Commercial API** with paid tiers; free tier heavily rate-limited; redistribution restricted | Use the paid [IQAir/AirVisual API](https://www.iqair.com/air-pollution-data-api); for open AQ use `earthlens.openaq` / `earthlens.airnow` / `earthlens.eea_aq` |
+| **Renewables.ninja** | Solar / wind power time series | **CC-BY-NC** (non-commercial) + rate-limited; academic use | Register at [renewables.ninja](https://www.renewables.ninja/) and pull per-site series under the NC licence; for open solar/wind resource use `earthlens.pvgis` / `earthlens.nrel` / `earthlens.solar_wind_atlas` |
+
+## Notes
+
+- **NC (non-commercial) sources** — MoL (many layers), Renewables.ninja, and IBAT's free tier — are excluded from
+  the default integration path because earthlens makes no assumption about a user's commercial status. Where an
+  **open-licensed** alternative covers the same need, it is named in the table (e.g. WDPA/IUCN for protected areas,
+  GBIF/OBIS for occurrences, OpenAQ/AirNow/EEA for air quality, PVGIS/NREL for renewables).
+- **Restricted-access sources** — GRDC — cannot be wrapped behind an anonymous `download()` because access is
+  gated by an individual agreement; a backend would only ever hold a per-user credential with redistribution
+  constraints, which does not fit earthlens's "fetch and hand back the data" contract.
+- **No-stable-client sources** — GVP — could be revisited if a maintained API/Python client and clear bulk-reuse
+  terms appear.
+
+These deferrals are tracked as `L15` in the low-tier roadmap. Re-evaluate a row if its licence or access model
+changes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
     - Command-line interface: reference/cli.md
   - Data Sources:
     - Supported providers: reference/providers.md
+    - Deferred providers: reference/deferred-providers.md
     - CHC (CHIRPS / CHIRTS / SPI / SPEI / …):
       - Introduction: reference/chc/introduction.md
       - Usage: reference/chc/usage.md

--- a/pixi.lock
+++ b/pixi.lock
@@ -11910,6 +11910,7 @@ packages:
   - boto3>=1.43.0 ; extra == 's3'
   - botocore>=1.34.0 ; extra == 's3'
   - cdsapi>=0.7.7 ; extra == 'ecmwf'
+  - ecmwf-datastores-client>=0.5.1 ; extra == 'ecmwf-modern'
   - earthengine-api>=1.7.26 ; extra == 'gee'
   - google-api-python-client>=2.0 ; extra == 'gee'
   - google-cloud-storage>=2.0 ; extra == 'gee'
@@ -11946,7 +11947,7 @@ packages:
   - erddapy>=3.0 ; extra == 'erddap'
   - overpy>=0.7 ; extra == 'osm'
   - ohsome>=0.4.0 ; extra == 'osm'
-  - earthlens[s3,ecmwf,gee,cmems,fdsn,earthdata,asf,hdx,eumetsat,nwp,nwm,radar,stac,openeo,sentinel-hub,tropycal,overture,usgs-water,ghsl,worldpop,gbif,obis,jaxa,erddap] ; extra == 'all'
+  - earthlens[s3,ecmwf,ecmwf-modern,gee,cmems,fdsn,earthdata,asf,hdx,eumetsat,nwp,nwm,radar,stac,openeo,sentinel-hub,tropycal,overture,usgs-water,ghsl,worldpop,gbif,obis,jaxa,erddap] ; extra == 'all'
   requires_python: '>=3.11,<4'
 - pypi: https://files.pythonhosted.org/packages/09/40/42bb2d98bc6103194d25fa8da141cd43cabf32277cbf2ab513fe35532196/eccodes-2.47.0-cp311-cp311-win_amd64.whl
   name: eccodes

--- a/pixi.lock
+++ b/pixi.lock
@@ -11890,7 +11890,7 @@ packages:
 - pypi: ./
   name: earthlens
   version: 0.9.0
-  sha256: 29ba7d6248851eb288c8a5e618aa6a8cccebeddc7d903ec5013d7a688ff69f12
+  sha256: f9445d2ff3e7eac2f9230f59a72e366e15cf7a944f9a8793643556dbe412c4d1
   requires_dist:
   - pyramids-gis>=0.38.0
   - geopandas>=1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ earthlens = "earthlens.cli:app"
 [project.optional-dependencies]
 s3 = ["boto3 >=1.43.0", "botocore >=1.34.0"]
 ecmwf = ["cdsapi >=0.7.7"]
+ecmwf-modern = ["ecmwf-datastores-client >=0.5.1"]
 gee = [
     "earthengine-api >=1.7.26",
     "google-api-python-client >=2.0",
@@ -140,7 +141,7 @@ osm = ["overpy >=0.7", "ohsome >=0.4.0"]
 # Self-referential: the union of every backend extra, without re-listing deps.
 # (argo and osm are intentionally excluded — see the notes above their extras.)
 all = [
-    "earthlens[s3,ecmwf,gee,cmems,fdsn,earthdata,asf,hdx,eumetsat,nwp,nwm,radar,stac,openeo,sentinel-hub,tropycal,overture,usgs-water,ghsl,worldpop,gbif,obis,jaxa,erddap]",
+    "earthlens[s3,ecmwf,ecmwf-modern,gee,cmems,fdsn,earthdata,asf,hdx,eumetsat,nwp,nwm,radar,stac,openeo,sentinel-hub,tropycal,overture,usgs-water,ghsl,worldpop,gbif,obis,jaxa,erddap]",
 ]
 
 [dependency-groups]

--- a/src/earthlens/ecmwf/endpoints.py
+++ b/src/earthlens/ecmwf/endpoints.py
@@ -20,8 +20,12 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import cdsapi
+
+if TYPE_CHECKING:
+    from ecmwf.datastores import Client as ModernClient
 
 __all__ = [
     "DEFAULT_ENDPOINT",
@@ -120,7 +124,7 @@ def _resolve_key(key_env: str) -> str | None:
     )
 
 
-def open_client(endpoint: str = DEFAULT_ENDPOINT) -> cdsapi.Client:
+def open_client(endpoint: str = DEFAULT_ENDPOINT) -> cdsapi.Client | ModernClient:
     """Build a `cdsapi.Client` bound to the named CADS endpoint.
 
     Args:
@@ -193,7 +197,7 @@ def _use_modern_client() -> bool:
     }
 
 
-def open_modern_client(endpoint: str = DEFAULT_ENDPOINT):
+def open_modern_client(endpoint: str = DEFAULT_ENDPOINT) -> ModernClient:
     """Build an `ecmwf.datastores.Client` for the named CADS endpoint.
 
     The `ecmwf-datastores-client` package (installed via the

--- a/src/earthlens/ecmwf/endpoints.py
+++ b/src/earthlens/ecmwf/endpoints.py
@@ -229,8 +229,9 @@ def open_modern_client(endpoint: str = DEFAULT_ENDPOINT) -> ModernClient:
         from ecmwf.datastores import Client as ModernClient
     except ImportError as exc:
         raise ImportError(
-            "EARTHLENS_ECMWF_MODERN is set but the modern client is not "
-            "installed. Install it with: pip install earthlens[ecmwf-modern]"
+            "The modern ECMWF client (ecmwf-datastores-client) is not "
+            "installed. Install it with: pip install earthlens[ecmwf-modern] "
+            "(and enable it with EARTHLENS_ECMWF_MODERN=1)."
         ) from exc
 
     url_default, url_env, key_env = ENDPOINTS[endpoint]

--- a/src/earthlens/ecmwf/endpoints.py
+++ b/src/earthlens/ecmwf/endpoints.py
@@ -215,8 +215,11 @@ def open_modern_client(endpoint: str = DEFAULT_ENDPOINT) -> ModernClient:
     async `submit()` / `download()` API is available to callers who want it.
 
     Token resolution mirrors `open_client` (`<ENDPOINT>_KEY`, else `CDSAPI_KEY`,
-    else `~/.cdsapirc`), so the same Personal Access Token authenticates. This
-    is opt-in — reached only when `EARTHLENS_ECMWF_MODERN` is truthy.
+    else `~/.cdsapirc`), so the same Personal Access Token authenticates. The
+    URL, however, is resolved from `<ENDPOINT>_URL` (env) or the built-in
+    default **only** — unlike `key`, it does not fall back to the `url:` line in
+    `~/.cdsapirc` (a no-op for the shipped default CDS URL). This is opt-in —
+    reached only when `EARTHLENS_ECMWF_MODERN` is truthy.
 
     Args:
         endpoint: One of the slugs in `ENDPOINTS`. Defaults to `"cds"`.

--- a/src/earthlens/ecmwf/endpoints.py
+++ b/src/earthlens/ecmwf/endpoints.py
@@ -29,6 +29,7 @@ __all__ = [
     "constraints_base_url",
     "endpoint_url",
     "open_client",
+    "open_modern_client",
 ]
 
 DEFAULT_ENDPOINT: str = "cds"
@@ -114,7 +115,9 @@ def _resolve_key(key_env: str) -> str | None:
         str | None: The token to authenticate with, or `None` when neither the
         endpoint-specific env var nor the shared CDS token is available.
     """
-    return os.environ.get(key_env) or os.environ.get("CDSAPI_KEY") or _read_cdsapirc_key()
+    return (
+        os.environ.get(key_env) or os.environ.get("CDSAPI_KEY") or _read_cdsapirc_key()
+    )
 
 
 def open_client(endpoint: str = DEFAULT_ENDPOINT) -> cdsapi.Client:
@@ -133,7 +136,16 @@ def open_client(endpoint: str = DEFAULT_ENDPOINT) -> cdsapi.Client:
         ValueError: If `endpoint` is not a known slug.
         AuthenticationError: If a non-CDS endpoint has no resolvable token
             (neither `<ENDPOINT>_KEY` nor a shared CDS PAT).
+
+    Note:
+        Opt-in modern client: when `EARTHLENS_ECMWF_MODERN` is truthy
+        (`1`/`true`/`yes`/`on`), this delegates to `open_modern_client`, which
+        returns an `ecmwf.datastores.Client` (the `cdsapi` successor) instead —
+        requires the `earthlens[ecmwf-modern]` extra. Unset (the default), the
+        behaviour below is byte-identical to before.
     """
+    if _use_modern_client():
+        return open_modern_client(endpoint)
     if endpoint not in ENDPOINTS:
         raise ValueError(
             f"unknown ECMWF endpoint {endpoint!r}; expected one of {sorted(ENDPOINTS)}"
@@ -161,3 +173,73 @@ def open_client(endpoint: str = DEFAULT_ENDPOINT) -> cdsapi.Client:
             f"Generate one at {profile} and accept the dataset licence."
         )
     return cdsapi.Client(url=url, key=key)
+
+
+def _use_modern_client() -> bool:
+    """Whether the opt-in `ecmwf-datastores-client` path is enabled.
+
+    Controlled by the `EARTHLENS_ECMWF_MODERN` environment variable (truthy =
+    `1` / `true` / `yes` / `on`, case-insensitive). Off by default so the
+    historic `cdsapi` path is untouched.
+
+    Returns:
+        bool: `True` when the modern client should be built.
+    """
+    return os.environ.get("EARTHLENS_ECMWF_MODERN", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def open_modern_client(endpoint: str = DEFAULT_ENDPOINT):
+    """Build an `ecmwf.datastores.Client` for the named CADS endpoint.
+
+    The `ecmwf-datastores-client` package (installed via the
+    `earthlens[ecmwf-modern]` extra) is the strategic successor to `cdsapi`. Its
+    blocking `retrieve(collection_id, request, target=...)` matches the `cdsapi`
+    call the backend makes, so it is a drop-in for the download path; the
+    async `submit()` / `download()` API is available to callers who want it.
+
+    Token resolution mirrors `open_client` (`<ENDPOINT>_KEY`, else `CDSAPI_KEY`,
+    else `~/.cdsapirc`), so the same Personal Access Token authenticates. This
+    is opt-in — reached only when `EARTHLENS_ECMWF_MODERN` is truthy.
+
+    Args:
+        endpoint: One of the slugs in `ENDPOINTS`. Defaults to `"cds"`.
+
+    Returns:
+        ecmwf.datastores.Client: A client pointed at the endpoint's URL.
+
+    Raises:
+        ValueError: If `endpoint` is not a known slug.
+        ImportError: If the `ecmwf-modern` extra is not installed.
+        AuthenticationError: If no token can be resolved for `endpoint`.
+    """
+    if endpoint not in ENDPOINTS:
+        raise ValueError(
+            f"unknown ECMWF endpoint {endpoint!r}; expected one of {sorted(ENDPOINTS)}"
+        )
+    try:
+        from ecmwf.datastores import Client as ModernClient
+    except ImportError as exc:
+        raise ImportError(
+            "EARTHLENS_ECMWF_MODERN is set but the modern client is not "
+            "installed. Install it with: pip install earthlens[ecmwf-modern]"
+        ) from exc
+
+    url_default, url_env, key_env = ENDPOINTS[endpoint]
+    url = os.environ.get(url_env, url_default)
+    key = _resolve_key(key_env)
+    if not key:
+        from earthlens.ecmwf.backend import AuthenticationError
+
+        profile = url.rsplit("/api", 1)[0] + "/profile"
+        raise AuthenticationError(
+            f"ECMWF {endpoint.upper()} needs a Personal Access Token. Set the "
+            f"{key_env} (or CDSAPI_KEY) environment variable, or configure "
+            f"~/.cdsapirc with your CDS token. Generate one at {profile} and "
+            f"accept the dataset licence."
+        )
+    return ModernClient(url=url, key=key)

--- a/src/earthlens/ecmwf/endpoints.py
+++ b/src/earthlens/ecmwf/endpoints.py
@@ -221,6 +221,13 @@ def open_modern_client(endpoint: str = DEFAULT_ENDPOINT) -> ModernClient:
     `~/.cdsapirc` (a no-op for the shipped default CDS URL). This is opt-in —
     reached only when `EARTHLENS_ECMWF_MODERN` is truthy.
 
+    Known limitation: the backend's friendly error classification (e.g. the
+    "licence not accepted" → `PermissionError`-with-hint mapping) is tuned to
+    `cdsapi`'s exception shapes, so a failure raised by `ecmwf.datastores.Client`
+    may fall through to a generic error instead. This opt-in path is not yet
+    exercised end-to-end; harden the classification before promoting it to the
+    default.
+
     Args:
         endpoint: One of the slugs in `ENDPOINTS`. Defaults to `"cds"`.
 

--- a/src/earthlens/ecmwf/endpoints.py
+++ b/src/earthlens/ecmwf/endpoints.py
@@ -145,8 +145,13 @@ def open_client(endpoint: str = DEFAULT_ENDPOINT) -> cdsapi.Client | ModernClien
         Opt-in modern client: when `EARTHLENS_ECMWF_MODERN` is truthy
         (`1`/`true`/`yes`/`on`), this delegates to `open_modern_client`, which
         returns an `ecmwf.datastores.Client` (the `cdsapi` successor) instead —
-        requires the `earthlens[ecmwf-modern]` extra. Unset (the default), the
-        behaviour below is byte-identical to before.
+        requires the `earthlens[ecmwf-modern]` extra. The flag is **process-wide**
+        (an environment variable, not a per-call argument). Unset (the default),
+        the behaviour below is byte-identical to before. When it *is* set, even
+        the `"cds"` path changes: `open_modern_client("cds")` resolves the URL +
+        token up front and raises `AuthenticationError` if none is found, rather
+        than returning a bare `cdsapi.Client()` that does cdsapi's own lazy
+        config discovery.
     """
     if _use_modern_client():
         return open_modern_client(endpoint)

--- a/src/earthlens/ecmwf/endpoints.py
+++ b/src/earthlens/ecmwf/endpoints.py
@@ -132,9 +132,12 @@ def open_client(endpoint: str = DEFAULT_ENDPOINT) -> cdsapi.Client | ModernClien
             Defaults to `"cds"`.
 
     Returns:
-        cdsapi.Client: A client pointed at the endpoint's URL. For `"cds"` with
-        no `CDSAPI_KEY` / `CDSAPI_URL` override set, this is the historic bare
-        `cdsapi.Client()` (which reads `~/.cdsapirc`).
+        cdsapi.Client | ecmwf.datastores.Client: A client pointed at the
+        endpoint's URL. By default a `cdsapi.Client` — for `"cds"` with no
+        `CDSAPI_KEY` / `CDSAPI_URL` override set, the historic bare
+        `cdsapi.Client()` (which reads `~/.cdsapirc`). When
+        `EARTHLENS_ECMWF_MODERN` is set, an `ecmwf.datastores.Client` instead
+        (see the note below).
 
     Raises:
         ValueError: If `endpoint` is not a known slug.

--- a/src/earthlens/nwp/nwp_data_catalog.yaml
+++ b/src/earthlens/nwp/nwp_data_catalog.yaml
@@ -1406,6 +1406,101 @@ datasets:
       relative_humidity_100hPa: "r@100"
       relative_humidity_50hPa: "r@50"
 
+  aifs-ens:                               # ECMWF Open Data, AIFS ENS (data-driven ensemble)
+    provider: ecmwf-opendata
+    title: "ECMWF AIFS ENS (AI ensemble)"
+    description: "ECMWF data-driven AI/ML ensemble — 0.25° global, 51 members (control + 50), to 360 h (open data)."
+    license: CC-BY-4.0
+    model_family: aifs-ens
+    resolution: 0.25deg
+    cycles_utc: [0, 6, 12, 18]
+    cadence_h: 6
+    step_cadence_h: 6
+    horizon_h: 360
+    backend: ecmwf-opendata
+    mirrors: [aws, azure, ecmwf]
+    request_options: {ecmwf_model: aifs-ens, stream: enfo, type: cf}
+    members: ["control", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50"]
+    bands:
+      temperature_2m: "2t"
+      precipitation_acc: "tp"
+      dewpoint_2m: "2d"
+      relative_humidity_2m: "2r"
+      wind_u_10m: "10u"
+      wind_v_10m: "10v"
+      wind_gust: "10fg"
+      pressure_msl: "msl"
+      surface_pressure: "sp"
+      total_cloud_cover: "tcc"
+      cape: "cape"
+      downward_shortwave_radiation: "ssrd"
+      # Pressure-level (3-D) fields — "param@level" (levtype=pl, levelist=level).
+      geopotential_height_1000hPa: "gh@1000"
+      geopotential_height_925hPa: "gh@925"
+      geopotential_height_850hPa: "gh@850"
+      geopotential_height_700hPa: "gh@700"
+      geopotential_height_600hPa: "gh@600"
+      geopotential_height_500hPa: "gh@500"
+      geopotential_height_400hPa: "gh@400"
+      geopotential_height_300hPa: "gh@300"
+      geopotential_height_250hPa: "gh@250"
+      geopotential_height_200hPa: "gh@200"
+      geopotential_height_150hPa: "gh@150"
+      geopotential_height_100hPa: "gh@100"
+      geopotential_height_50hPa: "gh@50"
+      temperature_1000hPa: "t@1000"
+      temperature_925hPa: "t@925"
+      temperature_850hPa: "t@850"
+      temperature_700hPa: "t@700"
+      temperature_600hPa: "t@600"
+      temperature_500hPa: "t@500"
+      temperature_400hPa: "t@400"
+      temperature_300hPa: "t@300"
+      temperature_250hPa: "t@250"
+      temperature_200hPa: "t@200"
+      temperature_150hPa: "t@150"
+      temperature_100hPa: "t@100"
+      temperature_50hPa: "t@50"
+      wind_u_1000hPa: "u@1000"
+      wind_u_925hPa: "u@925"
+      wind_u_850hPa: "u@850"
+      wind_u_700hPa: "u@700"
+      wind_u_600hPa: "u@600"
+      wind_u_500hPa: "u@500"
+      wind_u_400hPa: "u@400"
+      wind_u_300hPa: "u@300"
+      wind_u_250hPa: "u@250"
+      wind_u_200hPa: "u@200"
+      wind_u_150hPa: "u@150"
+      wind_u_100hPa: "u@100"
+      wind_u_50hPa: "u@50"
+      wind_v_1000hPa: "v@1000"
+      wind_v_925hPa: "v@925"
+      wind_v_850hPa: "v@850"
+      wind_v_700hPa: "v@700"
+      wind_v_600hPa: "v@600"
+      wind_v_500hPa: "v@500"
+      wind_v_400hPa: "v@400"
+      wind_v_300hPa: "v@300"
+      wind_v_250hPa: "v@250"
+      wind_v_200hPa: "v@200"
+      wind_v_150hPa: "v@150"
+      wind_v_100hPa: "v@100"
+      wind_v_50hPa: "v@50"
+      relative_humidity_1000hPa: "r@1000"
+      relative_humidity_925hPa: "r@925"
+      relative_humidity_850hPa: "r@850"
+      relative_humidity_700hPa: "r@700"
+      relative_humidity_600hPa: "r@600"
+      relative_humidity_500hPa: "r@500"
+      relative_humidity_400hPa: "r@400"
+      relative_humidity_300hPa: "r@300"
+      relative_humidity_250hPa: "r@250"
+      relative_humidity_200hPa: "r@200"
+      relative_humidity_150hPa: "r@150"
+      relative_humidity_100hPa: "r@100"
+      relative_humidity_50hPa: "r@50"
+
   aifs:                                   # ECMWF Open Data, AIFS (data-driven), single model
     provider: ecmwf-opendata
     title: "ECMWF AIFS (AI Forecasting System)"

--- a/src/earthlens/nwp/nwp_data_catalog.yaml
+++ b/src/earthlens/nwp/nwp_data_catalog.yaml
@@ -1413,6 +1413,10 @@ datasets:
     license: CC-BY-4.0
     model_family: aifs-ens
     resolution: 0.25deg
+    # Dissemination verified against ECMWF (2026-07-03): AIFS-ENS is produced 00/06/12/18
+    # UTC, 6-hourly steps to 360 h (15 days), 0.25deg, 51 members. Band set mirrors the IFS
+    # `ens` row's full param list; a band the ensemble does not publish 404s per-request
+    # (same behaviour as `ens`).
     cycles_utc: [0, 6, 12, 18]
     cadence_h: 6
     step_cadence_h: 6

--- a/tests/test_ecmwf/conftest.py
+++ b/tests/test_ecmwf/conftest.py
@@ -66,7 +66,12 @@ def _block_real_cdsapi(request, monkeypatch):
     the validator itself (in `test_constraints.py`) construct
     :class:`RequestValidator` directly so this default doesn't
     interfere.
+
+    Also clears `EARTHLENS_ECMWF_MODERN` so an ambient flag in a
+    contributor shell cannot silently divert `open_client` onto the
+    modern client and break the classic endpoint tests.
     """
+    monkeypatch.delenv("EARTHLENS_ECMWF_MODERN", raising=False)
     if request.cls is not None and request.cls.__name__ in _LIVE_CDS_TEST_CLASSES:
         return
 

--- a/tests/test_ecmwf/test_endpoints.py
+++ b/tests/test_ecmwf/test_endpoints.py
@@ -258,3 +258,28 @@ class TestModernClient:
         sentinel = object()
         monkeypatch.setattr(cdsapi, "Client", lambda *a, **k: sentinel)
         assert ep.open_client("cds") is sentinel
+
+    def test_open_modern_client_missing_token_raises_auth_error(
+        self, monkeypatch, tmp_path
+    ):
+        """No resolvable token raises `AuthenticationError` (modern path)."""
+        _clear_cads_env(monkeypatch)
+        _home_without_dotfile(monkeypatch, tmp_path)
+        _install_fake_datastores(monkeypatch)
+        with pytest.raises(AuthenticationError):
+            ep.open_modern_client("ewds")
+
+    def test_open_modern_client_unknown_endpoint_raises_value_error(self, monkeypatch):
+        """An unknown endpoint slug raises `ValueError` before any import."""
+        monkeypatch.setenv("EARTHLENS_ECMWF_MODERN", "1")
+        with pytest.raises(ValueError, match="unknown ECMWF endpoint"):
+            ep.open_modern_client("mars")
+
+    def test_open_client_cds_flag_set_no_token_raises(self, monkeypatch, tmp_path):
+        """With the flag set, `open_client('cds')` resolves eagerly and raises."""
+        _clear_cads_env(monkeypatch)
+        _home_without_dotfile(monkeypatch, tmp_path)
+        monkeypatch.setenv("EARTHLENS_ECMWF_MODERN", "1")
+        _install_fake_datastores(monkeypatch)
+        with pytest.raises(AuthenticationError):
+            ep.open_client("cds")

--- a/tests/test_ecmwf/test_endpoints.py
+++ b/tests/test_ecmwf/test_endpoints.py
@@ -283,3 +283,28 @@ class TestModernClient:
         _install_fake_datastores(monkeypatch)
         with pytest.raises(AuthenticationError):
             ep.open_client("cds")
+
+    def test_open_client_delegation_threads_url_and_key(self, monkeypatch, tmp_path):
+        """`open_client` with the flag set threads the endpoint url+key to the modern client."""
+        _clear_cads_env(monkeypatch)
+        _home_without_dotfile(monkeypatch, tmp_path)
+        monkeypatch.setenv("ADS_KEY", "ads-tok")
+        monkeypatch.setenv("EARTHLENS_ECMWF_MODERN", "on")
+        _install_fake_datastores(monkeypatch)
+        client = ep.open_client("ads")
+        assert isinstance(client, _RecordingModernClient)
+        assert client.url == "https://ads.atmosphere.copernicus.eu/api"
+        assert client.key == "ads-tok"
+
+    def test_use_modern_flag_strips_whitespace(self, monkeypatch):
+        """Surrounding whitespace around the flag value is ignored."""
+        monkeypatch.setenv("EARTHLENS_ECMWF_MODERN", " 1 ")
+        assert ep._use_modern_client() is True
+
+    def test_open_client_unknown_endpoint_with_flag_raises_value_error(
+        self, monkeypatch
+    ):
+        """An unknown endpoint raises `ValueError` through `open_client` on the modern path."""
+        monkeypatch.setenv("EARTHLENS_ECMWF_MODERN", "1")
+        with pytest.raises(ValueError, match="unknown ECMWF endpoint"):
+            ep.open_client("mars")

--- a/tests/test_ecmwf/test_endpoints.py
+++ b/tests/test_ecmwf/test_endpoints.py
@@ -126,7 +126,9 @@ class TestOpenClient:
 
     def test_read_cdsapirc_key_none_when_no_key_line(self, monkeypatch, tmp_path):
         """A `~/.cdsapirc` without a `key:` line resolves to no token."""
-        (tmp_path / ".cdsapirc").write_text("url: https://cds.climate.copernicus.eu/api\n")
+        (tmp_path / ".cdsapirc").write_text(
+            "url: https://cds.climate.copernicus.eu/api\n"
+        )
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         assert ep._read_cdsapirc_key() is None
 
@@ -168,7 +170,9 @@ class TestClientFor:
         ecmwf._clients = {}
         built: list[str] = []
         monkeypatch.setattr(
-            ECMWF, "_open_client", lambda self, endpoint: built.append(endpoint) or object()
+            ECMWF,
+            "_open_client",
+            lambda self, endpoint: built.append(endpoint) or object(),
         )
         first = ecmwf._client_for("ewds")
         second = ecmwf._client_for("ewds")
@@ -176,3 +180,81 @@ class TestClientFor:
         assert first is second
         assert third is not first
         assert built == ["ewds", "cds"]
+
+
+class _RecordingModernClient:
+    """Fake `ecmwf.datastores.Client` that records its url/key."""
+
+    def __init__(self, url=None, key=None):
+        self.url = url
+        self.key = key
+
+
+def _install_fake_datastores(monkeypatch):
+    """Inject a fake `ecmwf.datastores` module exposing `Client`."""
+    import sys
+    import types
+
+    module = types.ModuleType("ecmwf.datastores")
+    module.Client = _RecordingModernClient
+    monkeypatch.setitem(sys.modules, "ecmwf.datastores", module)
+
+
+class TestModernClient:
+    """Tests for the opt-in `ecmwf-datastores-client` path."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("1", True),
+            ("true", True),
+            ("YES", True),
+            ("on", True),
+            ("", False),
+            ("0", False),
+            ("no", False),
+        ],
+    )
+    def test_use_modern_flag(self, monkeypatch, value, expected):
+        """`EARTHLENS_ECMWF_MODERN` truthiness is parsed case-insensitively."""
+        monkeypatch.setenv("EARTHLENS_ECMWF_MODERN", value)
+        assert ep._use_modern_client() is expected
+
+    def test_open_modern_client_resolves_url_and_key(self, monkeypatch, tmp_path):
+        """`open_modern_client` builds the modern client with the endpoint url + token."""
+        _clear_cads_env(monkeypatch)
+        _home_without_dotfile(monkeypatch, tmp_path)
+        monkeypatch.setenv("EWDS_KEY", "tok-123")
+        _install_fake_datastores(monkeypatch)
+        client = ep.open_modern_client("ewds")
+        assert isinstance(client, _RecordingModernClient)
+        assert client.url == "https://ewds.climate.copernicus.eu/api"
+        assert client.key == "tok-123"
+
+    def test_open_client_delegates_when_flag_set(self, monkeypatch, tmp_path):
+        """With the flag set, `open_client` returns the modern client."""
+        _clear_cads_env(monkeypatch)
+        _home_without_dotfile(monkeypatch, tmp_path)
+        monkeypatch.setenv("CDSAPI_KEY", "pat")
+        monkeypatch.setenv("EARTHLENS_ECMWF_MODERN", "1")
+        _install_fake_datastores(monkeypatch)
+        assert isinstance(ep.open_client("ads"), _RecordingModernClient)
+
+    def test_missing_extra_raises_importerror(self, monkeypatch, tmp_path):
+        """A missing `ecmwf-datastores-client` raises a clear ImportError."""
+        import sys
+
+        _clear_cads_env(monkeypatch)
+        _home_without_dotfile(monkeypatch, tmp_path)
+        monkeypatch.setenv("EWDS_KEY", "tok")
+        monkeypatch.setitem(sys.modules, "ecmwf.datastores", None)
+        with pytest.raises(ImportError, match="ecmwf-modern"):
+            ep.open_modern_client("ewds")
+
+    def test_default_path_unchanged_without_flag(self, monkeypatch):
+        """Without the flag, `open_client('cds')` is the historic bare client."""
+        _clear_cads_env(monkeypatch)
+        monkeypatch.delenv("EARTHLENS_ECMWF_MODERN", raising=False)
+        sentinel = object()
+        monkeypatch.setattr(cdsapi, "Client", lambda *a, **k: sentinel)
+        assert ep.open_client("cds") is sentinel


### PR DESCRIPTION
# Description

Three small, independent low-tier roadmap items, each additive and non-breaking:

- **`aifs-ens` catalog row (NWP)** — adds ECMWF's AIFS ensemble to the ECMWF Open Data catalog. Served by
  `ecmwf-opendata` via `model=aifs-ens` (`stream=enfo`, `type=cf`; perturbed members `type=pf` + `number`):
  0.25° global, 51 members (control + 50), 00/06/12/18 UTC, 6-hourly to 360 h. The existing
  `request_options`/`members` machinery handles it with **no code change** — catalog-only.
- **Optional `[ecmwf-modern]` extra** — adds `ecmwf-datastores-client` (the strategic `cdsapi` successor) as an
  optional install, plus an **opt-in** runtime path: when `EARTHLENS_ECMWF_MODERN` is truthy,
  `endpoints.open_client()` delegates to a new `open_modern_client()` that builds an `ecmwf.datastores.Client`
  (its blocking `retrieve()` is a drop-in) using the same per-endpoint URL + PAT resolution. **Default (flag unset)
  is byte-identical** to the historic `cdsapi` path, so nothing regresses.
- **`docs/reference/deferred-providers.md`** — documents the sources that were evaluated but deliberately not
  integrated (GVP, GRDC, IBAT, Map of Life, IQAir, Renewables.ninja) — why each is deferred (NC licence /
  restricted access / commercial-only / no stable client) and the manual route + open-licensed earthlens
  alternative. Wired into the Data Sources nav.

Dependencies: `ecmwf-datastores-client` (already present in `pixi.lock`; only the editable-source hash was
refreshed for the `pyproject.toml` edit). No other new runtime dependency.

# Issues

- Closes #680 — aifs-ens catalog row, optional ecmwf-modern client, and deferred-providers docs (roadmap L16/L3/L15).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `python -m pytest tests/nwp/test_catalog.py` — **28 passed** (verifies the `aifs-ens` row resolves: 51
  members, correct `request_options`, 77 bands; `aifs`/`ens` still load).
- [x] `python -m pytest tests/test_ecmwf/test_endpoints.py` — **26 passed** (11 new tests: flag parsing, modern
  url/key resolution, `open_client` delegation, missing-extra `ImportError`, and the default `cdsapi` path
  unchanged). `black` clean.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

> Note: version bump / change-log / README-version were intentionally left for the maintainer — these are additive
> low-tier items and the modern-ECMWF path is opt-in/experimental (unit-tested with a stub, not yet exercised
> against a live datastore).

