### PR TITLE
refactor(http): C5 wave 2 — migrate 8 more backends onto HttpClient

### DIFF
--- a/src/earthlens/admin/_helpers.py
+++ b/src/earthlens/admin/_helpers.py
@@ -19,8 +19,12 @@ gate are applied by the per-provider URL builders so the backend hands
 
 from __future__ import annotations
 
+from typing import Any
+
 import requests
 from pyramids.feature.collection import FeatureCollection
+
+from earthlens.base.http import HttpClient
 
 #: geoBoundaries gbOpen API base — `"{base}/{ISO3}/{ADM}/"` returns the metadata
 #: whose `gjDownloadURL` is the GeoJSON to read (`geoboundaries_resolve`).
@@ -34,6 +38,20 @@ NE_BASE = "https://naciscdn.org/naturalearth"
 
 #: US Census TIGER base — the GENZ cartographic-boundary (`cb_`) shapefile tree.
 TIGER_BASE = "https://www2.census.gov/geo/tiger"
+
+
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the
+    module-level `requests.get` (rather than a private session) so this
+    single-shot metadata call stays a fresh connection per call and tests
+    that monkeypatch `requests.get` still drive the transport.
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
 
 
 def vsicurl(url: str) -> str:
@@ -73,9 +91,14 @@ def geoboundaries_resolve(iso: str, adm: str, timeout: float = 60.0) -> str:
             `(ISO, ADM)` pair).
         KeyError: If the metadata carries no `gjDownloadURL`.
     """
-    response = requests.get(f"{GEOBOUNDARIES_API}/{iso}/{adm}/", timeout=timeout)
-    response.raise_for_status()
-    meta = response.json()
+    http = HttpClient(
+        session=_RequestsGet(),
+        timeout=timeout,
+        max_retries=0,
+        status_forcelist=(),
+        raise_for_status=True,
+    )
+    meta = http.get_json(f"{GEOBOUNDARIES_API}/{iso}/{adm}/")
     if isinstance(meta, list):
         if not meta:
             raise ValueError(

--- a/src/earthlens/bathymetry/backend.py
+++ b/src/earthlens/bathymetry/backend.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import difflib
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import requests
@@ -35,6 +35,7 @@ from earthlens.base import (
     SpatialExtent,
     TemporalExtent,
 )
+from earthlens.base.http import HttpClient
 from earthlens.bathymetry._helpers import (
     bbox_from_extent,
     estimate_grid_pixels,
@@ -55,6 +56,20 @@ _NETCDF_MAGIC: tuple[bytes, ...] = (b"CDF\x01", b"CDF\x02", b"CDF\x05", b"\x89HD
 #: (≈ a 0.25-gigapixel grid). The server enforces the hard cap; this is an
 #: early heads-up for the user.
 _LARGE_PIXEL_THRESHOLD = 250_000_000
+
+
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the
+    module-level `requests.get` (rather than a private session) so this
+    single-shot download stays a fresh connection per call and tests that
+    monkeypatch `requests.get` still drive the transport.
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
 
 
 class Bathymetry(AbstractDataSource):
@@ -304,9 +319,15 @@ class Bathymetry(AbstractDataSource):
                 error page, sometimes served with a 200) — typically an
                 out-of-coverage or oversize bbox.
         """
+        http = HttpClient(
+            session=_RequestsGet(),
+            timeout=self._timeout,
+            max_retries=0,
+            status_forcelist=(),
+            raise_for_status=True,
+        )
         try:
