### PR TITLE
fix(stac): scope the anonymous S3 endpoint pin to the regions that need it

### DIFF
--- a/libs/providers/imagery/src/earthlens/stac/signers.py
+++ b/libs/providers/imagery/src/earthlens/stac/signers.py
@@ -832,6 +832,26 @@ class _AnonymousS3Signer:
         Returns:
             dict[str, str]: `{"AWS_NO_SIGN_REQUEST": "YES"}`, plus `AWS_REGION`
             and `AWS_S3_ENDPOINT` when a region is set.
+
+        Examples:
+            - An endpoint with no region emits only the no-sign flag:
+                ```python
+                >>> from earthlens.stac.signers import build_signer
+                >>> build_signer("anonymous").gdal_env()
+                {'AWS_NO_SIGN_REQUEST': 'YES'}
+
+                ```
+            - A region also pins GDAL at that region's S3 endpoint, so an
+              opt-in-region bucket is reached instead of rejected:
+                ```python
+                >>> from earthlens.stac.signers import build_signer
+                >>> env = build_signer("anonymous", region="us-west-2").gdal_env()
+                >>> env["AWS_REGION"]
+                'us-west-2'
+                >>> env["AWS_S3_ENDPOINT"]
+                's3.us-west-2.amazonaws.com'
+
+                ```
         """
         env = {"AWS_NO_SIGN_REQUEST": "YES"}
         if self._region:

--- a/libs/providers/imagery/src/earthlens/stac/signers.py
+++ b/libs/providers/imagery/src/earthlens/stac/signers.py
@@ -739,6 +739,80 @@ class BdcTokenSigner(_BaseSigner):
         )
 
 
+#: AWS **opt-in** regions (disabled by default). What matters here: their S3
+#: service *rejects* a request sent to the global `<bucket>.s3.amazonaws.com`
+#: endpoint with `IllegalLocationConstraintException` instead of redirecting it,
+#: so a public bucket in one of these regions is only reachable by naming the
+#: region's endpoint explicitly. Standard (enabled-by-default) regions redirect
+#: normally and are deliberately left unpinned — see `_region_needs_endpoint`.
+_OPT_IN_REGIONS = frozenset(
+    {
+        "af-south-1",
+        "ap-east-1",
+        "ap-east-2",
+        "ap-south-2",
+        "ap-southeast-3",
+        "ap-southeast-4",
+        "ap-southeast-5",
+        "ap-southeast-7",
+        "ca-west-1",
+        "eu-central-2",
+        "eu-south-1",
+        "eu-south-2",
+        "il-central-1",
+        "me-central-1",
+        "me-south-1",
+        "mx-central-1",
+    }
+)
+
+
+def _region_needs_endpoint(region: str) -> bool:
+    """Return whether a region must be reached at its own S3 endpoint.
+
+    True for an AWS opt-in region (the global endpoint rejects it, see
+    :data:`_OPT_IN_REGIONS`) and for any China-partition region (`cn-*`, whose
+    buckets the global `amazonaws.com` endpoint cannot reach at all). Standard
+    regions return False: the global endpoint redirects to them, so leaving them
+    unpinned keeps cross-region reads working for an endpoint that federates
+    buckets across regions (e.g. earth-search serving Copernicus DEM from
+    `eu-central-1` while its catalog region is `us-west-2`). GovCloud (`us-gov-*`)
+    is standard-TLD and needs no special case; the air-gapped ISO partitions
+    (`us-iso-*` / `us-isob-*`) are intentionally out of scope — they host no
+    public/anonymous STAC bucket.
+
+    Args:
+        region: An AWS region code (e.g. `"af-south-1"`, `"us-west-2"`).
+
+    Returns:
+        True when the region needs an explicit `AWS_S3_ENDPOINT`, else False.
+
+    Examples:
+        - An opt-in region needs its own endpoint:
+            ```python
+            >>> from earthlens.stac.signers import _region_needs_endpoint
+            >>> _region_needs_endpoint("af-south-1")
+            True
+
+            ```
+        - A standard region does not (the global endpoint redirects to it):
+            ```python
+            >>> from earthlens.stac.signers import _region_needs_endpoint
+            >>> _region_needs_endpoint("us-west-2")
+            False
+
+            ```
+        - A China-partition region needs its own endpoint:
+            ```python
+            >>> from earthlens.stac.signers import _region_needs_endpoint
+            >>> _region_needs_endpoint("cn-north-1")
+            True
+
+            ```
+    """
+    return region in _OPT_IN_REGIONS or region.startswith("cn-")
+
+
 class _AnonymousS3Signer:
     """Anonymous signer that also tells GDAL not to sign its S3 reads.
 
