### PR TITLE
chore: remove dead .gitignore rules for the retired root tests/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,6 @@ conda/
 .idea/*
 examples/data/chirps/*
 *.xml
-tests/mo/*
 
 # Local-only files (kept in worktree, not in git)
 CLAUDE.md
@@ -163,8 +162,6 @@ tools/gee/_gee_stac_cache/
 # notebooks reference these but the actual binary blobs (era5 .tif /
 # .nc, GEE export tifs) are reproduced on demand by running the
 # notebooks against live services. They must NOT enter git.
-# Pyramids reprojection test scratch (reproduced on demand by the tests)
-tests/data/netcdf/era5_repro_pyramids_*
 
 docs/examples/ecmwf/data/
 docs/examples/gee/out/


### PR DESCRIPTION
# Description

Removes two dead `.gitignore` rules left behind by the per-distribution test reorg (#785), which moved every
test out of the root `tests/` directory into `libs/<member>/tests/` and retired root `tests/`:

- `tests/mo/*` — the `mo/` scratch stub was deleted in #785.
- `tests/data/netcdf/era5_repro_pyramids_*` (and its now-orphaned comment) — that path no longer exists.

No moved test emits either artifact (grep-clean), so the rules ignore paths that can never be produced. This was
flagged as a Low finding in the #786 review rounds and deferred to a standalone change.

# Issues

- N/A (housekeeping; follows from #785 / #786).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `.gitignore`-only change, no code touched; the removed patterns match no path any current test produces.

# Checklist:

- [ ] updated version number in pyproject.toml. *(N/A — housekeeping.)*
- [ ] added changes to docs/change-log.md. *(N/A.)*
- [ ] updated the latest version in README file. *(N/A.)*
- [ ] I have added tests that prove my fix is effective or that my feature works. *(N/A — ignore-rule removal.)*
- [x] New and existing unit tests pass locally with my changes. *(unaffected — no code change.)*
- [ ] documentation are updated. *(N/A.)*
