### PR TITLE
chore: correct osm-pbf exclusion docs and pin CI composite actions to specific versions

### DIFF
--- a/.github/workflows/github-pages-mkdocs.yml
+++ b/.github/workflows/github-pages-mkdocs.yml
@@ -35,10 +35,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1
+      - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1.3.0
         with:
           trigger: 'pull_request'
           package-manager: 'uv'
+          package-manager-version: "0.11.29"
           install-groups: "groups: docs"
           deploy-token: ${{ secrets.ACTIONS_DEPLOY_TOKEN }}
 
@@ -49,10 +50,11 @@ jobs:
     - uses: actions/checkout@v5
       with:
         fetch-depth: 0
-    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1
+    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1.3.0
       with:
         trigger: 'main'
         package-manager: 'uv'
+        package-manager-version: "0.11.29"
         install-groups: "groups: docs"
         deploy-token: ${{ secrets.ACTIONS_DEPLOY_TOKEN }}
 
@@ -73,10 +75,11 @@ jobs:
         VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
         echo "tag=$VERSION" >> $GITHUB_OUTPUT
 
-    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1
+    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1.3.0
       with:
         trigger: 'release'
         package-manager: 'uv'
+        package-manager-version: "0.11.29"
         install-groups: "groups: docs"
         deploy-token: ${{ secrets.ACTIONS_DEPLOY_TOKEN }}
         release-tag: ${{ github.event.release.tag_name || steps.version.outputs.tag }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -63,7 +63,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release with Commitizen
-        uses: serapeum-org/github-actions/actions/release/github@github-release/v1
+        uses: serapeum-org/github-actions/actions/release/github@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           increment: ${{ github.event.inputs.increment }}
@@ -71,15 +71,3 @@ jobs:
           draft: ${{ github.event.inputs.draft }}
           package-manager: uv
           install-groups: "groups: dev"
-
-      - name: Update lockfile after version bump
-        run: uv lock
-
-      - name: Commit and push updated lockfile
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add uv.lock
-          git diff --cached --quiet && echo "No lockfile changes" && exit 0
-          git commit -m "build: sync uv.lock after version bump"
-          git push origin ${{ inputs.release-branch }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -63,11 +63,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release with Commitizen
-        uses: serapeum-org/github-actions/actions/release/github@main
+        uses: serapeum-org/github-actions/actions/release/github@github-release/v1.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           increment: ${{ github.event.inputs.increment }}
           prerelease-type: ${{ github.event.inputs.prerelease_type }}
           draft: ${{ github.event.inputs.draft }}
           package-manager: uv
+          package-manager-version: "0.11.29"
           install-groups: "groups: dev"

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -43,6 +43,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
+      # release/pypi forwards no uv version input, so uv resolves to latest here
+      # (the other lanes pin 0.11.29); the build/test path is pinned via wheel-test.yml.
       - name: Build and publish to PyPI
         uses: serapeum-org/github-actions/actions/release/pypi@pypi-release/v1.0.2
         with:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -44,7 +44,8 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       # release/pypi forwards no uv version input, so uv resolves to latest here
-      # (the other lanes pin 0.11.29); the build/test path is pinned via wheel-test.yml.
+      # (the other lanes pin 0.11.29); wheel-test.yml separately validates the
+      # wheels under the pinned uv. uv build output is insensitive to the patch.
       - name: Build and publish to PyPI
         uses: serapeum-org/github-actions/actions/release/pypi@pypi-release/v1.0.2
         with:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -44,7 +44,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Build and publish to PyPI
-        uses: serapeum-org/github-actions/actions/release/pypi@pypi-release/v1
+        uses: serapeum-org/github-actions/actions/release/pypi@pypi-release/v1.0.2
         with:
           pypi-username: __token__
           pypi-password: ${{ secrets.PYPI_PUBLISH }}

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -33,11 +33,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           python-version: "3.12"
           install-groups: "groups: dev, extras: all"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Run live CDS e2e tests
         env:
@@ -56,11 +57,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           python-version: "3.12"
           install-groups: "groups: dev, extras: all"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Run live Google Earth Engine e2e tests
         # The GEE e2e test skips itself when these are unset, so this
@@ -81,13 +83,14 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           # earthaccess >=0.18 requires Python >=3.12, so the Earthdata
           # extra is exercised under the py312 environment.
           python-version: "3.12"
           install-groups: "groups: dev, extras: all"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Run live NASA Earthdata e2e tests
         # The Earthdata e2e test skips itself when these are unset, so
@@ -110,11 +113,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           python-version: "3.12"
           install-groups: "groups: dev, extras: all"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Run live EUMETSAT Data Store e2e tests
         # The EUMETSAT e2e test skips itself when these are unset, so this
@@ -136,11 +140,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           python-version: "3.12"
           install-groups: "groups: dev, extras: all"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Run live STAC e2e tests
         # Earth Search is anonymous (no creds); MPC runs via planetary-computer
@@ -162,11 +167,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           python-version: "3.12"
           install-groups: "groups: dev, extras: all"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Run live Sentinel Hub e2e tests
         # The Sentinel Hub e2e tests skip themselves when these are unset, so
@@ -188,11 +194,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           python-version: "3.12"
           install-groups: "groups: dev, extras: all"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Run live NWP e2e tests
         # This lane installs the `nwp` extra (Herbie / ecmwf-opendata) via the
@@ -214,13 +221,14 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           # asf_search reuses the EDL auth from `earthdata`, which needs
           # Python >=3.12 for earthaccess >=0.18.
           python-version: "3.12"
           install-groups: "groups: dev, extras: all"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Run live ASF (InSAR) e2e tests
         # Anonymous search and stack run with no secrets; the authed
@@ -244,11 +252,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           python-version: "3.12"
           install-groups: "groups: dev, extras: all"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Run live IUCN Red List e2e tests
         # The IUCN e2e test skips itself when IUCN_TOKEN is unset, so this
@@ -269,11 +278,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           python-version: "3.12"
           install-groups: "groups: dev, extras: all"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Run live Protected Planet (WDPA) e2e tests
         # The WDPA e2e test skips itself when WDPA_TOKEN is unset, so this

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,11 +38,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           python-version: ${{ matrix.python-version }}
           install-groups: "groups: dev, extras: all"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Run ${{ matrix.member.name }} unit + integration suite
         run: >

--- a/.github/workflows/wheel-test.yml
+++ b/.github/workflows/wheel-test.yml
@@ -18,10 +18,11 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.0
         with:
           python-version: "3.12"
           verify-lock: true
+          version: "0.11.29"
 
       - name: Build every distribution's wheel
         # The workspace publishes seven distributions and the root one is a

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -151,7 +151,7 @@ one environment** — that is every extra in the table above **except two**:
 | Excluded | SDK | Why it can't join `all` |
 |---|---|---|
 | `argo` | `argopy` | **Two** independent problems, either one disqualifying. **(1) `xarray` — a resolution conflict:** `argopy >=1.4` needs `xarray>=2025.7`, but `openeo` (in `all`) caps `xarray<2025.01.2` — disjoint ranges, which is what `[tool.uv] conflicts` declares. **(2) `erddapy` — a runtime break:** `argopy 1.4.0` still *resolves* (it does not cap `erddapy`) but fails at `import` — it imports `erddapy.erddapy._quote_string_constraints`, which `erddapy 3.3` removed — while the `erddap` extra (in `all`) requires `erddapy>=3.0`. |
-| `osm-pbf` | `pyrosm` | `pyrosm` (0.11) and `osmium` (4.3.1) both ship wheels, but `pyrosm` pulls the **sdist-only** `cykhash` (no wheels for any Python), so adding `osm-pbf` to `all` would make `pip install earthlens[all]` require a C compiler — it is kept out to keep `all` wheel-only. Tracked in #783. |
+| `osm-pbf` | `pyrosm` | `pyrosm` (0.11) and `osmium` (4.3.1) both ship wheels, but `pyrosm` pulls the **sdist-only** `cykhash` (no wheels for any Python), so adding `osm-pbf` to `all` would make `pip install earthlens[all]` require a C compiler — it is kept out to keep `all` wheel-only. Tracked in [#783](https://github.com/serapeum-org/earthlens/issues/783). |
 
 (`osm` itself **is** in `all` — see the resolution note below for why.)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -151,7 +151,7 @@ one environment** — that is every extra in the table above **except two**:
 | Excluded | SDK | Why it can't join `all` |
 |---|---|---|
 | `argo` | `argopy` | **Two** independent problems, either one disqualifying. **(1) `xarray` — a resolution conflict:** `argopy >=1.4` needs `xarray>=2025.7`, but `openeo` (in `all`) caps `xarray<2025.01.2` — disjoint ranges, which is what `[tool.uv] conflicts` declares. **(2) `erddapy` — a runtime break:** `argopy 1.4.0` still *resolves* (it does not cap `erddapy`) but fails at `import` — it imports `erddapy.erddapy._quote_string_constraints`, which `erddapy 3.3` removed — while the `erddap` extra (in `all`) requires `erddapy>=3.0`. |
-| `osm-pbf` | `pyrosm` | `pyrosm` ships no prebuilt wheel for current Python and must compile from source (a heavy C/C++ build), so it is kept out of the one-shot union. |
+| `osm-pbf` | `pyrosm` | `pyrosm` (0.11) and `osmium` (4.3.1) both ship wheels, but `pyrosm` pulls the **sdist-only** `cykhash` (no wheels for any Python), so adding `osm-pbf` to `all` would make `pip install earthlens[all]` require a C compiler — it is kept out to keep `all` wheel-only. Reconsidered in #783. |
 
 (`osm` itself **is** in `all` — see the resolution note below for why.)
 
@@ -159,7 +159,7 @@ Each still installs **on its own**, in a separate environment:
 
 ```bash
 pip install earthlens[argo]      # its own env — pulls xarray>=2025.7
-pip install earthlens[osm-pbf]   # compiles pyrosm from source
+pip install earthlens[osm-pbf]   # builds cykhash (a pyrosm dep) from source — needs a C compiler
 ```
 
 > **What an `all` install actually resolves to.** With `argo` out,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -151,7 +151,7 @@ one environment** — that is every extra in the table above **except two**:
 | Excluded | SDK | Why it can't join `all` |
 |---|---|---|
 | `argo` | `argopy` | **Two** independent problems, either one disqualifying. **(1) `xarray` — a resolution conflict:** `argopy >=1.4` needs `xarray>=2025.7`, but `openeo` (in `all`) caps `xarray<2025.01.2` — disjoint ranges, which is what `[tool.uv] conflicts` declares. **(2) `erddapy` — a runtime break:** `argopy 1.4.0` still *resolves* (it does not cap `erddapy`) but fails at `import` — it imports `erddapy.erddapy._quote_string_constraints`, which `erddapy 3.3` removed — while the `erddap` extra (in `all`) requires `erddapy>=3.0`. |
-| `osm-pbf` | `pyrosm` | `pyrosm` (0.11) and `osmium` (4.3.1) both ship wheels, but `pyrosm` pulls the **sdist-only** `cykhash` (no wheels for any Python), so adding `osm-pbf` to `all` would make `pip install earthlens[all]` require a C compiler — it is kept out to keep `all` wheel-only. Reconsidered in #783. |
+| `osm-pbf` | `pyrosm` | `pyrosm` (0.11) and `osmium` (4.3.1) both ship wheels, but `pyrosm` pulls the **sdist-only** `cykhash` (no wheels for any Python), so adding `osm-pbf` to `all` would make `pip install earthlens[all]` require a C compiler — it is kept out to keep `all` wheel-only. Tracked in #783. |
 
 (`osm` itself **is** in `all` — see the resolution note below for why.)
 

--- a/docs/reference/osm/introduction.md
+++ b/docs/reference/osm/introduction.md
@@ -84,8 +84,8 @@ two extras and are imported lazily, so the package imports fine without them:
 - `pip install earthlens[osm]` → `overpy` + `ohsome` (the live protocols).
 - `pip install earthlens[osm-pbf]` → `pyrosm` + `osmium` (the `pbf` protocol).
   Note `pyosmium` is published on PyPI as `osmium`. This extra is **not** part
-  of `[all]` (it is heavy, and `pyrosm` builds a compiled dependency from
-  source), so install it explicitly for bulk PBF work.
+  of `[all]` because `pyrosm` pulls the sdist-only `cykhash` (it would need a C
+  compiler), so install it explicitly for bulk PBF work.
 
 !!! note "Overpass needs a real User-Agent"
     The canonical `overpass-api.de` endpoint returns HTTP 406 to requests with

--- a/docs/reference/osm/usage.md
+++ b/docs/reference/osm/usage.md
@@ -14,8 +14,8 @@ pip install earthlens[osm]      # overpy + ohsome  (Overpass + ohsome protocols)
 pip install earthlens[osm-pbf]  # pyrosm + osmium  (the pbf protocol)
 ```
 
-`[osm-pbf]` is **not** in `[all]` (it is heavy, and `pyrosm` builds a compiled
-dependency from source), so install it explicitly for bulk PBF work. Note
+`[osm-pbf]` is **not** in `[all]` because `pyrosm` pulls the sdist-only `cykhash`
+(it would need a C compiler), so install it explicitly for bulk PBF work. Note
 `pyosmium` is published on PyPI as `osmium`. There are no credentials to
 configure — Overpass, ohsome, and Geofabrik are all public.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ worldpop = ["earthlens-land[worldpop]"]
 
 # The self-referential "everything" extra: each entry re-activates one backend's
 # own extra on earthlens itself. `argo` (xarray clash with openeo -- see #789)
-# and `osm-pbf` (pyrosm builds from source) stay out; `osm` is included because
+# and `osm-pbf` (pyrosm's transitive cykhash dep is sdist-only) stay out; `osm` is included because
 # openeo already pins pandas<3, so ohsome's pandas<3 no longer collides.
 all = [
     "earthlens[asf]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,9 @@ worldpop = ["earthlens-land[worldpop]"]
 
 # The self-referential "everything" extra: each entry re-activates one backend's
 # own extra on earthlens itself. `argo` (xarray clash with openeo -- see #789)
-# and `osm-pbf` (pyrosm's transitive cykhash dep is sdist-only) stay out; `osm` is included because
-# openeo already pins pandas<3, so ohsome's pandas<3 no longer collides.
+# and `osm-pbf` (pyrosm's transitive cykhash dep is sdist-only) stay out; `osm`
+# is included because openeo already pins pandas<3, so ohsome's pandas<3 no
+# longer collides.
 all = [
     "earthlens[asf]",
     "earthlens[cmems]",


### PR DESCRIPTION
# Description

Two areas of maintenance on this branch.

**1. Docs — correct the `osm-pbf` exclusion reason.** The `earthlens[all]` exclusions table (shipped in #788)
said `osm-pbf` is excluded because *"pyrosm ships no prebuilt wheel."* That is inaccurate — `pyrosm 0.11.0` **and**
`osmium 4.3.1` both ship wheels (cp310–cp314). The actual sdist-only dependency is pyrosm's transitive
**`cykhash 2.0.1`** (0 wheels), so the real reason is to keep `pip install earthlens[all]` **wheel-only** (no C
compiler). Fixes the table row + the "install on its own" snippet in `docs/installation.md`.

**2. CI — pin the composite actions to specific versions and adopt their new inputs.** The workflows used the
moving `@<action>/v1` major tags; pin each to a specific version and take the inputs the actions have added since:

| Action | Pin | New input adopted |
|---|---|---|
| `release/github` | `@github-release/v1.4.0` | `package-manager-version` |
| `python-setup/uv` (×12) | `@uv/v1.2.0` | `version` |
| `mkdocs-deploy` (×3) | `@mkdocs/v1.3.0` | `package-manager-version` |
| `release/pypi` | `@pypi-release/v1.0.2` | *(none added)* |

The uv the actions install is pinned to **`0.11.29`** (the current latest, which CI already ran on via the
`latest` default) so releases and CI are reproducible. `release/pypi` gets only the version pin — it defines no
`package-manager-version` / `version` input, so none is passed there.

**Also drop the two redundant lock-sync steps** in `github-release.yml`: `release/github@v1.4.0` folds the
refreshed lockfile into the tagged version-bump commit (serapeum-org/github-actions#15), so re-locking and pushing
a second commit afterward is duplicate work.

No code, config, or lock changes — docs + CI-workflow only.

# Issues

- Closes #794 — correct the osm-pbf exclusion reason
- Closes #795 — adopt the release action's lockfile fold (now via the pinned `@github-release/v1.4.0`) and drop the
  redundant steps
- Refs #783 — the doc fix corrects the exclusion *reason*; the decision to add `osm-pbf` to `all` stays open there
- Refs serapeum-org/github-actions#14, #15 — the composite-action lockfile-fold this adopts

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — a docs accuracy fix plus a CI cleanup.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] **Docs**: verified on PyPI that `pyrosm 0.11.0` / `osmium 4.3.1` ship wheels (cp310–cp314) and `cykhash 2.0.1`
      is sdist-only (0 wheels).
- [x] **Action pins**: each `@<action>/v1` already pointed at the version now pinned (v1.4.0 / v1.2.0 / v1.3.0 /
      v1.0.2), so CI already runs on these; diffed every action's inputs against each workflow's `with:` block —
      all keys still exist and all required inputs are supplied (no API break).
- [x] All six workflow files re-parse as valid YAML; docs + workflow YAML only, no code paths or tests affected.

# Checklist:

- [ ] updated version number in pyproject.toml. *(N/A.)*
- [ ] added changes to docs/change-log.md. *(N/A.)*
- [ ] updated the latest version in README file. *(N/A.)*
- [ ] I have added tests that prove my fix is effective or that my feature works. *(N/A — docs + CI only.)*
- [x] New and existing unit tests pass locally with my changes. *(Unchanged — no code touched.)*
- [x] documentation are updated. *(docs/installation.md.)*