@@ -755,26 +829,31 @@ class _AnonymousS3Signer:
     the only kind that can succeed. Requester-pays keeps its own signer, which
     contributes real credentials plus `AWS_REQUEST_PAYER`, and is untouched.
 
-    When the endpoint declares a `region`, the signer pins GDAL at that region's
-    S3 endpoint (`AWS_REGION` + `AWS_S3_ENDPOINT=s3.<region>.amazonaws.com`), so
-    a `/vsis3/` read lands at `<bucket>.s3.<region>.amazonaws.com` rather than
-    the default global `<bucket>.s3.amazonaws.com`. This is **required** for a
-    bucket in an **opt-in** region (e.g. Digital Earth Africa on `af-south-1`),
-    which rejects the global endpoint with `IllegalLocationConstraintException`
-    ("the <region> location constraint is incompatible for the region specific
-    endpoint this request was sent to"). For a standard-region bucket the pin is
-    merely the canonical (redirect-free) endpoint, and for an HTTPS asset read
-    through `/vsicurl/` it is a no-op (the URL host is used directly). The pin
-    therefore fires for **every** anonymous endpoint that carries a `region`
-    (`deafrica`, `dea`, `earth-search`, `veda`), not only the opt-in one — each
-    serves single-region assets, so pinning the catalog region is correct. The
-    region comes from the catalog endpoint's `region:` field, threaded through
-    `build_signer`; when it is `None` (a regionless HTTPS-asset endpoint such as
-    the Brazil Data Cube) only the no-sign flag is emitted.
+    When the endpoint declares a `region` that **needs** its own S3 endpoint
+    (see :func:`_region_needs_endpoint`), the signer pins GDAL there
+    (`AWS_REGION` + `AWS_S3_ENDPOINT=s3.<region>.amazonaws.com`), so a `/vsis3/`
+    read lands at `<bucket>.s3.<region>.amazonaws.com` rather than the default
+    global `<bucket>.s3.amazonaws.com`. This is **required** for a bucket in an
+    **opt-in** region (e.g. Digital Earth Africa on `af-south-1`), which rejects
+    the global endpoint with `IllegalLocationConstraintException` ("the <region>
+    location constraint is incompatible for the region specific endpoint this
+    request was sent to"), and for the China partition (`cn-*`).
+
+    A **standard** region (e.g. `us-west-2`, `ap-southeast-2`) is deliberately
+    **left unpinned**: the global endpoint redirects to it, and pinning would be
+    wrong for an endpoint that federates buckets across regions — `earth-search`
+    is pinned by the catalog to `us-west-2` yet serves its `cop-dem-glo-90`
+    assets from an `eu-central-1` bucket, so a hard endpoint pin would send those
+    reads to the wrong region. Leaving standard regions unpinned keeps GDAL's
+    region redirect handling that case. The region comes from the catalog
+    endpoint's `region:` field, threaded through `build_signer`; when it is
+    `None`, a standard region, or an HTTPS `/vsicurl/` asset read, only the
+    no-sign flag is emitted.
 
     Args:
         region: AWS region of the endpoint's public bucket, or `None` when the
-            endpoint's assets are not region-bound S3 objects.
+            endpoint's assets are not region-bound S3 objects. Only an opt-in or
+            `cn-*` region triggers the endpoint pin.
 
     Examples:
         - The GDAL config opts out of request signing:
@@ -819,11 +898,13 @@ class _AnonymousS3Signer:
     def gdal_env(self) -> dict[str, str]:
         """Return the GDAL config for unsigned public-bucket reads.
 
-        Always emits `AWS_NO_SIGN_REQUEST=YES`. When the signer carries a
-        `region`, it additionally emits `AWS_REGION` and
-        `AWS_S3_ENDPOINT=s3.<region>.amazonaws.com` so a bucket in an opt-in
-        region is reached at its region-specific endpoint rather than the
-        global one it would otherwise reject.
+        Always emits `AWS_NO_SIGN_REQUEST=YES`. When the signer carries a region
+        that needs its own endpoint (opt-in or `cn-*`; see
+        :func:`_region_needs_endpoint`), it additionally emits `AWS_REGION` and
+        `AWS_S3_ENDPOINT=s3.<region>.amazonaws.com` so a bucket the global
+        endpoint would reject is reached at its region-specific endpoint. A
+        standard region emits only the no-sign flag, leaving GDAL's redirect to
+        find the bucket's region (correct for cross-region endpoints).
 
         Deliberately nothing more. Copying the requester-pays signer's
         `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR` and
@@ -835,7 +916,7 @@ class _AnonymousS3Signer:
 
         Returns:
             dict[str, str]: `{"AWS_NO_SIGN_REQUEST": "YES"}`, plus `AWS_REGION`
-            and `AWS_S3_ENDPOINT` when a region is set.
+            and `AWS_S3_ENDPOINT` when the region needs an explicit endpoint.
 
         Examples:
             - An endpoint with no region emits only the no-sign flag:
@@ -845,20 +926,27 @@ class _AnonymousS3Signer:
                 {'AWS_NO_SIGN_REQUEST': 'YES'}
 
                 ```
-            - A region also pins GDAL at that region's S3 endpoint, so an
-              opt-in-region bucket is reached instead of rejected:
+            - An opt-in region pins GDAL at that region's S3 endpoint, so a
+              bucket the global endpoint would reject is reached instead:
                 ```python
                 >>> from earthlens.stac.signers import build_signer
-                >>> env = build_signer("anonymous", region="us-west-2").gdal_env()
+                >>> env = build_signer("anonymous", region="af-south-1").gdal_env()
                 >>> env["AWS_REGION"]
-                'us-west-2'
+                'af-south-1'
                 >>> env["AWS_S3_ENDPOINT"]
-                's3.us-west-2.amazonaws.com'
+                's3.af-south-1.amazonaws.com'
+
+                ```
+            - A standard region is left unpinned (GDAL redirects to the bucket):
+                ```python
+                >>> from earthlens.stac.signers import build_signer
+                >>> build_signer("anonymous", region="us-west-2").gdal_env()
+                {'AWS_NO_SIGN_REQUEST': 'YES'}
 
                 ```
         """
         env = {"AWS_NO_SIGN_REQUEST": "YES"}
-        if self._region:
+        if self._region and _region_needs_endpoint(self._region):
             env["AWS_REGION"] = self._region
             # China regions live in a separate AWS partition whose S3 hosts end
             # in `.amazonaws.com.cn`; every other region uses `.amazonaws.com`.

--- a/libs/providers/imagery/src/earthlens/stac/signers.py
+++ b/libs/providers/imagery/src/earthlens/stac/signers.py
@@ -860,7 +860,14 @@ class _AnonymousS3Signer:
         env = {"AWS_NO_SIGN_REQUEST": "YES"}
         if self._region:
             env["AWS_REGION"] = self._region
-            env["AWS_S3_ENDPOINT"] = f"s3.{self._region}.amazonaws.com"
+            # China regions live in a separate AWS partition whose S3 hosts end
+            # in `.amazonaws.com.cn`; every other region uses `.amazonaws.com`.
+            tld = (
+                "amazonaws.com.cn"
+                if self._region.startswith("cn-")
+                else "amazonaws.com"
+            )
+            env["AWS_S3_ENDPOINT"] = f"s3.{self._region}.{tld}"
         return env
 
     def sign_request(self, request: Any) -> Any:

--- a/libs/providers/imagery/src/earthlens/stac/signers.py
+++ b/libs/providers/imagery/src/earthlens/stac/signers.py
@@ -755,18 +755,22 @@ class _AnonymousS3Signer:
     the only kind that can succeed. Requester-pays keeps its own signer, which
     contributes real credentials plus `AWS_REQUEST_PAYER`, and is untouched.
 
-    An anonymous bucket in an **opt-in** AWS region (e.g. Digital Earth Africa
-    on `af-south-1`) needs more than the no-sign flag: GDAL's default
-    virtual-hosted endpoint is the *global* `<bucket>.s3.amazonaws.com`, which
-    an opt-in bucket rejects with `IllegalLocationConstraintException` ("the
-    <region> location constraint is incompatible for the region specific
-    endpoint this request was sent to"). Passing the endpoint's `region` makes
-    the signer point GDAL at that region's endpoint (`AWS_REGION` +
-    `AWS_S3_ENDPOINT=s3.<region>.amazonaws.com`), so the request lands at
-    `<bucket>.s3.<region>.amazonaws.com`. The region comes from the catalog
-    endpoint's `region:` field, threaded through `build_signer`; when it is
-    `None` (an HTTPS-asset endpoint such as the Brazil Data Cube) only the
-    no-sign flag is emitted.
+    When the endpoint declares a `region`, the signer pins GDAL at that region's
+    S3 endpoint (`AWS_REGION` + `AWS_S3_ENDPOINT=s3.<region>.amazonaws.com`), so
+    a `/vsis3/` read lands at `<bucket>.s3.<region>.amazonaws.com` rather than
+    the default global `<bucket>.s3.amazonaws.com`. This is **required** for a
+    bucket in an **opt-in** region (e.g. Digital Earth Africa on `af-south-1`),
+    which rejects the global endpoint with `IllegalLocationConstraintException`
+    ("the <region> location constraint is incompatible for the region specific
+    endpoint this request was sent to"). For a standard-region bucket the pin is
+    merely the canonical (redirect-free) endpoint, and for an HTTPS asset read
+    through `/vsicurl/` it is a no-op (the URL host is used directly). The pin
+    therefore fires for **every** anonymous endpoint that carries a `region`
+    (`deafrica`, `dea`, `earth-search`, `veda`), not only the opt-in one — each
+    serves single-region assets, so pinning the catalog region is correct. The
+    region comes from the catalog endpoint's `region:` field, threaded through
+    `build_signer`; when it is `None` (a regionless HTTPS-asset endpoint such as
+    the Brazil Data Cube) only the no-sign flag is emitted.
 
     Args:
         region: AWS region of the endpoint's public bucket, or `None` when the

--- a/libs/providers/imagery/src/earthlens/stac/signers.py
+++ b/libs/providers/imagery/src/earthlens/stac/signers.py
@@ -755,12 +755,37 @@ class _AnonymousS3Signer:
     the only kind that can succeed. Requester-pays keeps its own signer, which
     contributes real credentials plus `AWS_REQUEST_PAYER`, and is untouched.
 
+    An anonymous bucket in an **opt-in** AWS region (e.g. Digital Earth Africa
+    on `af-south-1`) needs more than the no-sign flag: GDAL's default
+    virtual-hosted endpoint is the *global* `<bucket>.s3.amazonaws.com`, which
+    an opt-in bucket rejects with `IllegalLocationConstraintException` ("the
+    <region> location constraint is incompatible for the region specific
+    endpoint this request was sent to"). Passing the endpoint's `region` makes
+    the signer point GDAL at that region's endpoint (`AWS_REGION` +
+    `AWS_S3_ENDPOINT=s3.<region>.amazonaws.com`), so the request lands at
+    `<bucket>.s3.<region>.amazonaws.com`. The region comes from the catalog
+    endpoint's `region:` field, threaded through `build_signer`; when it is
+    `None` (an HTTPS-asset endpoint such as the Brazil Data Cube) only the
+    no-sign flag is emitted.
+
+    Args:
+        region: AWS region of the endpoint's public bucket, or `None` when the
+            endpoint's assets are not region-bound S3 objects.
+
     Examples:
         - The GDAL config opts out of request signing:
             ```python
             >>> from earthlens.stac.signers import build_signer
             >>> build_signer("anonymous").gdal_env()["AWS_NO_SIGN_REQUEST"]
             'YES'
+
+            ```
+        - A region-bound endpoint also pins GDAL to that region's S3 endpoint:
+            ```python
+            >>> from earthlens.stac.signers import build_signer
+            >>> env = build_signer("anonymous", region="af-south-1").gdal_env()
+            >>> env["AWS_REGION"], env["AWS_S3_ENDPOINT"]
+            ('af-south-1', 's3.af-south-1.amazonaws.com')
 
             ```
         - Signing a request or an href is still a no-op — nothing to add:
@@ -777,10 +802,26 @@ class _AnonymousS3Signer:
     #: signers' own attribute, so `_signer_for` logging reads the same.
     name: str = "anonymous"
 
+    def __init__(self, region: str | None = None) -> None:
+        """Store the endpoint's bucket region (or `None` for non-S3 assets).
+
+        Args:
+            region: AWS region of the anonymous bucket, used to pin GDAL at the
+                region's S3 endpoint. `None` leaves the endpoint at GDAL's
+                default (correct for HTTPS-asset endpoints).
+        """
+        self._region = region
+
     def gdal_env(self) -> dict[str, str]:
         """Return the GDAL config for unsigned public-bucket reads.
 
-        Deliberately just the one option. Copying the requester-pays signer's
+        Always emits `AWS_NO_SIGN_REQUEST=YES`. When the signer carries a
+        `region`, it additionally emits `AWS_REGION` and
+        `AWS_S3_ENDPOINT=s3.<region>.amazonaws.com` so a bucket in an opt-in
+        region is reached at its region-specific endpoint rather than the
+        global one it would otherwise reject.
+
+        Deliberately nothing more. Copying the requester-pays signer's
         `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR` and
         `CPL_VSIL_CURL_USE_HEAD=NO` alongside it would apply to *every*
         anonymous endpoint — the catalog default, so most of them — and
@@ -789,9 +830,14 @@ class _AnonymousS3Signer:
         for requester-pays, not part of not signing a request.
 
         Returns:
-            dict[str, str]: `{"AWS_NO_SIGN_REQUEST": "YES"}`.
+            dict[str, str]: `{"AWS_NO_SIGN_REQUEST": "YES"}`, plus `AWS_REGION`
+            and `AWS_S3_ENDPOINT` when a region is set.
         """
-        return {"AWS_NO_SIGN_REQUEST": "YES"}
+        env = {"AWS_NO_SIGN_REQUEST": "YES"}
+        if self._region:
+            env["AWS_REGION"] = self._region
+            env["AWS_S3_ENDPOINT"] = f"s3.{self._region}.amazonaws.com"
+        return env
 
     def sign_request(self, request: Any) -> Any:
         """Return `request` unchanged — an anonymous search needs no signing.
@@ -830,16 +876,18 @@ class _AnonymousS3Signer:
 def build_signer(signer_type: str, **creds: Any) -> Any:
     """Build the signer named by a catalog `signer:` field.
 
-    The `anonymous` / `aws-requester-pays` signers come from `pyramids.stac`
-    (imported lazily so the package imports without the `[stac]` extra); the
-    `mpc-sas` / `earthdata` / `cdse` / `cdse-s3` / `bdc-token` provider signers
-    are the earthlens-local classes above.
+    The `anonymous` signer is the earthlens-local `_AnonymousS3Signer` and the
+    `aws-requester-pays` signer comes from `pyramids.stac` (imported lazily so
+    the package imports without the `[stac]` extra); the `mpc-sas` /
+    `earthdata` / `cdse` / `cdse-s3` / `bdc-token` provider signers are the
+    earthlens-local classes above.
 
     Args:
         signer_type: One of `"anonymous"`, `"aws-requester-pays"`, `"mpc-sas"`,
             `"earthdata"`, `"cdse"`, `"cdse-s3"`, `"bdc-token"`.
         **creds: Extra credentials forwarded to the selected signer — `region`
-            for `aws-requester-pays`; `username` / `password` / `token` for
+            for `anonymous` (pins GDAL at an opt-in region's S3 endpoint) and
+            `aws-requester-pays`; `username` / `password` / `token` for
             `earthdata`; `username` / `password` / `client_id` for `cdse`; the
             CDSE S3 credential resolution kwargs for `cdse-s3` (see
             `auth_cdse.s3_credentials`); `token` for `bdc-token` (defaults to
@@ -884,7 +932,7 @@ def build_signer(signer_type: str, **creds: Any) -> Any:
             ```
     """
     if signer_type == "anonymous":
-        return _AnonymousS3Signer()
+        return _AnonymousS3Signer(region=creds.get("region"))
     if signer_type == "aws-requester-pays":
         from pyramids.stac import AWSRequesterPaysSigner
 

--- a/libs/providers/imagery/tests/stac/test_signers.py
+++ b/libs/providers/imagery/tests/stac/test_signers.py
@@ -469,15 +469,15 @@ class TestAnonymousS3Signer:
 class TestBuildSigner:
     """`build_signer` dispatches a catalog signer name to the right object."""
 
-    def test_anonymous(self, fake_pyramids):
-        """The anonymous name resolves to the pyramids AnonymousSigner."""
+    def test_anonymous(self):
+        """The anonymous name resolves to the local _AnonymousS3Signer."""
         assert build_signer("anonymous").name == "anonymous"
 
-    def test_anonymous_no_region_gdal_env_is_no_sign_only(self, fake_pyramids):
+    def test_anonymous_no_region_gdal_env_is_no_sign_only(self):
         """Without a region the anonymous signer emits only the no-sign flag."""
         assert build_signer("anonymous").gdal_env() == {"AWS_NO_SIGN_REQUEST": "YES"}
 
-    def test_anonymous_forwards_region_to_gdal_env(self, fake_pyramids):
+    def test_anonymous_forwards_region_to_gdal_env(self):
         """A region pins GDAL at that region's S3 endpoint (opt-in regions need this)."""
         env = build_signer("anonymous", region="af-south-1").gdal_env()
         assert env == {
@@ -486,7 +486,7 @@ class TestBuildSigner:
             "AWS_S3_ENDPOINT": "s3.af-south-1.amazonaws.com",
         }
 
-    def test_anonymous_ignores_unrelated_creds(self, fake_pyramids):
+    def test_anonymous_ignores_unrelated_creds(self):
         """The anonymous branch uses only region and drops the other backend kwargs."""
         env = build_signer(
             "anonymous", region="us-west-2", access_key="ak", secret_key="sk"

--- a/libs/providers/imagery/tests/stac/test_signers.py
+++ b/libs/providers/imagery/tests/stac/test_signers.py
@@ -430,22 +430,28 @@ class TestAnonymousS3Signer:
         """An empty-string region is falsy, so no region keys are added."""
         assert _AnonymousS3Signer("").gdal_env() == {"AWS_NO_SIGN_REQUEST": "YES"}
 
-    @pytest.mark.parametrize("region", ["af-south-1", "ap-southeast-2", "us-west-2"])
-    def test_gdal_env_with_region_pins_regional_endpoint(self, region):
-        """A region adds AWS_REGION and the matching regional S3 endpoint."""
+    @pytest.mark.parametrize("region", ["af-south-1", "eu-south-1", "me-south-1"])
+    def test_gdal_env_opt_in_region_pins_regional_endpoint(self, region):
+        """An opt-in region adds AWS_REGION and its regional S3 endpoint."""
         assert _AnonymousS3Signer(region).gdal_env() == {
             "AWS_NO_SIGN_REQUEST": "YES",
             "AWS_REGION": region,
             "AWS_S3_ENDPOINT": f"s3.{region}.amazonaws.com",
         }
 
+    @pytest.mark.parametrize("region", ["us-west-2", "ap-southeast-2", "eu-central-1"])
+    def test_gdal_env_standard_region_is_not_pinned(self, region):
+        """A standard region emits only the no-sign flag so GDAL can redirect."""
+        assert _AnonymousS3Signer(region).gdal_env() == {"AWS_NO_SIGN_REQUEST": "YES"}
+
     @pytest.mark.parametrize("region", ["cn-north-1", "cn-northwest-1"])
     def test_gdal_env_china_region_uses_cn_partition_endpoint(self, region):
-        """A China region resolves to the .amazonaws.com.cn partition host."""
-        assert (
-            _AnonymousS3Signer(region).gdal_env()["AWS_S3_ENDPOINT"]
-            == f"s3.{region}.amazonaws.com.cn"
-        )
+        """A China region pins the .amazonaws.com.cn partition host."""
+        assert _AnonymousS3Signer(region).gdal_env() == {
+            "AWS_NO_SIGN_REQUEST": "YES",
+            "AWS_REGION": region,
+            "AWS_S3_ENDPOINT": f"s3.{region}.amazonaws.com.cn",
+        }
 
     def test_sign_request_returns_same_object(self):
         """An anonymous search needs no signing, so the request is unchanged."""
@@ -489,12 +495,12 @@ class TestBuildSigner:
     def test_anonymous_ignores_unrelated_creds(self):
         """The anonymous branch uses only region and drops the other backend kwargs."""
         env = build_signer(
-            "anonymous", region="us-west-2", access_key="ak", secret_key="sk"
+            "anonymous", region="af-south-1", access_key="ak", secret_key="sk"
         ).gdal_env()
         assert env == {
             "AWS_NO_SIGN_REQUEST": "YES",
-            "AWS_REGION": "us-west-2",
-            "AWS_S3_ENDPOINT": "s3.us-west-2.amazonaws.com",
+            "AWS_REGION": "af-south-1",
+            "AWS_S3_ENDPOINT": "s3.af-south-1.amazonaws.com",
         }
 
     def test_aws_requester_pays_forwards_region(self, fake_pyramids):

--- a/libs/providers/imagery/tests/stac/test_signers.py
+++ b/libs/providers/imagery/tests/stac/test_signers.py
@@ -413,6 +413,19 @@ class TestBuildSigner:
         """The anonymous name resolves to the pyramids AnonymousSigner."""
         assert build_signer("anonymous").name == "anonymous"
 
+    def test_anonymous_no_region_gdal_env_is_no_sign_only(self, fake_pyramids):
+        """Without a region the anonymous signer emits only the no-sign flag."""
+        assert build_signer("anonymous").gdal_env() == {"AWS_NO_SIGN_REQUEST": "YES"}
+
+    def test_anonymous_forwards_region_to_gdal_env(self, fake_pyramids):
+        """A region pins GDAL at that region's S3 endpoint (opt-in regions need this)."""
+        env = build_signer("anonymous", region="af-south-1").gdal_env()
+        assert env == {
+            "AWS_NO_SIGN_REQUEST": "YES",
+            "AWS_REGION": "af-south-1",
+            "AWS_S3_ENDPOINT": "s3.af-south-1.amazonaws.com",
+        }
+
     def test_aws_requester_pays_forwards_region(self, fake_pyramids):
         """The requester-pays name resolves to the pyramids signer with the region."""
         signer = build_signer("aws-requester-pays", region="us-west-2")

--- a/libs/providers/imagery/tests/stac/test_signers.py
+++ b/libs/providers/imagery/tests/stac/test_signers.py
@@ -439,6 +439,14 @@ class TestAnonymousS3Signer:
             "AWS_S3_ENDPOINT": f"s3.{region}.amazonaws.com",
         }
 
+    @pytest.mark.parametrize("region", ["cn-north-1", "cn-northwest-1"])
+    def test_gdal_env_china_region_uses_cn_partition_endpoint(self, region):
+        """A China region resolves to the .amazonaws.com.cn partition host."""
+        assert (
+            _AnonymousS3Signer(region).gdal_env()["AWS_S3_ENDPOINT"]
+            == f"s3.{region}.amazonaws.com.cn"
+        )
+
     def test_sign_request_returns_same_object(self):
         """An anonymous search needs no signing, so the request is unchanged."""
         request = object()

--- a/libs/providers/imagery/tests/stac/test_signers.py
+++ b/libs/providers/imagery/tests/stac/test_signers.py
@@ -18,6 +18,7 @@ from earthlens.stac.signers import (
     CDSESigner,
     EarthdataSigner,
     PlanetaryComputerSigner,
+    _AnonymousS3Signer,
     _BearerProviderSigner,
     build_signer,
 )
@@ -406,6 +407,57 @@ class TestBearerProviderSigner:
 
 
 @pytest.mark.stac
+class TestAnonymousS3Signer:
+    """`_AnonymousS3Signer` opts out of S3 signing and pins the region endpoint."""
+
+    def test_name_is_anonymous(self):
+        """The signer reports the anonymous catalog label."""
+        assert _AnonymousS3Signer().name == "anonymous"
+
+    def test_init_defaults_region_to_none(self):
+        """A signer built with no argument carries no region."""
+        assert _AnonymousS3Signer()._region is None
+
+    def test_init_stores_region(self):
+        """An explicit region is stored for gdal_env to use."""
+        assert _AnonymousS3Signer("af-south-1")._region == "af-south-1"
+
+    def test_gdal_env_without_region_is_no_sign_only(self):
+        """Without a region only the no-sign flag is emitted."""
+        assert _AnonymousS3Signer().gdal_env() == {"AWS_NO_SIGN_REQUEST": "YES"}
+
+    def test_gdal_env_empty_region_is_treated_as_none(self):
+        """An empty-string region is falsy, so no region keys are added."""
+        assert _AnonymousS3Signer("").gdal_env() == {"AWS_NO_SIGN_REQUEST": "YES"}
+
+    @pytest.mark.parametrize("region", ["af-south-1", "ap-southeast-2", "us-west-2"])
+    def test_gdal_env_with_region_pins_regional_endpoint(self, region):
+        """A region adds AWS_REGION and the matching regional S3 endpoint."""
+        assert _AnonymousS3Signer(region).gdal_env() == {
+            "AWS_NO_SIGN_REQUEST": "YES",
+            "AWS_REGION": region,
+            "AWS_S3_ENDPOINT": f"s3.{region}.amazonaws.com",
+        }
+
+    def test_sign_request_returns_same_object(self):
+        """An anonymous search needs no signing, so the request is unchanged."""
+        request = object()
+        assert _AnonymousS3Signer().sign_request(request) is request
+
+    def test_sign_href_passes_through(self):
+        """The credential is the absence of one, so the href is unchanged."""
+        assert (
+            _AnonymousS3Signer().sign_href("s3://bucket/key.tif")
+            == "s3://bucket/key.tif"
+        )
+
+    def test_sign_item_returns_same_object(self):
+        """Returned items are not rewritten by the anonymous signer."""
+        item = object()
+        assert _AnonymousS3Signer().sign_item(item) is item
+
+
+@pytest.mark.stac
 class TestBuildSigner:
     """`build_signer` dispatches a catalog signer name to the right object."""
 
@@ -424,6 +476,17 @@ class TestBuildSigner:
             "AWS_NO_SIGN_REQUEST": "YES",
             "AWS_REGION": "af-south-1",
             "AWS_S3_ENDPOINT": "s3.af-south-1.amazonaws.com",
+        }
+
+    def test_anonymous_ignores_unrelated_creds(self, fake_pyramids):
+        """The anonymous branch uses only region and drops the other backend kwargs."""
+        env = build_signer(
+            "anonymous", region="us-west-2", access_key="ak", secret_key="sk"
+        ).gdal_env()
+        assert env == {
+            "AWS_NO_SIGN_REQUEST": "YES",
+            "AWS_REGION": "us-west-2",
+            "AWS_S3_ENDPOINT": "s3.us-west-2.amazonaws.com",
         }
 
     def test_aws_requester_pays_forwards_region(self, fake_pyramids):


### PR DESCRIPTION
# Description

The STAC backend's anonymous S3 signer (`_AnonymousS3Signer`) emitted only `AWS_NO_SIGN_REQUEST=YES` and dropped
the endpoint's AWS region, so GDAL `/vsis3` reads went to the global `<bucket>.s3.amazonaws.com` endpoint. A bucket
in an **opt-in** AWS region (Digital Earth Africa on `af-south-1`) rejects that with
`IllegalLocationConstraintException`:

```
The af-south-1 location constraint is incompatible for the region specific endpoint this request was sent to.
```

which is exactly what the `e2e-stac` lane hit for DEAfrica.

`build_signer("anonymous", region=…)` now forwards the catalog endpoint's region, and `_AnonymousS3Signer.gdal_env()`
pins GDAL at the region's S3 endpoint (`AWS_REGION` + `AWS_S3_ENDPOINT=s3.<region>.amazonaws.com`, `.amazonaws.com.cn`
for the China partition) — **but only for regions that actually need it**: AWS opt-in regions (whose global endpoint
rejects rather than redirects) and `cn-*`. A **standard** region emits only the no-sign flag.

That scoping matters: `earth-search` is pinned by the catalog to `us-west-2` yet federates buckets across regions —
its `cop-dem-glo-90` assets are `s3://` objects in an `eu-central-1` bucket. Pinning a standard-region endpoint to
one region would force those cross-region reads to the wrong endpoint; leaving standard regions unpinned lets GDAL's
region redirect find the bucket. So only the opt-in endpoints that genuinely require it (DEAfrica) are pinned. A
regionless HTTPS-asset endpoint (Brazil Data Cube) and HTTPS `/vsicurl` reads are unaffected.

No catalog change was needed — the endpoints already declare `region:`; the bug was that the region never reached
GDAL and, once it did, that the pin was too broad. No new dependencies.

**Scope note:** #933 has been rescoped to the DEAfrica opt-in-region failure, which this PR fixes. The VEDA
`AccessDenied` originally filed in the same lane is a separate access-model problem (`s3://veda-data-store` denies
anonymous S3 outright; only the VEDA raster API is public) and is tracked independently in #938 — out of scope here.

# Issues

- Closes #933 — bug(stac): DEAfrica rejects the region on the S3 fetch (opt-in af-south-1)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- **End-to-end against real data** — built the anonymous signer through the changed code and applied its
  `gdal_env()`:
  - DEAfrica `wofs_ls` (opt-in `af-south-1`): unpinned reproduces `IllegalLocationConstraintException`; pinned reads
    the real COG (8131×6991). ✅
  - earth-search `cop-dem-glo-90` (standard `us-west-2`, cross-region `eu-central-1` bucket): reads unpinned via
    GDAL redirect (120×1200) — confirming the scoped pin does not break the federated endpoint. ✅
- **Unit tests** — `TestAnonymousS3Signer` (init, no-region/empty-region, opt-in pins, standard-not-pinned,
  cn-partition full-dict, sign_* no-ops) and `TestBuildSigner` region-forwarding / unrelated-creds cases; plus
  doctests on `_region_needs_endpoint` and `gdal_env`.
- **Regression** — full non-e2e STAC suite (`pytest tests/stac -m "not e2e"`) → 176 passed; `signers.py` 98%
  line+branch (only pre-existing locking asserts uncovered).
- Lint: `ruff check` + `ruff format --check` clean; `mypy` clean on `signers.py`.
- Reviewed over two `/review-rounds` passes; all findings resolved (endpoint-pin scoping, China-partition endpoint,
  docstring accuracy, test tidy-ups).

To reproduce the live verification:

```bash
uv run --locked pytest -m "stac and e2e" -k deafrica -v
```

- [x] Test A — DEAfrica live COG read via the changed signer (pinned)
- [x] Test B — earth-search cop-dem read via the changed signer (unpinned, cross-region), signer unit tests, doctests, full non-e2e STAC suite

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