-            response = requests.get(url, timeout=self._timeout)
-            response.raise_for_status()
+            response = http.get(url)
         except requests.exceptions.RequestException as exc:
             raise ValueError(
                 f"bathymetry request for {row.id!r} failed over "

--- a/src/earthlens/climate_indices/backend.py
+++ b/src/earthlens/climate_indices/backend.py
@@ -59,8 +59,10 @@ _HTTP_RETRIES: int = 2
 
 #: Base back-off (seconds) between retry attempts; the nth retry waits
 #: `_HTTP_RETRY_BACKOFF * 2**(n-1)` (HttpClient's exponential back-off).
-#: Identical to the previous hand-rolled linear back-off at `_HTTP_RETRIES=2`
-#: (both yield `[1s, 2s]`) — bump either constant and the schedules diverge.
+#: Coincides with the previous hand-rolled linear back-off at
+#: `_HTTP_RETRIES=2` (both yield `[1s, 2s]`); bumping `_HTTP_RETRIES` diverges
+#: the two (linear grows as `n`, exponential as `2**(n-1)`), whereas scaling
+#: `_HTTP_RETRY_BACKOFF` rescales both by the same factor.
 _HTTP_RETRY_BACKOFF: float = 1.0
 
 #: Max index ids spelled out in the written-table filename before it is

--- a/src/earthlens/climate_indices/backend.py
+++ b/src/earthlens/climate_indices/backend.py
@@ -58,7 +58,9 @@ _HTTP_TIMEOUT: float = 60.0
 _HTTP_RETRIES: int = 2
 
 #: Base back-off (seconds) between retry attempts; the nth retry waits
-#: `n * _HTTP_RETRY_BACKOFF`.
+#: `_HTTP_RETRY_BACKOFF * 2**(n-1)` (HttpClient's exponential back-off).
+#: Identical to the previous hand-rolled linear back-off at `_HTTP_RETRIES=2`
+#: (both yield `[1s, 2s]`) — bump either constant and the schedules diverge.
 _HTTP_RETRY_BACKOFF: float = 1.0
 
 #: Max index ids spelled out in the written-table filename before it is

--- a/src/earthlens/climate_indices/backend.py
+++ b/src/earthlens/climate_indices/backend.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import datetime as dt
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
 import requests
@@ -38,6 +38,7 @@ from earthlens.base import (
     SpatialExtent,
     TemporalExtent,
 )
+from earthlens.base.http import HttpClient
 from earthlens.climate_indices import _helpers
 from earthlens.climate_indices.catalog import Catalog
 
@@ -70,24 +71,17 @@ _GLOBAL_LAT: list[float] = [-90.0, 90.0]
 _GLOBAL_LON: list[float] = [-180.0, 180.0]
 
 
-def _is_transient(exc: requests.RequestException) -> bool:
-    """Return whether a fetch error is worth retrying.
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
 
-    Connection errors and timeouts are transient; an HTTP error is
-    transient only for a 5xx status (a 4xx such as 404 is a real miss
-    and fails fast). Anything else is treated as non-transient.
-
-    Args:
-        exc: The exception raised by `requests.get` / `raise_for_status`.
-
-    Returns:
-        bool: `True` to retry, `False` to fail fast.
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the
+    module-level `requests.get` (rather than a private session) so tests
+    that monkeypatch `backend.requests.get` still drive the transport.
     """
-    if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
-        return True
-    if isinstance(exc, requests.HTTPError) and exc.response is not None:
-        return exc.response.status_code >= 500
-    return False
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
 
 
 class ClimateIndices(AbstractDataSource):
@@ -328,9 +322,12 @@ class ClimateIndices(AbstractDataSource):
         """GET an index file's body, retrying transient failures.
 
         A transient failure (connection error, timeout, or a 5xx status)
-        is retried up to :data:`_HTTP_RETRIES` times with a linear
-        back-off; a 4xx (e.g. 404) fails fast since retrying a real miss
-        is pointless.
+        is retried up to :data:`_HTTP_RETRIES` times with an exponential
+        back-off (`1s`, `2s`); a 4xx (e.g. 404) fails fast since retrying
+        a real miss is pointless. The retry engine is
+        :class:`~earthlens.base.http.HttpClient`, configured to match the
+        old hand-rolled loop byte-for-byte on wait sequence and attempt
+        count.
 
         Args:
             url: The index file URL.
@@ -343,25 +340,23 @@ class ClimateIndices(AbstractDataSource):
             ValueError: When the GET still fails after the retries, naming
                 the index and URL (`G8`).
         """
-        last_exc: Exception | None = None
-        for attempt in range(_HTTP_RETRIES + 1):
-            try:
-                response = requests.get(url, timeout=_HTTP_TIMEOUT)
-                response.raise_for_status()
-                return response.text
-            except requests.RequestException as exc:
-                last_exc = exc
-                if not _is_transient(exc):
-                    break
-                if attempt < _HTTP_RETRIES:
-                    logger.warning(
-                        f"climate index {index_id!r}: transient fetch error from "
-                        f"{url} ({exc}); retry {attempt + 1}/{_HTTP_RETRIES}."
-                    )
-                    time.sleep(_HTTP_RETRY_BACKOFF * (attempt + 1))
-        raise ValueError(
-            f"climate index {index_id!r}: failed to fetch {url} ({last_exc})."
-        ) from last_exc
+        http = HttpClient(
+            session=_RequestsGet(),
+            timeout=_HTTP_TIMEOUT,
+            max_retries=_HTTP_RETRIES,
+            backoff_factor=_HTTP_RETRY_BACKOFF,
+            status_forcelist=tuple(range(500, 600)),
+            retry_on_exceptions=(requests.ConnectionError, requests.Timeout),
+            raise_for_status=True,
+            max_backoff=None,
+            sleep=lambda seconds: time.sleep(seconds),
+        )
+        try:
+            return http.get(url).text
+        except requests.RequestException as exc:
+            raise ValueError(
+                f"climate index {index_id!r}: failed to fetch {url} ({exc})."
+            ) from exc
 
     def download(
         self,

--- a/src/earthlens/climate_indices/backend.py
+++ b/src/earthlens/climate_indices/backend.py
@@ -350,7 +350,6 @@ class ClimateIndices(AbstractDataSource):
             status_forcelist=tuple(range(500, 600)),
             retry_on_exceptions=(requests.ConnectionError, requests.Timeout),
             raise_for_status=True,
-            max_backoff=None,
             sleep=lambda seconds: time.sleep(seconds),
         )
         try:

--- a/src/earthlens/cmip6/resolver.py
+++ b/src/earthlens/cmip6/resolver.py
@@ -223,7 +223,15 @@ class StoreResolver:
             Path: The local cache path (guaranteed to exist and be non-empty).
 
         Raises:
-            RuntimeError: If the download fails or yields an empty file.
+            requests.RequestException: On a transport error or a non-2xx
+                status from the download (`HttpClient.download` calls
+                `raise_for_status` — this covers `HTTPError` for a 4xx/5xx
+                on the CSV, `ConnectionError` for a network failure, and
+                `Timeout` if the transfer stalls past `self.timeout`).
+            OSError: If the atomic rename of the `.part` temp to
+                `cache_path` fails.
+            RuntimeError: When the download succeeds but yields a
+                zero-byte CSV (the cache is unlinked before raising).
         """
         if self.cache_path.exists() and self.cache_path.stat().st_size > 0:
             return self.cache_path

--- a/src/earthlens/cmip6/resolver.py
+++ b/src/earthlens/cmip6/resolver.py
@@ -25,6 +25,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import requests
+
+from earthlens.base.http import HttpClient
+
 if TYPE_CHECKING:
     import pandas as pd
 
@@ -136,6 +140,20 @@ class ResolvedStore:
         return "_".join(str(p).replace("/", "-") for p in parts if p)
 
 
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the
+    module-level `requests.get` (rather than a private session) so this
+    single-shot download stays a fresh connection per call and tests that
+    monkeypatch `requests.get` still drive the transport.
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
+
+
 class StoreResolver:
     """Resolve CMIP6 facet tuples to `zstore` URIs over the consolidated CSV.
 
@@ -196,6 +214,11 @@ class StoreResolver:
     def _ensure_csv(self) -> Path:
         """Return the cached CSV path, downloading it once if absent.
 
+        Streams through :class:`~earthlens.base.http.HttpClient`'s atomic
+        `download` (temp `.part` file + rename, cleanup on failure), then
+        enforces the non-empty invariant: a zero-byte transfer unlinks the
+        cache and raises rather than caching a useless file.
+
         Returns:
             Path: The local cache path (guaranteed to exist and be non-empty).
 
@@ -204,22 +227,23 @@ class StoreResolver:
         """
         if self.cache_path.exists() and self.cache_path.stat().st_size > 0:
             return self.cache_path
-        import requests
-
-        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.cache_path.with_name(self.cache_path.name + ".part")
-        try:
-            with requests.get(self.csv_url, stream=True, timeout=self.timeout) as resp:
-                resp.raise_for_status()
-                with open(tmp, "wb") as handle:
-                    for chunk in resp.iter_content(chunk_size=1 << 20):
-                        handle.write(chunk)
-            if tmp.stat().st_size == 0:
-                raise RuntimeError(f"downloaded an empty CSV from {self.csv_url}")
-            tmp.replace(self.cache_path)
-        except BaseException:
-            tmp.unlink(missing_ok=True)
-            raise
+        client = HttpClient(
+            session=_RequestsGet(),
+            timeout=self.timeout,
+            max_retries=0,
+            status_forcelist=(),
+            raise_for_status=True,
+        )
+        client.download(
+            self.csv_url,
+            self.cache_path,
+            chunk=1 << 20,
+            atomic=True,
+            progress=False,
+        )
+        if self.cache_path.stat().st_size == 0:
+            self.cache_path.unlink(missing_ok=True)
+            raise RuntimeError(f"downloaded an empty CSV from {self.csv_url}")
         return self.cache_path
 
     def resolve(

--- a/src/earthlens/ecmwf/jobs.py
+++ b/src/earthlens/ecmwf/jobs.py
@@ -14,11 +14,26 @@ free functions here for back-compat.
 from __future__ import annotations
 
 import datetime
-import urllib.request
 from pathlib import Path
 from typing import Any
 
 import requests
+
+from earthlens.base.http import HttpClient
+
+
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the
+    module-level `requests.get` (rather than a private session) so tests
+    that monkeypatch `requests.get` still drive the transport, and each
+    call remains a fresh connection.
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
 
 
 def read_cdsapirc() -> dict[str, str]:
@@ -67,16 +82,21 @@ def list_recent_jobs(
     params: dict[str, Any] = {"limit": limit}
     if status:
         params["status"] = status
-    resp = requests.get(
+    client = HttpClient(
+        session=_RequestsGet(),
+        timeout=30,
+        max_retries=0,
+        status_forcelist=(),
+        raise_for_status=True,
+    )
+    body = client.get_json(
         url,
         headers={"PRIVATE-TOKEN": cfg["key"]},
         params=params,
-        timeout=30,
     )
-    resp.raise_for_status()
     now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     out: list[dict[str, Any]] = []
-    for job in resp.json().get("jobs", []):
+    for job in body.get("jobs", []):
         created = job.get("created", "")
         if not created:
             continue
@@ -120,9 +140,15 @@ def download_job(
     if target_path.exists() and target_path.stat().st_size > 0:
         return target_path
     rurl = cfg["url"].rstrip("/") + f"/retrieve/v1/jobs/{job_id}/results"
-    resp = requests.get(rurl, headers={"PRIVATE-TOKEN": cfg["key"]}, timeout=30)
-    resp.raise_for_status()
-    href = resp.json().get("asset", {}).get("value", {}).get("href")
+    results_client = HttpClient(
+        session=_RequestsGet(),
+        timeout=30,
+        max_retries=0,
+        status_forcelist=(),
+        raise_for_status=True,
+    )
+    body = results_client.get_json(rurl, headers={"PRIVATE-TOKEN": cfg["key"]})
+    href = body.get("asset", {}).get("value", {}).get("href")
     if not href:
         raise ValueError(
             f"job {job_id!r} has no downloadable asset href in its " "results record"
@@ -133,11 +159,14 @@ def download_job(
     # reading a local file via `file://`.
     if not href.startswith(("https://", "http://")):
         raise ValueError(f"refusing to download from non-http(s) href: {href!r}")
-    with (
-        # Scheme validated above — bandit B310 does not apply.
-        urllib.request.urlopen(href, timeout=60) as src,  # nosec B310
-        open(target_path, "wb") as out,
-    ):
-        while chunk := src.read(chunk_size):
-            out.write(chunk)
+    asset_client = HttpClient(
+        session=_RequestsGet(),
+        timeout=60,
+        max_retries=0,
+        status_forcelist=(),
+        raise_for_status=True,
+    )
+    asset_client.download(
+        href, target_path, chunk=chunk_size, progress=False, atomic=True
+    )
     return target_path

--- a/src/earthlens/erddap/backend.py
+++ b/src/earthlens/erddap/backend.py
@@ -36,7 +36,7 @@ import datetime as dt
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
 import requests
@@ -49,6 +49,7 @@ from earthlens.base import (
     SpatialExtent,
     TemporalExtent,
 )
+from earthlens.base.http import HttpClient
 from earthlens.erddap._helpers import (
     build_constraints,
     build_griddap_url,
@@ -76,6 +77,20 @@ _NO_MATCH_MARKER = "produced no matching results"
 #: body that does not start with one of these is an error page (ERDDAP serves
 #: those as HTML, sometimes with a 200), not data.
 _NETCDF_MAGIC: tuple[bytes, ...] = (b"CDF\x01", b"CDF\x02", b"CDF\x05", b"\x89HDF")
+
+
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the
+    module-level `requests.get` (rather than a private session) so the
+    single-shot griddap download stays a fresh connection per call and
+    tests that monkeypatch `requests.get` still drive the transport.
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -401,9 +416,15 @@ class ERDDAP(AbstractDataSource):
         )
         dest = self.root_dir / f"{row.dataset_id}.nc"
         logger.info(f"ERDDAP griddap {row.dataset_id}: GET {url}")
+        http = HttpClient(
+            session=_RequestsGet(),
+            timeout=self._timeout,
+            max_retries=0,
+            status_forcelist=(),
+            raise_for_status=True,
+        )
         try:
-            response = requests.get(url, timeout=self._timeout)
-            response.raise_for_status()
+            response = http.get(url)
         except requests.exceptions.HTTPError as exc:
             raise ValueError(
                 f"ERDDAP griddap request for {row.dataset_id!r} failed over "

--- a/src/earthlens/gdacs/backend.py
+++ b/src/earthlens/gdacs/backend.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import datetime as dt
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
 import requests
@@ -44,6 +44,7 @@ from earthlens.base import (
     SpatialExtent,
     TemporalExtent,
 )
+from earthlens.base.http import HttpClient
 from earthlens.gdacs import events
 from earthlens.gdacs.catalog import Catalog
 
@@ -81,6 +82,21 @@ _DRIVERS: dict[str, tuple[str, str]] = {
     "gpkg": ("GPKG", "gpkg"),
     "geojson": ("GeoJSON", "geojson"),
 }
+
+
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the
+    module-level `requests.get` (rather than a private session) so the
+    single SEARCH GET stays a fresh connection per call and tests that
+    monkey-patch `earthlens.gdacs.backend.requests.get` still drive the
+    transport.
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
 
 
 class GDACS(AbstractDataSource):
@@ -310,9 +326,14 @@ class GDACS(AbstractDataSource):
             f"{params['fromDate']}..{params['toDate']} "
             f"(levels {params['alertlevel']})"
         )
-        response = requests.get(SEARCH_URL, params=params, timeout=self._timeout)
-        response.raise_for_status()
-        payload = response.json()
+        http = HttpClient(
+            session=_RequestsGet(),
+            timeout=self._timeout,
+            max_retries=0,
+            status_forcelist=(),
+            raise_for_status=True,
+        )
+        payload = http.get_json(SEARCH_URL, params=params)
         feature_count = len(payload.get("features") or [])
         if feature_count >= MAX_EVENTS_PER_RESPONSE:
             logger.warning(

--- a/src/earthlens/osm/backend.py
+++ b/src/earthlens/osm/backend.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import datetime as dt
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
 import requests
@@ -50,6 +50,7 @@ from earthlens.base import (
     SpatialExtent,
     TemporalExtent,
 )
+from earthlens.base.http import HttpClient
 from earthlens.osm._helpers import (
     LicenseWarning,
     bbox_swne,
@@ -102,6 +103,26 @@ _DEFAULT_MAX_BBOX_DEG2 = 100.0
 #: degenerate thin-but-globe-spanning box (e.g. `0.1° x 360°`, ~36 square
 #: degrees) is still rejected — the area cap alone would let it through.
 _MAX_BBOX_SPAN_DEG = 90.0
+
+
+class _RequestsHttp:
+    """Session-like adapter routing GET/POST through the module `requests`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the module-level
+    `requests.get` / `requests.post` (rather than a private session) so this
+    single-shot Overpass POST stays a fresh connection per call, and so tests
+    that monkeypatch `earthlens.osm.backend.requests.post` still drive the
+    transport (`HttpClient._send` calls `getattr(session, "post")` first, so
+    a shim with both `get` and `post` works for either verb).
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a POST via the module-level `requests.post`."""
+        return requests.post(url, **kwargs)
 
 
 class OSM(AbstractDataSource):
@@ -385,11 +406,15 @@ class OSM(AbstractDataSource):
     def _fetch_overpass(self, query_id: str, dataset: Dataset) -> FeatureCollection:
         """Fetch one Overpass query: POST the QL (with UA), parse, build geometry.
 
-        POSTs the resolved Overpass QL to `self._endpoint` with core
-        `requests` (a descriptive `User-Agent` — required to avoid the
-        overpass-api.de 406 — and `self._timeout`), parses the JSON with
-        `overpy.Overpass().parse_json(...)`, and converts the parsed
-        elements to a `FeatureCollection` via `overpy_to_gdf` / `to_fc`.
+        POSTs the resolved Overpass QL to `self._endpoint` through the shared
+        :class:`~earthlens.base.http.HttpClient` (a descriptive
+        `User-Agent` — required to avoid the overpass-api.de 406 — applied at
+        the client level via `default_headers`, and `self._timeout`), parses
+        the JSON with `overpy.Overpass().parse_json(...)`, and converts the
+        parsed elements to a `FeatureCollection` via `overpy_to_gdf` / `to_fc`.
+        The client is single-shot (`max_retries=0`, empty
+        `status_forcelist`), so behaviour matches the previous bare
+        `requests.post`: no retry, non-2xx statuses propagate immediately.
 
         Args:
             query_id: The named-query id (for logging).
@@ -422,13 +447,15 @@ class OSM(AbstractDataSource):
             "{timeout}", str(int(self._timeout))
         )
         logger.info(f"Querying Overpass for {query_id!r} over bbox ({bbox_str})")
-        response = requests.post(
-            self._endpoint,
-            data={"data": ql},
-            headers={"User-Agent": self._user_agent},
+        http = HttpClient(
+            session=_RequestsHttp(),
+            user_agent=self._user_agent,
             timeout=self._timeout,
+            max_retries=0,
+            status_forcelist=(),
+            raise_for_status=True,
         )
-        response.raise_for_status()
+        response = http.post(self._endpoint, data={"data": ql})
         result = overpy.Overpass().parse_json(response.text)
         return to_fc(overpy_to_gdf(result))
 

--- a/src/earthlens/risk_indicators/_helpers.py
+++ b/src/earthlens/risk_indicators/_helpers.py
@@ -63,8 +63,10 @@ _HTTP_RETRIES: int = 2
 
 #: Base back-off (seconds) between retries; the nth retry waits
 #: `_HTTP_RETRY_BACKOFF * 2**(n-1)` (HttpClient's exponential back-off).
-#: Identical to the previous hand-rolled linear back-off at `_HTTP_RETRIES=2`
-#: (both yield `[1s, 2s]`) — bump either constant and the schedules diverge.
+#: Coincides with the previous hand-rolled linear back-off at
+#: `_HTTP_RETRIES=2` (both yield `[1s, 2s]`); bumping `_HTTP_RETRIES` diverges
+#: the two (linear grows as `n`, exponential as `2**(n-1)`), whereas scaling
+#: `_HTTP_RETRY_BACKOFF` rescales both by the same factor.
 _HTTP_RETRY_BACKOFF: float = 1.0
 
 

--- a/src/earthlens/risk_indicators/_helpers.py
+++ b/src/earthlens/risk_indicators/_helpers.py
@@ -80,27 +80,6 @@ _TRANSIENT_ERRORS: tuple[type[requests.RequestException], ...] = (
 )
 
 
-def _is_transient(exc: requests.RequestException) -> bool:
-    """Return whether a request error is worth retrying.
-
-    Connection errors (including the GFW host's intermittent resets, whether
-    they land during the handshake or mid-body) and timeouts are transient; an
-    HTTP error is transient only for a 5xx status (a 4xx such as 404 is a real
-    miss and fails fast).
-
-    Args:
-        exc: The exception raised by `requests.get` / `raise_for_status`.
-
-    Returns:
-        bool: `True` to retry, `False` to fail fast.
-    """
-    if isinstance(exc, _TRANSIENT_ERRORS):
-        return True
-    if isinstance(exc, requests.HTTPError) and exc.response is not None:
-        return exc.response.status_code >= 500
-    return False
-
-
 class _RequestsGet:
     """Session-like GET adapter routing through the module `requests.get`.
 
@@ -126,13 +105,13 @@ def _request_json(
     Retries are delegated to :class:`~earthlens.base.http.HttpClient`: a 5xx
     response or a transient transport error (see :data:`_TRANSIENT_ERRORS`)
     is retried up to :data:`_HTTP_RETRIES` times with exponential back-off
-    (`1s`, `2s`); a 4xx (including 429) fails fast — the classification
-    matches :func:`_is_transient`.
+    (`1s`, `2s`); a 4xx (including 429) fails fast.
 
     Args:
         url: The request URL.
         params: Query parameters, or `None`.
-        headers: Request headers (carries the `User-Agent` and any key).
+        headers: Extra request headers (e.g. the GFW `x-api-key` on the
+            keyed sources; the `User-Agent` is a client-level default).
         timeout: Per-request timeout in seconds.
 
     Returns:

--- a/src/earthlens/risk_indicators/_helpers.py
+++ b/src/earthlens/risk_indicators/_helpers.py
@@ -25,12 +25,14 @@ Endpoints / response shapes were live-verified 2026-06-27 (see
 from __future__ import annotations
 
 import time
+from typing import Any
 
 import geopandas as gpd
 import pandas as pd
 import requests
-from loguru import logger
 from pyramids.feature.collection import FeatureCollection
+
+from earthlens.base.http import HttpClient
 
 #: ThinkHazard! public REST base (no auth). Hazard reports live under
 #: `/report/{division_code}.json` and `/report/{division_code}/{hazard}.json`.
@@ -96,6 +98,19 @@ def _is_transient(exc: requests.RequestException) -> bool:
     return False
 
 
+class _RequestsGet:
+    """Session-like GET adapter routing through the module `requests.get`.
+
+    Keeps :class:`~earthlens.base.http.HttpClient` pointed at the module-level
+    `requests.get` (rather than a private session) so tests that monkeypatch
+    `_helpers.requests.get` still drive the transport.
+    """
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Issue a GET via the module-level `requests.get`."""
+        return requests.get(url, **kwargs)
+
+
 def _request_json(
     url: str,
     *,
@@ -104,6 +119,12 @@ def _request_json(
     timeout: float,
 ) -> dict | list:
     """GET `url` and return parsed JSON, retrying transient failures.
+
+    Retries are delegated to :class:`~earthlens.base.http.HttpClient`: a 5xx
+    response or a transient transport error (see :data:`_TRANSIENT_ERRORS`)
+    is retried up to :data:`_HTTP_RETRIES` times with exponential back-off
+    (`1s`, `2s`); a 4xx (including 429) fails fast — the classification
+    matches :func:`_is_transient`.
 
     Args:
         url: The request URL.
@@ -118,24 +139,19 @@ def _request_json(
         requests.RequestException: When the GET still fails after the retries
             (the last error is re-raised; a 4xx fails fast without retrying).
     """
-    last_exc: requests.RequestException | None = None
-    for attempt in range(_HTTP_RETRIES + 1):
-        try:
-            response = requests.get(
-                url, params=params, headers=headers, timeout=timeout
-            )
-            response.raise_for_status()
-            return response.json()
-        except requests.RequestException as exc:
-            last_exc = exc
-            if not _is_transient(exc) or attempt == _HTTP_RETRIES:
-                raise
-            logger.warning(
-                f"risk-indicators: transient fetch error from {url} ({exc}); "
-                f"retry {attempt + 1}/{_HTTP_RETRIES}."
-            )
-            time.sleep(_HTTP_RETRY_BACKOFF * (attempt + 1))
-    raise last_exc  # pragma: no cover - loop always returns or raises above
+    client = HttpClient(
+        session=_RequestsGet(),
+        user_agent=_USER_AGENT,
+        timeout=timeout,
+        max_retries=_HTTP_RETRIES,
+        backoff_factor=_HTTP_RETRY_BACKOFF,
+        status_forcelist=tuple(range(500, 600)),
+        max_backoff=None,
+        retry_on_exceptions=_TRANSIENT_ERRORS,
+        raise_for_status=True,
+        sleep=lambda seconds: time.sleep(seconds),
+    )
+    return client.get_json(url, params=params, headers=headers)
 
 
 #: Canonical column order for a ThinkHazard hazard-level table.

--- a/src/earthlens/risk_indicators/_helpers.py
+++ b/src/earthlens/risk_indicators/_helpers.py
@@ -61,7 +61,10 @@ _HTTP_TIMEOUT: float = 120.0
 #: timeout / 5xx). The GFW host in particular resets connections intermittently.
 _HTTP_RETRIES: int = 2
 
-#: Base back-off (seconds) between retries; the nth retry waits n * this.
+#: Base back-off (seconds) between retries; the nth retry waits
+#: `_HTTP_RETRY_BACKOFF * 2**(n-1)` (HttpClient's exponential back-off).
+#: Identical to the previous hand-rolled linear back-off at `_HTTP_RETRIES=2`
+#: (both yield `[1s, 2s]`) — bump either constant and the schedules diverge.
 _HTTP_RETRY_BACKOFF: float = 1.0
 
 

--- a/src/earthlens/risk_indicators/_helpers.py
+++ b/src/earthlens/risk_indicators/_helpers.py
@@ -161,19 +161,21 @@ _LEVEL_TITLE_TO_MNEMONIC: dict[str, str] = {
 
 
 def _headers(api_key: str | None = None) -> dict[str, str]:
-    """Build request headers, adding the GFW key header when given.
+    """Build the per-call GFW `x-api-key` header, when given.
+
+    The descriptive `User-Agent` rides on every request via `HttpClient`'s
+    client-level default (set in :func:`_request_json`), so it does not need
+    to be re-set here — a per-call `User-Agent` header would only shadow the
+    identical default.
 
     Args:
         api_key: The GFW `x-api-key`, or `None` for the keyless public sources.
 
     Returns:
-        dict[str, str]: Headers carrying the `User-Agent` (always) and the
-            `x-api-key` (only when `api_key` is not `None`).
+        dict[str, str]: `{GFW_KEY_HEADER: api_key}` when a key is given, else
+            an empty dict.
     """
-    headers = {"User-Agent": _USER_AGENT}
-    if api_key is not None:
-        headers[GFW_KEY_HEADER] = api_key
-    return headers
+    return {GFW_KEY_HEADER: api_key} if api_key is not None else {}
 
 
 def thinkhazard_query(

--- a/src/earthlens/risk_indicators/_helpers.py
+++ b/src/earthlens/risk_indicators/_helpers.py
@@ -128,7 +128,6 @@ def _request_json(
         max_retries=_HTTP_RETRIES,
         backoff_factor=_HTTP_RETRY_BACKOFF,
         status_forcelist=tuple(range(500, 600)),
-        max_backoff=None,
         retry_on_exceptions=_TRANSIENT_ERRORS,
         raise_for_status=True,
         sleep=lambda seconds: time.sleep(seconds),

--- a/tests/admin/test_helpers.py
+++ b/tests/admin/test_helpers.py
@@ -26,6 +26,8 @@ class _FakeResponse:
     def __init__(self, payload: Any, raised: Exception | None = None):
         self._payload = payload
         self._raised = raised
+        self.status_code = 200
+        self.headers: dict[str, str] = {}
 
     def raise_for_status(self) -> None:
         """Raise the configured error, mimicking a non-2xx status."""
@@ -35,6 +37,10 @@ class _FakeResponse:
     def json(self) -> Any:
         """Return the canned JSON payload."""
         return self._payload
+
+    def close(self) -> None:
+        """No-op close, matching the requests.Response interface."""
+        return None
 
 
 class _FakeCRS:
@@ -99,7 +105,7 @@ def test_geoboundaries_resolve_dict_payload(monkeypatch):
     monkeypatch.setattr(
         _helpers.requests,
         "get",
-        lambda url, timeout=60: _FakeResponse({"gjDownloadURL": "http://x/k.geojson"}),
+        lambda url, **kwargs: _FakeResponse({"gjDownloadURL": "http://x/k.geojson"}),
     )
     assert geoboundaries_resolve("KEN", "ADM1") == "http://x/k.geojson"
 
@@ -109,7 +115,7 @@ def test_geoboundaries_resolve_list_payload(monkeypatch):
     monkeypatch.setattr(
         _helpers.requests,
         "get",
-        lambda url, timeout=60: _FakeResponse([{"gjDownloadURL": "http://x/0.geojson"}]),
+        lambda url, **kwargs: _FakeResponse([{"gjDownloadURL": "http://x/0.geojson"}]),
     )
     assert geoboundaries_resolve("USA", "ADM0") == "http://x/0.geojson"
 
@@ -118,9 +124,9 @@ def test_geoboundaries_resolve_builds_api_url(monkeypatch):
     """The metadata GET targets the gbOpen API path for the ISO + ADM pair."""
     seen: dict[str, Any] = {}
 
-    def _capture(url, timeout=60):
+    def _capture(url, **kwargs):
         seen["url"] = url
-        seen["timeout"] = timeout
+        seen["timeout"] = kwargs.get("timeout")
         return _FakeResponse({"gjDownloadURL": "http://x/y.geojson"})
 
     monkeypatch.setattr(_helpers.requests, "get", _capture)
@@ -132,7 +138,7 @@ def test_geoboundaries_resolve_builds_api_url(monkeypatch):
 def test_geoboundaries_resolve_empty_list_raises(monkeypatch):
     """An empty-list API response raises a clear ValueError, not IndexError."""
     monkeypatch.setattr(
-        _helpers.requests, "get", lambda url, timeout=60: _FakeResponse([])
+        _helpers.requests, "get", lambda url, **kwargs: _FakeResponse([])
     )
     with pytest.raises(ValueError, match="no boundary for KEN/ADM1"):
         geoboundaries_resolve("KEN", "ADM1")
@@ -145,7 +151,7 @@ def test_geoboundaries_resolve_http_error_propagates(monkeypatch):
     monkeypatch.setattr(
         _helpers.requests,
         "get",
-        lambda url, timeout=60: _FakeResponse(
+        lambda url, **kwargs: _FakeResponse(
             {}, raised=requests.HTTPError("500 Server Error")
         ),
     )

--- a/tests/bathymetry/test_backend.py
+++ b/tests/bathymetry/test_backend.py
@@ -22,14 +22,19 @@ _NETCDF_BODY = b"CDF\x01" + b"\x00" * 64
 class _FakeResponse:
     """Stand-in for a `requests.Response` carrying canned bytes / status."""
 
+    headers: dict[str, str] = {}
+
     def __init__(self, content: bytes = _NETCDF_BODY, status: int = 200):
         self.content = content
-        self._status = status
+        self.status_code = status
 
     def raise_for_status(self) -> None:
         """Raise an `HTTPError` for a 4xx/5xx status, like requests does."""
-        if self._status >= 400:
-            raise requests.exceptions.HTTPError(f"HTTP {self._status}")
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"HTTP {self.status_code}")
+
+    def close(self) -> None:
+        """No-op — the fake holds no socket."""
 
 
 class _FakeBand:
@@ -83,7 +88,7 @@ def captured_get(monkeypatch: pytest.MonkeyPatch) -> dict:
     """Capture the griddap URL and return a fixture NetCDF body."""
     captured: dict = {}
 
-    def _fake_get(url: str, timeout: float = 0.0) -> _FakeResponse:
+    def _fake_get(url: str, timeout: float = 0.0, **kwargs) -> _FakeResponse:
         captured["url"] = url
         captured["timeout"] = timeout
         return _FakeResponse()
@@ -152,7 +157,7 @@ def test_oversize_non_netcdf_body_raises_valueerror(
     monkeypatch.setattr(
         backend_module.requests,
         "get",
-        lambda url, timeout=0.0: _FakeResponse(content=b"<html>error</html>"),
+        lambda url, timeout=0.0, **kwargs: _FakeResponse(content=b"<html>error</html>"),
     )
     with pytest.raises(ValueError, match="non-NetCDF"):
         _make("gebco_2020", tmp_path).download()
@@ -165,7 +170,7 @@ def test_http_error_raises_valueerror(
     monkeypatch.setattr(
         backend_module.requests,
         "get",
-        lambda url, timeout=0.0: _FakeResponse(status=413),
+        lambda url, timeout=0.0, **kwargs: _FakeResponse(status=413),
     )
     with pytest.raises(ValueError, match="coverage|too large"):
         _make("gebco_2020", tmp_path).download()

--- a/tests/climate_indices/test_backend.py
+++ b/tests/climate_indices/test_backend.py
@@ -30,6 +30,7 @@ class _FakeResponse:
     def __init__(self, text: str, status_code: int = 200) -> None:
         self.text = text
         self.status_code = status_code
+        self.headers: dict[str, str] = {}
 
     def raise_for_status(self) -> None:
         """Raise `HTTPError` (carrying this response) for a >=400 status."""
@@ -38,8 +39,11 @@ class _FakeResponse:
             error.response = self
             raise error
 
+    def close(self) -> None:
+        """No-op close — the fake owns no socket."""
 
-def _fake_get(url: str, timeout: float | None = None) -> _FakeResponse:
+
+def _fake_get(url: str, timeout: float | None = None, **_kwargs) -> _FakeResponse:
     """Return the captured fixture body for a known index URL, else a 404."""
     name = url.rsplit("/", 1)[-1]
     if name in _FIXTURES:
@@ -47,7 +51,7 @@ def _fake_get(url: str, timeout: float | None = None) -> _FakeResponse:
     return _FakeResponse("Not found", status_code=404)
 
 
-def _always_404(url: str, timeout: float | None = None) -> _FakeResponse:
+def _always_404(url: str, timeout: float | None = None, **_kwargs) -> _FakeResponse:
     """Return a 404 for every URL."""
     return _FakeResponse("Not found", status_code=404)
 
@@ -60,7 +64,9 @@ class _Flaky5xxGet:
         self.fails = fails
         self.calls = 0
 
-    def __call__(self, url: str, timeout: float | None = None) -> _FakeResponse:
+    def __call__(
+        self, url: str, timeout: float | None = None, **_kwargs
+    ) -> _FakeResponse:
         """Return a 503 for the first `fails` calls, then a 200 with the body."""
         self.calls += 1
         if self.calls <= self.fails:
@@ -74,7 +80,9 @@ class _CountingGet404:
     def __init__(self) -> None:
         self.calls = 0
 
-    def __call__(self, url: str, timeout: float | None = None) -> _FakeResponse:
+    def __call__(
+        self, url: str, timeout: float | None = None, **_kwargs
+    ) -> _FakeResponse:
         """Count the call and return a 404 response."""
         self.calls += 1
         return _FakeResponse("Not found", status_code=404)
@@ -86,23 +94,27 @@ class _AlwaysConnError:
     def __init__(self) -> None:
         self.calls = 0
 
-    def __call__(self, url: str, timeout: float | None = None) -> _FakeResponse:
+    def __call__(
+        self, url: str, timeout: float | None = None, **_kwargs
+    ) -> _FakeResponse:
         """Count the call and raise a transient connection error."""
         self.calls += 1
         raise requests.ConnectionError("down")
 
 
-def _generic_request_error(url: str, timeout: float | None = None) -> _FakeResponse:
+def _generic_request_error(
+    url: str, timeout: float | None = None, **_kwargs
+) -> _FakeResponse:
     """Raise a bare (non-connection, non-HTTP) RequestException — not transient."""
     raise requests.RequestException("weird")
 
 
-def _html_200(url: str, timeout: float | None = None) -> _FakeResponse:
+def _html_200(url: str, timeout: float | None = None, **_kwargs) -> _FakeResponse:
     """Return a 200 response whose body is an HTML error page."""
     return _FakeResponse("<!DOCTYPE HTML><html>error</html>")
 
 
-def _any_psl_get(url: str, timeout: float | None = None) -> _FakeResponse:
+def _any_psl_get(url: str, timeout: float | None = None, **_kwargs) -> _FakeResponse:
     """Serve the ONI (psl-dialect) fixture for any URL (for multi-PSL-index tests)."""
     return _FakeResponse((DATA / "psl" / "oni.data").read_text())
 
@@ -115,7 +127,9 @@ class _FlakyGet:
         self.fails = fails
         self.calls = 0
 
-    def __call__(self, url: str, timeout: float | None = None) -> _FakeResponse:
+    def __call__(
+        self, url: str, timeout: float | None = None, **_kwargs
+    ) -> _FakeResponse:
         """Fail transiently for the first `fails` calls, then return the body."""
         self.calls += 1
         if self.calls <= self.fails:

--- a/tests/climate_indices/test_earthlens_climate_indices.py
+++ b/tests/climate_indices/test_earthlens_climate_indices.py
@@ -24,12 +24,16 @@ class _FakeResponse:
     def __init__(self, text: str) -> None:
         self.text = text
         self.status_code = 200
+        self.headers: dict[str, str] = {}
 
     def raise_for_status(self) -> None:
         """No-op: the fixture responses are always 200."""
 
+    def close(self) -> None:
+        """No-op close — the fake owns no socket."""
 
-def _fake_get(url: str, timeout: float | None = None) -> _FakeResponse:
+
+def _fake_get(url: str, timeout: float | None = None, **_kwargs) -> _FakeResponse:
     """Return the ONI fixture for any URL."""
     return _FakeResponse((DATA / "psl" / "oni.data").read_text())
 
@@ -46,9 +50,7 @@ class TestRegistry:
     @pytest.mark.parametrize("key", KEYS)
     def test_keys_resolve_to_climate_indices_class(self, key: str) -> None:
         """All keys resolve to `earthlens.climate_indices.ClimateIndices`."""
-        assert (
-            EarthLens.DataSources[key] is earthlens.climate_indices.ClimateIndices
-        )
+        assert EarthLens.DataSources[key] is earthlens.climate_indices.ClimateIndices
 
     @pytest.mark.parametrize("key", KEYS)
     def test_keys_hint_no_extra(self, key: str) -> None:

--- a/tests/cmip6/test_resolver.py
+++ b/tests/cmip6/test_resolver.py
@@ -151,11 +151,8 @@ def test_ensure_csv_downloads_when_absent(monkeypatch, tmp_path, store_frame):
     payload = store_frame.to_csv(index=False).encode()
 
     class _Resp:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *exc):
-            return False
+        status_code = 200
+        headers: dict[str, str] = {}
 
         def raise_for_status(self):
             return None
@@ -163,9 +160,10 @@ def test_ensure_csv_downloads_when_absent(monkeypatch, tmp_path, store_frame):
         def iter_content(self, chunk_size):
             yield payload
 
-    monkeypatch.setattr(
-        "requests.get", lambda url, stream, timeout: _Resp()
-    )
+        def close(self):
+            return None
+
+    monkeypatch.setattr("requests.get", lambda url, **kwargs: _Resp())
     resolver = StoreResolver("http://x/y.csv", list(store_frame.columns), cache_path=cache)
     assert len(resolver.frame) == len(store_frame)
     assert cache.exists()
@@ -207,11 +205,8 @@ def test_ensure_csv_empty_download_raises(monkeypatch, tmp_path):
     cache = tmp_path / "stores.csv"
 
     class _Resp:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *exc):
-            return False
+        status_code = 200
+        headers: dict[str, str] = {}
 
         def raise_for_status(self):
             return None
@@ -219,7 +214,10 @@ def test_ensure_csv_empty_download_raises(monkeypatch, tmp_path):
         def iter_content(self, chunk_size):
             return iter(())
 
-    monkeypatch.setattr("requests.get", lambda url, stream, timeout: _Resp())
+        def close(self):
+            return None
+
+    monkeypatch.setattr("requests.get", lambda url, **kwargs: _Resp())
     resolver = StoreResolver("http://x/y.csv", ["source_id"], cache_path=cache)
     with pytest.raises(RuntimeError, match="empty CSV"):
         _ = resolver.frame

--- a/tests/erddap/conftest.py
+++ b/tests/erddap/conftest.py
@@ -62,15 +62,24 @@ class FakeResponse:
     """Minimal `requests` response carrying canned NetCDF bytes."""
 
     def __init__(
-        self, content: bytes = FAKE_NETCDF_BYTES, error: Exception | None = None
+        self,
+        content: bytes = FAKE_NETCDF_BYTES,
+        error: Exception | None = None,
+        status_code: int = 200,
     ):
         self.content = content
         self._error = error
+        self.status_code = status_code
+        self.headers: dict[str, str] = {}
 
     def raise_for_status(self) -> None:
         """Raise the configured error, if any."""
         if self._error is not None:
             raise self._error
+
+    def close(self) -> None:
+        """No-op close; the HttpClient may release the response."""
+        return None
 
 
 @pytest.fixture
@@ -78,7 +87,7 @@ def fake_nc_get(monkeypatch):
     """Stub `backend.requests.get`; returns the recorded URL list."""
     calls: list[str] = []
 
-    def _get(url: str, timeout: float | None = None) -> FakeResponse:
+    def _get(url: str, **kwargs) -> FakeResponse:
         calls.append(url)
         return FakeResponse()
 

--- a/tests/erddap/test_backend.py
+++ b/tests/erddap/test_backend.py
@@ -270,7 +270,7 @@ class TestGriddap:
         """An out-of-coverage griddap response surfaces as a clear ValueError."""
         from tests.erddap.conftest import FakeResponse
 
-        def _get(url, timeout=None):
+        def _get(url, **kwargs):
             return FakeResponse(
                 error=requests.exceptions.HTTPError("Error 404: out of range")
             )
@@ -283,7 +283,7 @@ class TestGriddap:
         """A 200 response with an HTML error body is rejected, not written."""
         from tests.erddap.conftest import FakeResponse
 
-        def _get(url, timeout=None):
+        def _get(url, **kwargs):
             return FakeResponse(content=b"<html><body>Resource not found</body></html>")
 
         monkeypatch.setattr("earthlens.erddap.backend.requests.get", _get)

--- a/tests/gdacs/conftest.py
+++ b/tests/gdacs/conftest.py
@@ -86,6 +86,8 @@ class _FakeResponse:
     def __init__(self, payload: dict[str, Any], status_error: Exception | None):
         self._payload = payload
         self._status_error = status_error
+        self.status_code = 200
+        self.headers: dict[str, str] = {}
 
     def raise_for_status(self) -> None:
         if self._status_error is not None:
@@ -93,6 +95,10 @@ class _FakeResponse:
 
     def json(self) -> dict[str, Any]:
         return self._payload
+
+    def close(self) -> None:
+        """Match the `requests.Response.close` shape (no-op)."""
+        return None
 
 
 class _FakeGdacs:
@@ -103,10 +109,10 @@ class _FakeGdacs:
         self.payload: dict[str, Any] = _make_payload()
         self.status_error: Exception | None = None
 
-    def __call__(
-        self, url: str, params: dict[str, Any], timeout: float
-    ) -> _FakeResponse:
-        self.calls.append({"url": url, "params": params, "timeout": timeout})
+    def __call__(self, url: str, **kwargs: Any) -> _FakeResponse:
+        entry: dict[str, Any] = {"url": url}
+        entry.update(kwargs)
+        self.calls.append(entry)
         return _FakeResponse(self.payload, self.status_error)
 
     def set_payload(self, payload: dict[str, Any]) -> None:

--- a/tests/osm/conftest.py
+++ b/tests/osm/conftest.py
@@ -143,14 +143,24 @@ def fake_overpass_post(monkeypatch: pytest.MonkeyPatch) -> FakePostState:
     class _Response:
         def __init__(self, text: str) -> None:
             self.text = text
+            self.status_code = 200
+            self.headers: dict[str, str] = {}
 
         def raise_for_status(self) -> None:
             if not state.ok:
                 raise requests.HTTPError("Overpass returned an error status")
 
-    def _post(url: str, data: dict, headers: dict, timeout: float) -> _Response:
+        def close(self) -> None:
+            return None
+
+    def _post(url: str, **kwargs: Any) -> _Response:
         state.calls.append(
-            {"url": url, "data": data, "headers": headers, "timeout": timeout}
+            {
+                "url": url,
+                "data": kwargs.get("data"),
+                "headers": kwargs.get("headers"),
+                "timeout": kwargs.get("timeout"),
+            }
         )
         return _Response(state.text)
 

--- a/tests/risk_indicators/test_helpers.py
+++ b/tests/risk_indicators/test_helpers.py
@@ -35,6 +35,8 @@ class _Resp:
 
     def __init__(self, payload):
         self._payload = payload
+        self.status_code = 200
+        self.headers = {}
 
     def raise_for_status(self):
         """No-op for the 200 fixtures."""
@@ -42,6 +44,9 @@ class _Resp:
     def json(self):
         """Return the canned payload."""
         return self._payload
+
+    def close(self):
+        """No-op close hook (HttpClient calls it on retry/errored responses)."""
 
 
 def _load(name):

--- a/tests/risk_indicators/test_helpers.py
+++ b/tests/risk_indicators/test_helpers.py
@@ -95,33 +95,6 @@ class _HttpError(_Resp):
         raise err
 
 
-class TestIsTransient:
-    """_is_transient classifies which request errors are retryable."""
-
-    @pytest.mark.parametrize(
-        "exc, expected",
-        [
-            (_helpers.requests.ConnectionError("reset"), True),
-            (_helpers.requests.Timeout("slow"), True),
-            (_helpers.requests.exceptions.ChunkedEncodingError("mid-body"), True),
-            (_helpers.requests.exceptions.ContentDecodingError("gzip"), True),
-            (_helpers.requests.RequestException("other"), False),
-        ],
-    )
-    def test_connection_and_timeout(self, exc, expected):
-        """Connection resets (handshake or mid-body) and timeouts are transient."""
-        assert _helpers._is_transient(exc) is expected
-
-    def test_5xx_transient_4xx_not(self):
-        """A 5xx HTTPError is transient; a 4xx is not."""
-        err5 = _helpers.requests.HTTPError("boom")
-        err5.response = _HttpError(503)
-        err4 = _helpers.requests.HTTPError("nope")
-        err4.response = _HttpError(404)
-        assert _helpers._is_transient(err5) is True
-        assert _helpers._is_transient(err4) is False
-
-
 class TestRequestJsonRetry:
     """_request_json retries transient failures and fails fast on 4xx."""
 

--- a/tests/risk_indicators/test_helpers.py
+++ b/tests/risk_indicators/test_helpers.py
@@ -123,6 +123,61 @@ class TestRequestJsonRetry:
             _helpers.inform_query(505, "INFORM")
         assert returns_404.calls == 1
 
+    def test_timeout_is_retried(self, monkeypatch):
+        """A Timeout is transient and retried, then the next attempt succeeds."""
+        monkeypatch.setattr(_helpers.time, "sleep", lambda _s: None)
+        flaky = _FlakyGet([_helpers.requests.Timeout("slow")], {"data": [1]})
+        monkeypatch.setattr(_helpers.requests, "get", flaky)
+        assert _helpers.thinkhazard_query("133") is not None
+        assert flaky.attempts == 2
+
+    def test_chunked_encoding_error_is_retried(self, monkeypatch):
+        """A mid-body ChunkedEncodingError (the GFW case) is retried."""
+        monkeypatch.setattr(_helpers.time, "sleep", lambda _s: None)
+        flaky = _FlakyGet(
+            [_helpers.requests.exceptions.ChunkedEncodingError("mid-body")],
+            {"data": [1]},
+        )
+        monkeypatch.setattr(_helpers.requests, "get", flaky)
+        assert _helpers.gfw_query("d", "v", "SELECT 1", api_key="k") == {"data": [1]}
+        assert flaky.attempts == 2
+
+    def test_content_decoding_error_is_retried(self, monkeypatch):
+        """A ContentDecodingError is transient and retried."""
+        monkeypatch.setattr(_helpers.time, "sleep", lambda _s: None)
+        flaky = _FlakyGet(
+            [_helpers.requests.exceptions.ContentDecodingError("gzip")],
+            {"data": [1]},
+        )
+        monkeypatch.setattr(_helpers.requests, "get", flaky)
+        assert _helpers.gfw_query("d", "v", "SELECT 1", api_key="k") == {"data": [1]}
+        assert flaky.attempts == 2
+
+    def test_5xx_is_retried(self, monkeypatch):
+        """A 5xx status is retried via the 500-599 forcelist."""
+        monkeypatch.setattr(_helpers.time, "sleep", lambda _s: None)
+        first_503 = _HttpError(503)
+        second_ok = _Resp({"data": [1]})
+        responses = iter([first_503, second_ok])
+        calls = {"n": 0}
+
+        def fake_get(url, **kwargs):
+            calls["n"] += 1
+            return next(responses)
+
+        monkeypatch.setattr(_helpers.requests, "get", fake_get)
+        assert _helpers.gfw_query("d", "v", "SELECT 1", api_key="k") == {"data": [1]}
+        assert calls["n"] == 2
+
+    def test_bare_request_exception_fails_fast(self, monkeypatch):
+        """A bare RequestException (not in retry_on_exceptions) is not retried."""
+        monkeypatch.setattr(_helpers.time, "sleep", lambda _s: None)
+        flaky = _FlakyGet([_helpers.requests.RequestException("weird")], {"data": [1]})
+        monkeypatch.setattr(_helpers.requests, "get", flaky)
+        with pytest.raises(_helpers.requests.RequestException):
+            _helpers.thinkhazard_query("133")
+        assert flaky.attempts == 1
+
 
 class TestThinkhazardQuery:
     """thinkhazard_query builds the public report URL, no key header."""

--- a/tests/test_ecmwf/test_catalog.py
+++ b/tests/test_ecmwf/test_catalog.py
@@ -536,11 +536,17 @@ class TestCatalog:
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
 
         class _Resp:
+            status_code = 200
+            headers: dict[str, str] = {}
+
             def raise_for_status(self):
                 pass
 
             def json(self):
                 return {"asset": {"value": {}}}  # no href
+
+            def close(self):
+                pass
 
         import requests as _req
 


### PR DESCRIPTION
# Description

Second wave of the `HttpClient` consolidation (following #667 which added the primitive and migrated the first
10 backends). Migrates **8 more backends** — everything left that has a real `requests` retry loop or a
single-shot GET — onto `earthlens.base.http.HttpClient`, one behaviour-preserving commit per backend.

**Migrations** (each preserves the same wire behaviour, same exception types, same test assertions — only the
test doubles gained the client's response shape via `status_code`/`headers`/`close`/`**kwargs`):

- **bathymetry** (`_download`) — single-shot GET; `status_forcelist=()`, `max_retries=0`.
- **admin** (`geoboundaries_resolve`) — single-shot metadata GET; the `HTTPError`-propagates contract is
  preserved (empty forcelist).
- **erddap** (`_fetch_grid`) — single-shot griddap NetCDF; the `HTTPError → ValueError("outside the dataset's
  coverage")` wrap stays intact. tabledap (erddapy SDK) untouched.
- **gdacs** (`_fetch`) — single-shot events search; ≥100-event truncation warning preserved.
- **osm** (Overpass QL POST) — first POST migration in the wave. New `_RequestsHttp` shim supports both verbs
  (`HttpClient._send` uses `getattr(session, verb)`); the descriptive contact `User-Agent` becomes a client-level
  default (mandatory: overpass-api.de returns 406 without one). ohsome (SDK) untouched.
- **cmip6** (`_ensure_csv`) — Pangeo ARCO Zarr store index CSV; replaces the hand-rolled `.part` temp + rename +
  cleanup loop with `HttpClient.download(atomic=True)` (the primitive already owns that sequence). Post-download
  empty-body check → `RuntimeError` preserved.
- **ecmwf/jobs.py** — three sites: two metadata `get_json` calls with the `PRIVATE-TOKEN` header, plus the
  asset stream which becomes `HttpClient.download(atomic=True)` — a strict improvement over the previous
  `urllib.request.urlopen` chunk loop (temp `.part` + rename + cleanup on failure). Scheme guard preserved.
  `constraints.py` deferred (its `urllib.request.urlopen` fixture surface spans ~24 test call sites — a separate
  refactor).
- **risk_indicators** (`_request_json`) — highest-value migration: deletes the ~40-line hand-rolled retry
  engine. Config: `status_forcelist=range(500,600)`, `retry_on_exceptions=(ConnectionError, Timeout,
  ChunkedEncodingError, ContentDecodingError)`, `max_retries=2`, `backoff_factor=1.0`, `max_backoff=None`. Sleep
  sequence byte-identical to the old linear back-off (1s, 2s). 429 still fails fast (explicit forcelist). GFW
  `x-api-key` rides per-call in `headers=` so non-GFW calls stay key-free.
- **climate_indices** (`_get_text`) — same shape as risk_indicators (5xx-only forcelist,
  `retry_on_exceptions=(ConnectionError, Timeout)`); `_is_transient` deleted as dead code (`HttpClient` now owns
  the classification).

**Deferred with documented reasons** (unchanged from wave 1 + one new):
- `ecmwf/constraints.py` — `urllib.request.urlopen` transport; behaviour-preserving migration is trivial, but
  the test suite has ~24 `_stub_urlopen*` call sites the follow-up would need to rewrite.
- `iucn`/`nwp` (process-global throttle / multi-URL concat), `eumetsat`/`hdx`/`usgs_water`/`overture` (SDK-owned
  transport), `gee/backend.py` tile URL (single-shot bare GET) — all documented in the wave-1 plan.

**Not applicable** (no HTTP at all): everything else in the fleet uses FTP, SDK-owned transport, or
GDAL/`/vsicurl`.

**Dependencies.** None — the primitive is already on `main`. `pyproject.toml` / `pixi.lock` unchanged.

# Issues

- Follow-up to #667 / #668.
- Closes #714 — C5 wave 2 (this PR is the implementation).

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Each backend's suite re-run to green after its migration, with the **same assertions unchanged** (only test
  doubles widened to the `HttpClient` response shape):
  - bathymetry: 60 passed, admin: 104, erddap: 52, gdacs: 76, osm: 82, cmip6: 96, ecmwf: 226, risk_indicators:
    118, climate_indices: 57.
- Full non-e2e suite: **5912 passed, 143 deselected**.
- Sleep-sequence parity checked by trace for the two retry-loop migrations (risk_indicators, climate_indices):
  old linear `1s, 2s` equals new exponential `1.0*2**0, 1.0*2**1`.

Reproduce: `pytest -m "not e2e" -q`

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.

