### PR TITLE
feat(bathymetry): add EMODnet Bathymetry as a WCS coverage on the bathymetry backend

### DIFF
--- a/docs/examples/bathymetry/07_emodnet_european_bathymetry.ipynb
+++ b/docs/examples/bathymetry/07_emodnet_european_bathymetry.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "0",
    "metadata": {},
    "source": [
     "# EMODnet Bathymetry — European high-resolution DTM (OGC WCS)\n",
@@ -16,6 +17,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1",
    "metadata": {},
    "source": [
     "## Setup\n",
@@ -27,6 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,6 +45,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## The EMODnet rows in the catalog\n",
@@ -54,6 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,6 +70,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Download an EMODnet subset over WCS\n",
@@ -77,6 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,6 +99,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Read and map the sea floor\n",
@@ -103,6 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,6 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,6 +148,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "10",
    "metadata": {},
    "source": [
     "## European coverage — when to reach for a global DEM\n",
@@ -152,6 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,6 +174,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Attribution\n",

--- a/docs/examples/bathymetry/07_emodnet_european_bathymetry.ipynb
+++ b/docs/examples/bathymetry/07_emodnet_european_bathymetry.ipynb
@@ -1,0 +1,189 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# EMODnet Bathymetry — European high-resolution DTM (OGC WCS)\n",
+    "\n",
+    "Fetch a small **EMODnet Bathymetry** Digital Terrain Model (DTM) subset over a\n",
+    "North Sea AOI, map the sea-floor depth, and see how the European DTM complements\n",
+    "the global GEBCO / ETOPO grids. Unlike the ERDDAP `griddap` DEMs, EMODnet is read\n",
+    "over **OGC WCS** through `pyramids.Dataset.from_wcs` — `earthlens` supplies only the\n",
+    "coverage id, AOI, CRS, and protocol version, and never touches a competing array\n",
+    "stack."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "`earthlens` provides the unified `EarthLens` entry point; `pyramids` reads the\n",
+    "written GeoTIFF; downloads go to a temporary directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from pyramids.dataset import Dataset\n",
+    "\n",
+    "from earthlens.bathymetry import Catalog\n",
+    "from earthlens.core import EarthLens"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The EMODnet rows in the catalog\n",
+    "\n",
+    "The `bathymetry` catalog carries the latest EMODnet release as `emodnet` plus\n",
+    "year-stamped older releases. Each is a `wcs`-transport row pointing at the EMODnet\n",
+    "Bathymetry OGC WCS. Reading the catalog is offline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog = Catalog()\n",
+    "for dataset_id in sorted(d for d in catalog.datasets if d.startswith('emodnet')):\n",
+    "    row = catalog.get(dataset_id)\n",
+    "    print(f'{dataset_id:14} transport={row.transport:4} coverage={row.dataset_id}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download an EMODnet subset over WCS\n",
+    "\n",
+    "Build the request — the `bathymetry` source, the `emodnet` dataset, and a small\n",
+    "North Sea AOI (`aoi` is `[min_lon, min_lat, max_lon, max_lat]`). `download()` issues\n",
+    "the WCS `GetCoverage`, crops to the AOI, and returns the written GeoTIFF path(s)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out = tempfile.mkdtemp()\n",
+    "paths = EarthLens(\n",
+    "    data_source='bathymetry',\n",
+    "    dataset='emodnet',\n",
+    "    aoi=[2.0, 53.0, 4.0, 55.0],\n",
+    "    path=out,\n",
+    ").download(progress_bar=False)\n",
+    "paths"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read and map the sea floor\n",
+    "\n",
+    "Read the GeoTIFF with `pyramids` and map the mean depth — every value in this\n",
+    "all-water AOI is below sea level, so the depths are negative (metres)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = Dataset.read_file(str(paths[0]))\n",
+    "arr = np.asarray(ds.read_array(), dtype='float32')\n",
+    "arr = arr[0] if arr.ndim == 3 else arr\n",
+    "print(\n",
+    "    'epsg',\n",
+    "    ds.epsg,\n",
+    "    '| shape',\n",
+    "    arr.shape,\n",
+    "    '| depth range',\n",
+    "    round(float(np.nanmin(arr))),\n",
+    "    '..',\n",
+    "    round(float(np.nanmax(arr))),\n",
+    "    'm',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6, 5))\n",
+    "plt.imshow(arr, cmap='Blues_r')\n",
+    "plt.colorbar(label='mean depth (m, negative = below sea level)')\n",
+    "plt.title('EMODnet Bathymetry DTM (~3.75″) — southern North Sea')\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## European coverage — when to reach for a global DEM\n",
+    "\n",
+    "EMODnet covers European seas and the extended NE-Atlantic domain, advertised as\n",
+    "the `native_bbox` below (`west, south, east, north`). A request whose bbox extends\n",
+    "beyond it warns that out-of-coverage cells come back as `0.0` fill, and a request\n",
+    "entirely outside raises — pointing you at the global `gebco_2020` / `etopo1_ice`\n",
+    "DEMs for those areas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row = catalog.get('emodnet')\n",
+    "print('coverage extent (W, S, E, N):', row.native_bbox)\n",
+    "print('for areas outside it, use dataset=\"gebco_2020\" or \"etopo1_ice\"')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Attribution\n",
+    "\n",
+    "- **EMODnet Bathymetry** — EMODnet Digital Bathymetry (DTM 2024), EMODnet\n",
+    "  Bathymetry Consortium (doi:10.12770/cf51df64-56f9-4a99-b1aa-36b8d7b743a1).\n",
+    "\n",
+    "Provided under the EMODnet use conditions (attribution required). A DEM is a static\n",
+    "grid with no time axis, so `download(aggregate=...)` is rejected."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/bathymetry/08_emodnet_wcs_deep_dive.ipynb
+++ b/docs/examples/bathymetry/08_emodnet_wcs_deep_dive.ipynb
@@ -1,0 +1,469 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# EMODnet Bathymetry over OGC WCS — a guided tour\n",
+    "\n",
+    "The `bathymetry` backend serves two kinds of Digital Terrain Model (DTM): the\n",
+    "global GEBCO / ETOPO grids over NOAA **ERDDAP griddap**, and the European\n",
+    "high-resolution **EMODnet** DTM over **OGC WCS**. This notebook focuses on the\n",
+    "WCS side — what `dataset=\"emodnet\"` gives you, how the request is shaped, how\n",
+    "it compares to the global grids, how the release history evolved, and how the\n",
+    "European-domain guard protects you from silent out-of-coverage data.\n",
+    "\n",
+    "By the end you will be able to pull an EMODnet subset, read its depths, reason\n",
+    "about resolution and coverage, and pick between EMODnet and a global DEM for a\n",
+    "given area. The read path is `pyramids.Dataset.from_wcs` — `earthlens` supplies\n",
+    "only the coverage id, AOI, CRS, and protocol version.\n",
+    "\n",
+    "API: `earthlens.core.EarthLens` · `earthlens.bathymetry.Catalog`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "`EarthLens` is the unified entry point; `pyramids` reads the written GeoTIFF;\n",
+    "`pandas` renders the catalog tables and `matplotlib` the maps. Downloads go to a\n",
+    "temporary directory — every dataset here is fetched live, no local fixtures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from pyramids.dataset import Dataset\n",
+    "\n",
+    "from earthlens.bathymetry import Catalog\n",
+    "from earthlens.core import EarthLens"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "We will fetch several small subsets, so a tiny helper keeps the teaching cells\n",
+    "about the *feature* rather than the plumbing. It downloads one DEM subset, reads\n",
+    "the elevation band, and masks the GEBCO no-data fill (`32767`) so land/edges do\n",
+    "not skew the colour scale. `aoi` is `[min_lon, min_lat, max_lon, max_lat]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fetch_depth(dataset, aoi):\n",
+    "    out = tempfile.mkdtemp()\n",
+    "    paths = EarthLens(\n",
+    "        data_source='bathymetry', dataset=dataset, aoi=aoi, path=out\n",
+    "    ).download(progress_bar=False)\n",
+    "    grid = np.asarray(Dataset.read_file(str(paths[0])).read_array(), dtype='float32')\n",
+    "    grid = grid[0] if grid.ndim == 3 else grid\n",
+    "    return np.where(grid == 32767, np.nan, grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Two transports, one backend\n",
+    "\n",
+    "The bathymetry catalog mixes ERDDAP-`griddap` rows (GEBCO / ETOPO) with OGC-`wcs`\n",
+    "rows (EMODnet). Reading the catalog is offline. The `transport` column is what\n",
+    "the backend dispatches on; the WCS rows also carry a `wcs_version` and a\n",
+    "`native_bbox` (the coverage's advertised extent, used by the domain guard)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog = Catalog()\n",
+    "rows = [\n",
+    "    {\n",
+    "        'dataset': d,\n",
+    "        'transport': r.transport,\n",
+    "        'coverage/id': r.dataset_id,\n",
+    "        'native_resolution': r.native_resolution,\n",
+    "    }\n",
+    "    for d in sorted(catalog.datasets)\n",
+    "    for r in [catalog.get(d)]\n",
+    "]\n",
+    "pd.DataFrame(rows).set_index('dataset')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "The three global rows are `erddap-griddap`; the five `emodnet*` rows are `wcs`.\n",
+    "`emodnet` is the latest release; the year-stamped ids pin older DTMs. Everything\n",
+    "below uses the WCS rows."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## Quickstart — an EMODnet subset over the North Sea\n",
+    "\n",
+    "The shortest end-to-end example: pick `dataset=\"emodnet\"` and a small North Sea\n",
+    "AOI. `download()` issues the WCS `GetCoverage`, crops to the AOI, and writes a\n",
+    "GeoTIFF; `fetch_depth` hands back the depth array (metres, negative = below sea\n",
+    "level)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "north_sea = [2.0, 53.0, 4.0, 55.0]\n",
+    "emodnet_depth = fetch_depth('emodnet', north_sea)\n",
+    "emodnet_depth.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "A quick numeric sanity check before mapping — the range should be plausible shelf-sea depths, all below sea level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    'depth range',\n",
+    "    round(float(np.nanmin(emodnet_depth))),\n",
+    "    '..',\n",
+    "    round(float(np.nanmax(emodnet_depth))),\n",
+    "    'm',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6, 5))\n",
+    "plt.imshow(emodnet_depth, cmap='Blues_r')\n",
+    "plt.colorbar(label='mean depth (m, negative = below sea level)')\n",
+    "plt.title('EMODnet DTM (~3.75″) — southern North Sea')\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "The southern North Sea is shallow (tens of metres) and the ~3.75-arc-second grid\n",
+    "resolves fine seabed structure — sandbanks and channels — that a global DEM\n",
+    "would blur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "## How the WCS request is shaped\n",
+    "\n",
+    "`earthlens` never talks WCS dialects itself — it reads four fields off the\n",
+    "catalog row and hands them to `pyramids.Dataset.from_wcs`. Inspect them for\n",
+    "`emodnet`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row = catalog.get('emodnet')\n",
+    "{\n",
+    "    'endpoint': row.endpoint,\n",
+    "    'coverage': row.dataset_id,\n",
+    "    'wcs_version': row.wcs_version,\n",
+    "    'crs': row.crs,\n",
+    "    'native_bbox': row.native_bbox,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "| Field | Meaning | Value for `emodnet` |\n",
+    "|---|---|---|\n",
+    "| `endpoint` | The OGC WCS service URL | `ows.emodnet-bathymetry.eu/wcs` |\n",
+    "| `coverage` | WCS coverage id sent as `GetCoverage` | `emodnet:mean` |\n",
+    "| `wcs_version` | Protocol version GDAL negotiates | `1.0.0` |\n",
+    "| `crs` | Request / native CRS | `EPSG:4326` |\n",
+    "| `native_bbox` | Advertised extent `(W, S, E, N)` for the domain guard | `(-70.5, 11, 43, 90)` |\n",
+    "\n",
+    "The `1.0.0` version is deliberate: this GeoServer only subsets cleanly at WCS\n",
+    "`1.0.0` with the colon coverage id `emodnet:mean` (the 2.0.1 `emodnet__mean` id\n",
+    "fails GDAL subsetting)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "## Depth distribution\n",
+    "\n",
+    "A histogram reads the seabed better than a single min/max — it shows where most\n",
+    "of the AOI sits depth-wise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6, 4))\n",
+    "plt.hist(emodnet_depth[np.isfinite(emodnet_depth)].ravel(), bins=60, color='steelblue')\n",
+    "plt.xlabel('depth (m)')\n",
+    "plt.ylabel('pixel count')\n",
+    "plt.title('EMODnet depth distribution — southern North Sea')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "The mass sits in the shallow shelf range with a tail toward deeper channels — the classic North Sea profile."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "## Regional detail vs the global GEBCO grid\n",
+    "\n",
+    "EMODnet is the *coastal / shelf* complement to the global DEMs. Fetch GEBCO over\n",
+    "the **same** AOI and compare the grid shapes: same footprint, very different\n",
+    "pixel counts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gebco_depth = fetch_depth('gebco_2020', north_sea)\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        'rows': [emodnet_depth.shape[0], gebco_depth.shape[0]],\n",
+    "        'cols': [emodnet_depth.shape[1], gebco_depth.shape[1]],\n",
+    "    },\n",
+    "    index=['emodnet (~3.75″)', 'gebco_2020 (15″)'],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 2, figsize=(11, 5))\n",
+    "axes[0].imshow(emodnet_depth, cmap='Blues_r')\n",
+    "axes[0].set_title('EMODnet (~3.75″)')\n",
+    "axes[0].axis('off')\n",
+    "axes[1].imshow(gebco_depth, cmap='Blues_r')\n",
+    "axes[1].set_title('GEBCO 2020 (15″)')\n",
+    "axes[1].axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23",
+   "metadata": {},
+   "source": [
+    "Same 2°×2° box, but EMODnet packs ~4× the pixels per axis, so seabed\n",
+    "features sharpen. For an open-ocean or global request you would still reach for\n",
+    "GEBCO / ETOPO; for European coastal detail, EMODnet."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24",
+   "metadata": {},
+   "source": [
+    "## Release history — the DTM improves over time\n",
+    "\n",
+    "`emodnet` tracks the latest published DTM; the year-stamped rows pin older\n",
+    "releases. Successive releases refine both **resolution** and **coverage**.\n",
+    "Compare the 2016 release with the latest over the same North Sea box:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "emodnet2016_depth = fetch_depth('emodnet_2016', north_sea)\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        'grid_rows': [emodnet_depth.shape[0], emodnet2016_depth.shape[0]],\n",
+    "        'min_depth': [\n",
+    "            float(np.nanmin(emodnet_depth)),\n",
+    "            float(np.nanmin(emodnet2016_depth)),\n",
+    "        ],\n",
+    "        'mean_depth': [\n",
+    "            float(np.nanmean(emodnet_depth)),\n",
+    "            float(np.nanmean(emodnet2016_depth)),\n",
+    "        ],\n",
+    "    },\n",
+    "    index=['emodnet (latest)', 'emodnet_2016'],\n",
+    ").round(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26",
+   "metadata": {},
+   "source": [
+    "The depths agree closely in this stable shelf area, but the grids differ in\n",
+    "resolution — the newer release is finer. Pick a specific release when you need\n",
+    "reproducibility against a published DTM version; otherwise `emodnet` gives you\n",
+    "the current best."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27",
+   "metadata": {},
+   "source": [
+    "## The European-domain guard\n",
+    "\n",
+    "EMODnet is regional, and its WCS server returns a **zero-filled** grid (not an\n",
+    "error) for an area outside coverage. To stop that becoming silent bad data, each\n",
+    "row carries its own `native_bbox` and the backend guards every request against\n",
+    "it. Crucially, the older releases cover a **smaller** domain than the latest:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "releases = ['emodnet', 'emodnet_2022', 'emodnet_2020', 'emodnet_2018', 'emodnet_2016']\n",
+    "pd.DataFrame(\n",
+    "    {'native_bbox (W, S, E, N)': [catalog.get(d).native_bbox for d in releases]},\n",
+    "    index=releases,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29",
+   "metadata": {},
+   "source": [
+    "The guard has three behaviours, keyed on the request bbox vs the row's\n",
+    "`native_bbox`:\n",
+    "\n",
+    "| Request vs coverage | Behaviour |\n",
+    "|---|---|\n",
+    "| Fully inside | proceeds silently |\n",
+    "| Partially outside | proceeds, but **logs a warning** that out-of-coverage cells come back as `0.0` fill |\n",
+    "| Fully outside | **raises `ValueError`**, pointing you at the global `gebco_2020` / `etopo1_ice` DEMs |\n",
+    "\n",
+    "This is why the per-release `native_bbox` above must be exact: the latest and\n",
+    "2022 run west into the Atlantic (`-70.5`), while 2016 stops at `-36` west and\n",
+    "`85°N`. Using one extent for all releases would let an older-release request\n",
+    "slip into the gap and return silent zeros."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30",
+   "metadata": {},
+   "source": [
+    "## Takeaway\n",
+    "\n",
+    "- `dataset=\"emodnet\"` fetches the European high-resolution DTM over OGC WCS\n",
+    "  through `pyramids.Dataset.from_wcs`, on the same `download() -> GeoTIFF`\n",
+    "  contract as the global griddap DEMs.\n",
+    "- It is ~4× finer than GEBCO over European seas; reach for GEBCO / ETOPO outside\n",
+    "  the EMODnet domain.\n",
+    "- Year-stamped ids pin older releases, which differ in resolution **and** extent.\n",
+    "- The domain guard uses each row's `native_bbox` to reject fully-outside requests\n",
+    "  and warn on partial overlap, so you never silently map zero-fill as real depth.\n",
+    "\n",
+    "### Attribution\n",
+    "\n",
+    "EMODnet Digital Bathymetry (DTM 2024), EMODnet Bathymetry Consortium\n",
+    "(doi:10.12770/cf51df64-56f9-4a99-b1aa-36b8d7b743a1); EMODnet use conditions,\n",
+    "attribution required. GEBCO Compilation Group (2020) GEBCO 2020 Grid. A DTM is a\n",
+    "static grid, so `download(aggregate=...)` is rejected."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/reference/bathymetry/datasets.md
+++ b/docs/reference/bathymetry/datasets.md
@@ -1,19 +1,47 @@
 # Bathymetry — available datasets
 
-The `bathymetry` backend ships three curated DEM rows. Pick one with the
-`dataset=` argument. Every row is a static global elevation grid served as
-a NOAA ERDDAP `griddap` coverage, with a single elevation band in **metres
-relative to sea level** (negative = below sea level).
+The `bathymetry` backend ships curated DEM rows across two transports. Pick one
+with the `dataset=` argument. Every row is a static elevation grid with a single
+band in **metres relative to sea level** (negative = below sea level).
 
-| `dataset=` | DEM | Native resolution | Band | Longitude | Server |
+- **Global DEMs (ERDDAP `griddap`)** — GEBCO / ETOPO, served as NOAA ERDDAP
+  coverages, subset server-side to the request bbox.
+- **European high-resolution DEM (OGC WCS)** — EMODnet Bathymetry, read through
+  pyramids `Dataset.from_wcs`; the coastal / shelf complement to the global DEMs.
+
+| `dataset=` | DEM | Native resolution | Band | Transport | Server / coverage |
 |---|---|---|---|---|---|
-| `gebco_2020` | GEBCO 2020 (topography + bathymetry) | 15 arc-second | `elevation` | −180..180 | NOAA CoastWatch ERDDAP |
-| `etopo1_ice` | ETOPO1 global relief, **Ice Surface** | 1 arc-minute | `z` | −180..180 | NOAA upwell ERDDAP |
-| `etopo1_bedrock` | ETOPO1 global relief, **Bedrock** | 1 arc-minute | `z` | −180..180 | NOAA upwell ERDDAP |
+| `gebco_2020` | GEBCO 2020 (topography + bathymetry) | 15 arc-second | `elevation` | ERDDAP `griddap` | NOAA CoastWatch ERDDAP |
+| `etopo1_ice` | ETOPO1 global relief, **Ice Surface** | 1 arc-minute | `z` | ERDDAP `griddap` | NOAA upwell ERDDAP |
+| `etopo1_bedrock` | ETOPO1 global relief, **Bedrock** | 1 arc-minute | `z` | ERDDAP `griddap` | NOAA upwell ERDDAP |
+| `emodnet` | EMODnet Bathymetry DTM, **latest release** (DTM 2024) | ~3.75 arc-second | `elevation` | OGC WCS | EMODnet Bathymetry WCS (`emodnet:mean`) |
+| `emodnet_2022` | EMODnet Bathymetry DTM, 2022 release | ~3.75 arc-second | `elevation` | OGC WCS | EMODnet Bathymetry WCS (`emodnet:mean_2022`) |
+| `emodnet_2020` | EMODnet Bathymetry DTM, 2020 release | ~3.75 arc-second | `elevation` | OGC WCS | EMODnet Bathymetry WCS (`emodnet:mean_2020`) |
+| `emodnet_2018` | EMODnet Bathymetry DTM, 2018 release | ~3.75 arc-second | `elevation` | OGC WCS | EMODnet Bathymetry WCS (`emodnet:mean_2018`) |
+| `emodnet_2016` | EMODnet Bathymetry DTM, 2016 release | ~3.75 arc-second | `elevation` | OGC WCS | EMODnet Bathymetry WCS (`emodnet:mean_2016`) |
 
-The ETOPO variant is the dataset id, not a `variables` knob: choose
-`etopo1_ice` for the top of the ice sheets or `etopo1_bedrock` for their
-base.
+The ETOPO / EMODnet **release is the dataset id, not a `variables` knob**: choose
+`etopo1_ice` vs `etopo1_bedrock`, or `emodnet` (latest) vs a year-stamped
+`emodnet_2022` / `_2020` / `_2018` / `_2016`.
+
+## EMODnet Bathymetry (European seas)
+
+`dataset="emodnet"` fetches the EMODnet Digital Terrain Model — a high-resolution
+(~3.75 arc-second) grid of mean sea-floor depth harmonised from national
+hydrographic surveys and satellite-derived bathymetry, covering **European seas
+and the extended NE-Atlantic domain** (roughly longitude −70.5°..43°, latitude
+11°..90°). It is read over **OGC WCS** via pyramids `Dataset.from_wcs` and cropped
+to the request bbox.
+
+Because the coverage is regional, a request whose bounding box falls entirely
+outside that domain raises a clear error pointing you back at the global DEMs
+(`gebco_2020` / `etopo1_ice`) — the WCS server would otherwise return a
+zero-filled grid rather than an error.
+
+**Licence / attribution.** EMODnet Bathymetry is provided under the EMODnet use
+conditions (attribution required). Cite: *EMODnet Digital Bathymetry (DTM 2024),
+EMODnet Bathymetry Consortium* (doi:10.12770/cf51df64-56f9-4a99-b1aa-36b8d7b743a1).
+See the [EMODnet terms of use](https://emodnet.ec.europa.eu/en/terms-use-emodnet-online-services-data-and-data-products).
 
 ## Facade aliases
 
@@ -24,7 +52,8 @@ you think about the data:
 - `data_source="etopo"` — then pass `dataset="etopo1_ice"` or
   `dataset="etopo1_bedrock"`.
 
-`data_source="bathymetry"` works with any of the three `dataset=` ids.
+`data_source="bathymetry"` works with any of the `dataset=` ids (including the
+`emodnet` rows).
 
 ## Listing the ids programmatically
 
@@ -32,15 +61,19 @@ you think about the data:
 from earthlens.bathymetry import Catalog
 
 catalog = Catalog()
-sorted(catalog.datasets)        # ['etopo1_bedrock', 'etopo1_ice', 'gebco_2020']
-catalog.get("gebco_2020").variable      # 'elevation'
-catalog.get("etopo1_ice").native_resolution    # '1 arc-minute'
+sorted(catalog.datasets)
+# ['emodnet', 'emodnet_2016', 'emodnet_2018', 'emodnet_2020', 'emodnet_2022',
+#  'etopo1_bedrock', 'etopo1_ice', 'gebco_2020']
+catalog.get("gebco_2020").variable          # 'elevation'
+catalog.get("emodnet").transport            # 'wcs'
+catalog.get("emodnet").dataset_id           # 'emodnet:mean'
 ```
 
 ## Versions
 
-These are the versions cleanly subsettable over the public ERDDAP
-`griddap` transport today (GEBCO 2020 and ETOPO1). Newer releases (ETOPO
-2022, later GEBCO grids) are not exposed as a bbox-subsettable ERDDAP
-coverage on the public hosts; when they are, they can be added as extra
-catalog rows without any backend change.
+The global rows are the versions cleanly subsettable over the public ERDDAP
+`griddap` transport today (GEBCO 2020 and ETOPO1). For EMODnet, `emodnet` tracks
+the latest published DTM release while the year-stamped ids pin an earlier one.
+Newer global releases (ETOPO 2022, later GEBCO grids) are not yet exposed as a
+bbox-subsettable ERDDAP coverage on the public hosts; when they are, they can be
+added as extra catalog rows without any backend change.

--- a/docs/reference/provider-datasets.md
+++ b/docs/reference/provider-datasets.md
@@ -71,7 +71,7 @@ or station — not a dataset id), noted as such.
 | `worldpop` | WorldPop — population counts, age/sex, density, births/pregnancies, projections, + 54 covariate layers | `pop`, `age_structures`, `pop_density`, `cviirs` | 11 families + 54 covariates |
 | `soilgrids` | ISRIC SoilGrids 2.0 soil properties (250 m, WCS) × 6 depths × 5 quantiles | `clay`, `phh2o`, `soc`, `bdod` | 11 properties |
 | `dem` | Copernicus DEM global land elevation — COG tiles on AWS | `cop-dem-glo-30`, `cop-dem-glo-90` | 2 |
-| `bathymetry` | Global topography/bathymetry DEMs (NOAA ERDDAP) — GEBCO, ETOPO1 | `gebco_2020`, `etopo1_ice`, `etopo1_bedrock` | 3 |
+| `bathymetry` | Global topography/bathymetry DEMs (NOAA ERDDAP GEBCO/ETOPO1) + EMODnet European high-res DTM (OGC WCS) | `gebco_2020`, `etopo1_ice`, `etopo1_bedrock`, `emodnet` (+ `_2016`/`_2018`/`_2020`/`_2022`) | 8 |
 | `glaciers` | Glacier outlines + mass balance — RGI 7.0, GLIMS, WGMS FoG | `rgi:outlines`, `glims:outlines`, `wgms:mass_balance` | 5 |
 | `gbif` | GBIF species occurrences by taxon + bbox + time | `animals`, `plants`, `birds`, `mammals` (or `taxon:<name>`) | *(query service)* |
 | `wdpa` | Protected Planet (WDPA) protected-area polygons by country | `KEN`, `BRA`, `IDN` (ISO3, or a WDPA id) | *(query service)* |

--- a/libs/providers/land/src/earthlens/bathymetry/backend.py
+++ b/libs/providers/land/src/earthlens/bathymetry/backend.py
@@ -344,12 +344,14 @@ class Bathymetry(AbstractDataSource):
     def _guard_wcs_domain(
         self, row: Dataset, bbox: tuple[float, float, float, float]
     ) -> None:
-        """Reject a WCS request whose bbox misses the coverage extent.
+        """Reject or warn about a WCS request that leaves the coverage extent.
 
         The EMODnet WCS server returns a zero-filled grid (not an error) for an
-        AOI outside its coverage, so an explicit intersection check turns a
-        silent all-zeros download into a clear error pointing at the global
-        DEMs.
+        AOI outside its coverage. A **fully disjoint** bbox is turned into a
+        clear error pointing at the global DEMs; a bbox that only **partially**
+        overlaps the coverage is allowed through (the in-coverage cells are
+        real) but logs a warning, because its out-of-coverage cells come back as
+        `0.0` (sea-level) fill indistinguishable from a genuine 0 m reading.
 
         Args:
             row: The resolved `wcs` catalog row (carries `native_bbox`).
@@ -374,6 +376,17 @@ class Bathymetry(AbstractDataSource):
                 f"request bbox {bbox} is outside the {row.id!r} coverage extent "
                 f"{extent} (European seas / NE Atlantic). Use a global DEM "
                 f"(dataset='gebco_2020' or 'etopo1_ice') for this area."
+            )
+        outside = (
+            west < ext_west or east > ext_east or south < ext_south or north > ext_north
+        )
+        if outside:
+            logger.warning(
+                f"bathymetry {row.id}: request bbox {bbox} extends beyond the "
+                f"coverage extent {extent}; cells outside the coverage return as "
+                f"0.0 (sea-level) fill, not real depths. Shrink the bbox to the "
+                f"coverage, or use a global DEM (gebco_2020 / etopo1_ice) for the "
+                f"out-of-domain area."
             )
 
     def _client(self) -> HttpClient:

--- a/libs/providers/land/src/earthlens/bathymetry/backend.py
+++ b/libs/providers/land/src/earthlens/bathymetry/backend.py
@@ -9,12 +9,16 @@ endpoint (GEBCO / ETOPO — subset to a NetCDF read back with
 through `pyramids.Dataset.from_wcs`). Either path writes a GeoTIFF.
 
 Every shipped DEM is static (no time axis), so the facade-forwarded
-`aggregate=` is rejected: there is no temporal field to reduce. The NetCDF is
+`aggregate=` is rejected: there is no temporal field to reduce. The grid is
 read **only** through pyramids — earthlens never imports a competing array
-stack to touch the NetCDF. An
-out-of-coverage / oversize request surfaces as a clear `ValueError` (a raster
-has no "zero pixels" — and ERDDAP caps response size), never a bare HTTP error
-or a corrupt file.
+stack to touch it. On the griddap path an out-of-coverage / oversize request
+surfaces as a clear `ValueError` (ERDDAP rejects it or returns an HTML error
+body, never data), so the user never sees a bare HTTP error or a corrupt file.
+The WCS path instead guards the request bbox against the coverage's
+`native_bbox` (:meth:`Bathymetry._guard_wcs_domain`) — a fully out-of-coverage
+AOI raises, a partial overlap is allowed through with a warning (its
+out-of-coverage cells come back as `0.0` fill) — because the WCS server returns
+a zero-filled grid, not an error, outside coverage.
 
 The DEMs are public, so there is no auth module.
 """

--- a/libs/providers/land/src/earthlens/bathymetry/backend.py
+++ b/libs/providers/land/src/earthlens/bathymetry/backend.py
@@ -2,10 +2,11 @@
 
 `Bathymetry` is a download-and-localise raster backend (`OUTPUT_KIND="raster"`).
 A `dataset=<id>` selects a curated :class:`~earthlens.bathymetry.catalog.Dataset`
-row (an ERDDAP `griddap` endpoint + coverage id + elevation band); `download()`
-subsets that global DEM to the request bbox, writes the NetCDF, reads it back
-with `pyramids.netcdf.NetCDF`, and writes a GeoTIFF — returning the list of
-written GeoTIFF paths.
+row and `download()` subsets that DEM to the request bbox, returning the list of
+written GeoTIFF paths. Two transports ship, chosen per row: an ERDDAP `griddap`
+endpoint (GEBCO / ETOPO — subset to a NetCDF read back with
+`pyramids.netcdf.NetCDF`) and an OGC WCS endpoint (EMODnet Bathymetry — read
+through `pyramids.Dataset.from_wcs`). Either path writes a GeoTIFF.
 
 Every shipped DEM is static (no time axis), so the facade-forwarded
 `aggregate=` is rejected: there is no temporal field to reduce. The NetCDF is
@@ -57,11 +58,11 @@ _LARGE_PIXEL_THRESHOLD = 250_000_000
 class Bathymetry(AbstractDataSource):
     """Global topography / bathymetry DEM backend (raster GeoTIFF output).
 
-    Fetches a curated static DEM (GEBCO 2020, ETOPO1 ice / bedrock) subset to
-    the request bbox through one uniform ERDDAP `griddap` transport, written
-    as GeoTIFF. The request is a search/fetch split: :meth:`_search` names the
-    single resolved product and :meth:`_fetch` realises it (download → pyramids
-    → GeoTIFF).
+    Fetches a curated static DEM (GEBCO 2020, ETOPO1 ice / bedrock via ERDDAP
+    `griddap`; EMODnet Bathymetry via OGC WCS) subset to the request bbox and
+    written as GeoTIFF. The request is a search/fetch split: :meth:`_search`
+    names the single resolved product and :meth:`_fetch` realises it (download
+    → pyramids → GeoTIFF), dispatching on the row's `transport`.
 
     Attributes:
         OUTPUT_KIND: Fixed `"raster"`; every DEM yields a gridded GeoTIFF.
@@ -239,11 +240,11 @@ class Bathymetry(AbstractDataSource):
         return [self._fetch_one_dem(product) for product in products]
 
     def _fetch_one_dem(self, product: RemoteProduct) -> Path:
-        """Subset one DEM to NetCDF, then write a GeoTIFF via pyramids.
+        """Subset one DEM to a GeoTIFF via the row's transport.
 
-        Builds the griddap subset URL, GETs the NetCDF (validating the magic
-        bytes), then `pyramids.netcdf.NetCDF` reads it and writes the
-        elevation band to GeoTIFF.
+        Dispatches on the resolved row's `transport`: `"wcs"` rows are read
+        over OGC WCS through pyramids `Dataset.from_wcs` (:meth:`_fetch_wcs`),
+        every other row over ERDDAP `griddap` (:meth:`_fetch_griddap`).
 
         Args:
             product: The `RemoteProduct` whose `metadata["dataset"]` is the
@@ -253,21 +254,127 @@ class Bathymetry(AbstractDataSource):
             Path: The written GeoTIFF at `<root_dir>/<id>.tif`.
 
         Raises:
-            ValueError: When the server rejects the request or returns a
-                non-NetCDF body (out-of-coverage / oversize bbox).
+            ValueError: When the server rejects the request, returns a
+                non-NetCDF body, or the request falls outside a WCS row's
+                coverage (out-of-coverage / oversize bbox).
         """
         row: Dataset = product.metadata["dataset"]
         bbox = bbox_from_extent(self.space)
         self._log_estimated_size(row, bbox)
+        tif_path = self.root_dir / f"{row.id}.tif"
+        if row.transport == "wcs":
+            self._fetch_wcs(row, bbox, tif_path)
+        else:
+            self._fetch_griddap(row, bbox, tif_path)
+        return tif_path
+
+    def _fetch_griddap(
+        self, row: Dataset, bbox: tuple[float, float, float, float], tif_path: Path
+    ) -> None:
+        """Subset an ERDDAP `griddap` DEM to NetCDF, then write a GeoTIFF.
+
+        Builds the griddap subset URL, GETs the NetCDF (validating the magic
+        bytes), then `pyramids.netcdf.NetCDF` reads it and writes the
+        elevation band to GeoTIFF.
+
+        Args:
+            row: The resolved `griddap` catalog row.
+            bbox: `(west, south, east, north)` of the request in degrees.
+            tif_path: Destination GeoTIFF path.
+
+        Raises:
+            ValueError: When the server rejects the request or returns a
+                non-NetCDF body (out-of-coverage / oversize bbox).
+        """
         url = griddap_subset_url(
             row.endpoint, row.dataset_id, row.variable, bbox, row.lon_convention
         )
         nc_path = self.root_dir / f"{row.id}.nc"
-        tif_path = self.root_dir / f"{row.id}.tif"
         logger.info(f"bathymetry {row.id}: GET {url}")
         self._download(url, row, nc_path)
         self._to_geotiff(nc_path, row.variable, tif_path)
-        return tif_path
+
+    def _fetch_wcs(
+        self, row: Dataset, bbox: tuple[float, float, float, float], tif_path: Path
+    ) -> None:
+        """Read a WCS-transport DEM through pyramids `from_wcs`, write a GeoTIFF.
+
+        Guards the request against the coverage's advertised extent first (a
+        WCS server returns an all-zeros grid, not an error, outside coverage),
+        then delegates the `GetCoverage` request, subset, and read entirely to
+        `pyramids.Dataset.from_wcs` — earthlens supplies only the coverage id,
+        AOI bbox, CRS, and protocol version. A polygon `aoi=` is applied with
+        the shared `mask_to_geometry` (a no-op without one), matching the
+        griddap path.
+
+        Args:
+            row: The resolved `wcs` catalog row.
+            bbox: `(west, south, east, north)` of the request in `row.crs`.
+            tif_path: Destination GeoTIFF path.
+
+        Raises:
+            ValueError: When the bbox is outside the coverage extent, or the
+                WCS request / read fails.
+        """
+        from pyramids.dataset import Dataset as PyramidsDataset
+
+        self._guard_wcs_domain(row, bbox)
+        logger.info(
+            f"bathymetry {row.id}: WCS GetCoverage {row.endpoint} "
+            f"coverage={row.dataset_id} bbox={bbox}"
+        )
+        try:
+            dataset = PyramidsDataset.from_wcs(
+                row.endpoint,
+                coverage=row.dataset_id,
+                bbox=bbox,
+                crs=row.crs,
+                version=row.wcs_version or None,
+                timeout=self._timeout,
+            )
+        except Exception as exc:
+            raise ValueError(
+                f"bathymetry WCS request for {row.id!r} failed over "
+                f"{self._extent_label()}: {exc}. The bbox may be outside the "
+                f"coverage, or too large for the server (shrink it)."
+            ) from exc
+        dataset = mask_to_geometry(dataset, self.space)
+        dataset.to_file(str(tif_path))
+
+    def _guard_wcs_domain(
+        self, row: Dataset, bbox: tuple[float, float, float, float]
+    ) -> None:
+        """Reject a WCS request whose bbox misses the coverage extent.
+
+        The EMODnet WCS server returns a zero-filled grid (not an error) for an
+        AOI outside its coverage, so an explicit intersection check turns a
+        silent all-zeros download into a clear error pointing at the global
+        DEMs.
+
+        Args:
+            row: The resolved `wcs` catalog row (carries `native_bbox`).
+            bbox: `(west, south, east, north)` of the request in `row.crs`.
+
+        Raises:
+            ValueError: If the request bbox does not intersect `native_bbox`.
+        """
+        extent = row.native_bbox
+        if extent is None:
+            return
+        west, south, east, north = bbox
+        ext_west, ext_south, ext_east, ext_north = extent
+        disjoint = (
+            east <= ext_west
+            or west >= ext_east
+            or north <= ext_south
+            or south >= ext_north
+        )
+        if disjoint:
+            raise ValueError(
+                f"request bbox {bbox} is outside the {row.id!r} coverage extent "
+                f"{extent} (European seas / NE Atlantic). Use a global DEM "
+                f"(dataset='gebco_2020' or 'etopo1_ice') for this area."
+            )
 
     def _client(self) -> HttpClient:
         """Return this instance's HTTP client, built once.

--- a/libs/providers/land/src/earthlens/bathymetry/backend.py
+++ b/libs/providers/land/src/earthlens/bathymetry/backend.py
@@ -336,7 +336,8 @@ class Bathymetry(AbstractDataSource):
             raise ValueError(
                 f"bathymetry WCS request for {row.id!r} failed over "
                 f"{self._extent_label()}: {exc}. The bbox may be outside the "
-                f"coverage, or too large for the server (shrink it)."
+                f"coverage or too large for the server (shrink it), or the WCS "
+                f"service may be unavailable."
             ) from exc
         dataset = mask_to_geometry(dataset, self.space)
         dataset.to_file(str(tif_path))

--- a/libs/providers/land/src/earthlens/bathymetry/backend.py
+++ b/libs/providers/land/src/earthlens/bathymetry/backend.py
@@ -263,7 +263,6 @@ class Bathymetry(AbstractDataSource):
         """
         row: Dataset = product.metadata["dataset"]
         bbox = bbox_from_extent(self.space)
-        self._log_estimated_size(row, bbox)
         tif_path = self.root_dir / f"{row.id}.tif"
         if row.transport == "wcs":
             self._fetch_wcs(row, bbox, tif_path)
@@ -289,6 +288,7 @@ class Bathymetry(AbstractDataSource):
             ValueError: When the server rejects the request or returns a
                 non-NetCDF body (out-of-coverage / oversize bbox).
         """
+        self._log_estimated_size(row, bbox)
         url = griddap_subset_url(
             row.endpoint, row.dataset_id, row.variable, bbox, row.lon_convention
         )
@@ -322,6 +322,7 @@ class Bathymetry(AbstractDataSource):
         from pyramids.dataset import Dataset as PyramidsDataset
 
         self._guard_wcs_domain(row, bbox)
+        self._log_estimated_size(row, bbox)
         logger.info(
             f"bathymetry {row.id}: WCS GetCoverage {row.endpoint} "
             f"coverage={row.dataset_id} bbox={bbox}"

--- a/libs/providers/land/src/earthlens/bathymetry/backend.py
+++ b/libs/providers/land/src/earthlens/bathymetry/backend.py
@@ -122,8 +122,11 @@ class Bathymetry(AbstractDataSource):
             end: Accepted for facade parity; ignored.
             lat_lim: `[lat_min, lat_max]` bounding-box latitudes. Required.
             lon_lim: `[lon_min, lon_max]` bounding-box longitudes. Required.
-            dataset: The curated DEM id to fetch (`"gebco_2020"`,
-                `"etopo1_ice"`, `"etopo1_bedrock"`). Required.
+            dataset: The curated DEM id to fetch — a global ERDDAP DEM
+                (`"gebco_2020"`, `"etopo1_ice"`, `"etopo1_bedrock"`) or an
+                EMODnet Bathymetry WCS row (`"emodnet"` for the latest release,
+                or a year-stamped `"emodnet_2022"` / `"_2020"` / `"_2018"` /
+                `"_2016"`). Required.
             variables: Optional band name(s); defaults to the row's single
                 elevation band. A name other than that band raises with a
                 did-you-mean.

--- a/libs/providers/land/src/earthlens/bathymetry/backend.py
+++ b/libs/providers/land/src/earthlens/bathymetry/backend.py
@@ -353,6 +353,10 @@ class Bathymetry(AbstractDataSource):
         real) but logs a warning, because its out-of-coverage cells come back as
         `0.0` (sea-level) fill indistinguishable from a genuine 0 m reading.
 
+        The numeric comparison assumes the request bbox and `native_bbox` share
+        `EPSG:4326` lon/lat degrees (true for every shipped row); a future row
+        in a projected CRS is skipped rather than mis-guarded on mixed units.
+
         Args:
             row: The resolved `wcs` catalog row (carries `native_bbox`).
             bbox: `(west, south, east, north)` of the request in `row.crs`.
@@ -362,6 +366,10 @@ class Bathymetry(AbstractDataSource):
         """
         extent = row.native_bbox
         if extent is None:
+            return
+        if row.crs != "EPSG:4326":
+            # native_bbox and the request bbox are only comparable in lon/lat
+            # degrees; skip the numeric guard for any other CRS.
             return
         west, south, east, north = bbox
         ext_west, ext_south, ext_east, ext_north = extent

--- a/libs/providers/land/src/earthlens/bathymetry/catalog.py
+++ b/libs/providers/land/src/earthlens/bathymetry/catalog.py
@@ -129,30 +129,38 @@ class Dataset(BaseModel):
 
         A `transport: wcs` row is read through pyramids `from_wcs`, which
         needs the WCS protocol version and (for the out-of-domain guard) the
-        coverage's advertised extent. Enforce both here so a malformed row
-        fails at catalog load, not mid-download.
+        coverage's advertised extent. Enforce both here — present, and not
+        degenerate (a blank version, or a zero/negative-area `native_bbox`) —
+        so a malformed row fails at catalog load, not mid-download.
 
         Returns:
             Dataset: The validated row (unchanged).
 
         Raises:
-            ValueError: If a `wcs` row is missing `wcs_version` or
-                `native_bbox`.
+            ValueError: If a `wcs` row is missing / blank `wcs_version` or
+                `native_bbox`, or `native_bbox` has non-positive area.
         """
-        if self.transport == "wcs":
-            missing = [
-                name
-                for name, value in (
-                    ("wcs_version", self.wcs_version),
-                    ("native_bbox", self.native_bbox),
-                )
-                if not value
-            ]
-            if missing:
-                raise ValueError(
-                    f"wcs row {self.id or self.dataset_id!r} is missing "
-                    f"required field(s): {', '.join(missing)}."
-                )
+        if self.transport != "wcs":
+            return self
+        missing = [
+            name
+            for name, value in (
+                ("wcs_version", (self.wcs_version or "").strip()),
+                ("native_bbox", self.native_bbox),
+            )
+            if not value
+        ]
+        if missing:
+            raise ValueError(
+                f"wcs row {self.id or self.dataset_id!r} is missing "
+                f"required field(s): {', '.join(missing)}."
+            )
+        bbox = self.native_bbox
+        if bbox is not None and (bbox[0] >= bbox[2] or bbox[1] >= bbox[3]):
+            raise ValueError(
+                f"wcs row {self.id or self.dataset_id!r} has a degenerate "
+                f"native_bbox {bbox}; expected west < east and south < north."
+            )
         return self
 
 

--- a/libs/providers/land/src/earthlens/bathymetry/catalog.py
+++ b/libs/providers/land/src/earthlens/bathymetry/catalog.py
@@ -9,12 +9,16 @@ informational `available_datasets:` list — and validated here against typed
 pydantic rows. The loader merges every file at construction time (the
 ghsl / cmems sharded pattern) through a `(path, mtime_ns)` parse cache.
 
-Every shipped row uses the single `erddap-griddap` transport pinned in the
-A1 gate (`planning/bathymetry/captures/bathymetry-sdk-facts.md`): a NOAA
-ERDDAP `griddap` coverage subset by bbox to a NetCDF the backend reads with
-pyramids and writes to GeoTIFF. The `transport` field still admits the
-`gebco-api` / `opendap` values so a future row can carry a different
-endpoint without a model change, but none ships today.
+Two transports ship today, both pinned live in an A1 gate:
+
+* `erddap-griddap` (GEBCO / ETOPO — `planning/bathymetry/captures/`): a NOAA
+  ERDDAP `griddap` coverage subset by bbox to a NetCDF the backend reads with
+  pyramids and writes to GeoTIFF.
+* `wcs` (EMODnet Bathymetry — `planning/flood-risk/captures/`): an OGC WCS
+  coverage read over pyramids `Dataset.from_wcs` and cropped to the AOI.
+
+The `transport` field also admits the reserved `gebco-api` / `opendap` values
+so a future row can carry a different endpoint without a model change.
 """
 
 from __future__ import annotations
@@ -22,7 +26,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, ValidationError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    ValidationError,
+    model_validator,
+)
 
 from earthlens.base import AbstractCatalog
 from earthlens.base.catalog_source import (
@@ -41,10 +52,10 @@ CATALOG_PATH: Path = Path(__file__).parent / "catalog"
 #: per-family file invalidates the entry without re-parsing an unchanged tree.
 _CATALOG_CACHE: dict[Any, tuple[list[str], dict[str, Dataset]]] = CatalogParseCache()
 
-#: Transport mechanisms a catalog row may declare. Only `erddap-griddap`
-#: ships today; the other two are reserved for a future GEBCO-API / OPeNDAP
-#: row (see the module docstring).
-Transport = Literal["erddap-griddap", "gebco-api", "opendap"]
+#: Transport mechanisms a catalog row may declare. `erddap-griddap` (GEBCO /
+#: ETOPO) and `wcs` (EMODnet Bathymetry) ship today; `gebco-api` / `opendap`
+#: are reserved for a future row (see the module docstring).
+Transport = Literal["erddap-griddap", "wcs", "gebco-api", "opendap"]
 
 #: Longitude conventions an ERDDAP DEM may serve its grid in.
 LonConvention = Literal["-180..180", "0..360"]
@@ -65,22 +76,35 @@ class Dataset(BaseModel):
     """One curated DEM row — an endpoint, a coverage id, and a band.
 
     Attributes:
-        id: Catalog key for the row (`"gebco_2020"`, `"etopo1_ice"`). Set
-            from the catalog key by the loader.
+        id: Catalog key for the row (`"gebco_2020"`, `"etopo1_ice"`,
+            `"emodnet"`). Set from the catalog key by the loader.
         title: Human-readable one-line description.
-        transport: How the grid is fetched. Every shipped row is
-            `"erddap-griddap"`; `"gebco-api"` / `"opendap"` are reserved.
-        endpoint: Base URL of the server (an ERDDAP base, no trailing
-            `/griddap`). A trailing slash is tolerated by the URL builder.
+        transport: How the grid is fetched — `"erddap-griddap"` (GEBCO /
+            ETOPO) or `"wcs"` (EMODnet Bathymetry); `"gebco-api"` /
+            `"opendap"` are reserved.
+        endpoint: Base URL of the server — an ERDDAP base (no trailing
+            `/griddap`) for `erddap-griddap`, or the OGC WCS endpoint for
+            `wcs`. A trailing slash is tolerated.
         dataset_id: The coverage / dataset id on that server
-            (`"GEBCO_2020"`, `"etopo1_ice"`).
+            (`"GEBCO_2020"`, `"etopo1_ice"`, or the WCS coverage
+            `"emodnet:mean"`).
         variable: The single elevation band name in the grid (`"elevation"`
-            for GEBCO, `"z"` for ETOPO1).
+            for GEBCO / EMODnet, `"z"` for ETOPO1).
         native_resolution: Human-readable native cell size
-            (`"15 arc-second"`, `"1 arc-minute"`).
+            (`"15 arc-second"`, `"1 arc-minute"`, `"3.75 arc-second"`).
         lon_convention: Whether the server's longitude axis runs
-            `"-180..180"` or `"0..360"`. The URL builder normalises the
-            request bbox to this.
+            `"-180..180"` or `"0..360"`. The griddap URL builder normalises
+            the request bbox to this.
+        wcs_version: The OGC WCS protocol version pyramids `from_wcs` must
+            negotiate (`"1.0.0"` for EMODnet — its GeoServer only subsets
+            cleanly at 1.0.0). Empty for non-`wcs` rows.
+        crs: The request / native CRS for a `wcs` row (`"EPSG:4326"`).
+            Ignored by the griddap path.
+        native_bbox: The coverage's advertised extent as
+            `(west, south, east, north)` in `crs`, used by the `wcs` branch
+            to guard out-of-domain requests (the WCS server returns an
+            all-zeros grid, not an error, outside coverage). `None` for
+            griddap rows (ERDDAP rejects an out-of-coverage bbox itself).
         license_note: Attribution / licence text surfaced in docs and logs.
     """
 
@@ -94,7 +118,42 @@ class Dataset(BaseModel):
     variable: str
     native_resolution: str = ""
     lon_convention: LonConvention = "-180..180"
+    wcs_version: str = ""
+    crs: str = "EPSG:4326"
+    native_bbox: tuple[float, float, float, float] | None = None
     license_note: str = ""
+
+    @model_validator(mode="after")
+    def _check_wcs_fields(self) -> Dataset:
+        """Require a `wcs` row to carry the fields its transport needs.
+
+        A `transport: wcs` row is read through pyramids `from_wcs`, which
+        needs the WCS protocol version and (for the out-of-domain guard) the
+        coverage's advertised extent. Enforce both here so a malformed row
+        fails at catalog load, not mid-download.
+
+        Returns:
+            Dataset: The validated row (unchanged).
+
+        Raises:
+            ValueError: If a `wcs` row is missing `wcs_version` or
+                `native_bbox`.
+        """
+        if self.transport == "wcs":
+            missing = [
+                name
+                for name, value in (
+                    ("wcs_version", self.wcs_version),
+                    ("native_bbox", self.native_bbox),
+                )
+                if not value
+            ]
+            if missing:
+                raise ValueError(
+                    f"wcs row {self.id or self.dataset_id!r} is missing "
+                    f"required field(s): {', '.join(missing)}."
+                )
+        return self
 
 
 def _yaml_files_for(path: Path) -> list[Path]:

--- a/libs/providers/land/src/earthlens/bathymetry/catalog/_index.yaml
+++ b/libs/providers/land/src/earthlens/bathymetry/catalog/_index.yaml
@@ -1,9 +1,14 @@
 # Bathymetry catalog index — every curated DEM id (informational).
 #
 # Each id resolves to a row in one of the per-family files (gebco.yaml,
-# etopo.yaml). The loader checks every curated row appears here, mirroring
-# the ghsl / cmems sharded-catalog contract.
+# etopo.yaml, emodnet.yaml). The loader checks every curated row appears here,
+# mirroring the ghsl / cmems sharded-catalog contract.
 available_datasets:
   - gebco_2020
   - etopo1_ice
   - etopo1_bedrock
+  - emodnet
+  - emodnet_2022
+  - emodnet_2020
+  - emodnet_2018
+  - emodnet_2016

--- a/libs/providers/land/src/earthlens/bathymetry/catalog/emodnet.yaml
+++ b/libs/providers/land/src/earthlens/bathymetry/catalog/emodnet.yaml
@@ -1,0 +1,88 @@
+# EMODnet Bathymetry DTM — European high-resolution sea-floor depth, served
+# as OGC WCS by the EMODnet Bathymetry GeoServer.
+#
+# The EMODnet Digital Terrain Model harmonises national hydrographic surveys
+# and satellite-derived bathymetry into a continuous ~3.75-arc-second grid of
+# mean depth (metres, negative below sea level) over European seas and the
+# extended NE-Atlantic domain — the coastal / shelf complement to the global
+# GEBCO / ETOPO DEMs. Unlike the ERDDAP-griddap rows, this coverage is read
+# over OGC WCS through pyramids `Dataset.from_wcs`. Pinned live in the A1 gate
+# — see planning/flood-risk/captures/emodnet-bathymetry-wcs-facts.md.
+#
+# GDAL's WCS driver reads this GeoServer only at WCS 1.0.0 with the colon
+# coverage id `emodnet:mean` (the 2.0.1 `emodnet__mean` id fails GDAL
+# subsetting with "Empty intersection after subsetting"). `emodnet` = the
+# latest release (DTM 2024); the year-stamped rows are the older DTM releases
+# (the release is the dataset id, mirroring ETOPO's ice / bedrock split).
+datasets:
+  emodnet:
+    title: "EMODnet Bathymetry DTM (European sea-floor depth, ~3.75 arc-second, latest release)"
+    transport: wcs
+    endpoint: https://ows.emodnet-bathymetry.eu/wcs
+    dataset_id: "emodnet:mean"
+    variable: elevation
+    native_resolution: 3.75 arc-second
+    lon_convention: "-180..180"
+    wcs_version: "1.0.0"
+    crs: EPSG:4326
+    native_bbox: [-70.5, 11.0, 43.0, 90.0]
+    license_note: >-
+      EMODnet Digital Bathymetry (DTM 2024), EMODnet Bathymetry Consortium
+      (doi:10.12770/cf51df64-56f9-4a99-b1aa-36b8d7b743a1); EMODnet use conditions,
+      attribution required — https://emodnet.ec.europa.eu/en/terms-use-emodnet-online-services-data-and-data-products.
+  emodnet_2022:
+    title: "EMODnet Bathymetry DTM 2022 release (European sea-floor depth, ~3.75 arc-second)"
+    transport: wcs
+    endpoint: https://ows.emodnet-bathymetry.eu/wcs
+    dataset_id: "emodnet:mean_2022"
+    variable: elevation
+    native_resolution: 3.75 arc-second
+    lon_convention: "-180..180"
+    wcs_version: "1.0.0"
+    crs: EPSG:4326
+    native_bbox: [-70.5, 11.0, 43.0, 90.0]
+    license_note: >-
+      EMODnet Digital Bathymetry (DTM 2022), EMODnet Bathymetry Consortium; EMODnet use conditions,
+      attribution required — https://emodnet.ec.europa.eu/en/terms-use-emodnet-online-services-data-and-data-products.
+  emodnet_2020:
+    title: "EMODnet Bathymetry DTM 2020 release (European sea-floor depth, ~3.75 arc-second)"
+    transport: wcs
+    endpoint: https://ows.emodnet-bathymetry.eu/wcs
+    dataset_id: "emodnet:mean_2020"
+    variable: elevation
+    native_resolution: 3.75 arc-second
+    lon_convention: "-180..180"
+    wcs_version: "1.0.0"
+    crs: EPSG:4326
+    native_bbox: [-70.5, 11.0, 43.0, 90.0]
+    license_note: >-
+      EMODnet Digital Bathymetry (DTM 2020), EMODnet Bathymetry Consortium; EMODnet use conditions,
+      attribution required — https://emodnet.ec.europa.eu/en/terms-use-emodnet-online-services-data-and-data-products.
+  emodnet_2018:
+    title: "EMODnet Bathymetry DTM 2018 release (European sea-floor depth, ~3.75 arc-second)"
+    transport: wcs
+    endpoint: https://ows.emodnet-bathymetry.eu/wcs
+    dataset_id: "emodnet:mean_2018"
+    variable: elevation
+    native_resolution: 3.75 arc-second
+    lon_convention: "-180..180"
+    wcs_version: "1.0.0"
+    crs: EPSG:4326
+    native_bbox: [-70.5, 11.0, 43.0, 90.0]
+    license_note: >-
+      EMODnet Digital Bathymetry (DTM 2018), EMODnet Bathymetry Consortium; EMODnet use conditions,
+      attribution required — https://emodnet.ec.europa.eu/en/terms-use-emodnet-online-services-data-and-data-products.
+  emodnet_2016:
+    title: "EMODnet Bathymetry DTM 2016 release (European sea-floor depth, ~3.75 arc-second)"
+    transport: wcs
+    endpoint: https://ows.emodnet-bathymetry.eu/wcs
+    dataset_id: "emodnet:mean_2016"
+    variable: elevation
+    native_resolution: 3.75 arc-second
+    lon_convention: "-180..180"
+    wcs_version: "1.0.0"
+    crs: EPSG:4326
+    native_bbox: [-70.5, 11.0, 43.0, 90.0]
+    license_note: >-
+      EMODnet Digital Bathymetry (DTM 2016), EMODnet Bathymetry Consortium; EMODnet use conditions,
+      attribution required — https://emodnet.ec.europa.eu/en/terms-use-emodnet-online-services-data-and-data-products.

--- a/libs/providers/land/src/earthlens/bathymetry/catalog/emodnet.yaml
+++ b/libs/providers/land/src/earthlens/bathymetry/catalog/emodnet.yaml
@@ -22,7 +22,6 @@ datasets:
     dataset_id: "emodnet:mean"
     variable: elevation
     native_resolution: 3.75 arc-second
-    lon_convention: "-180..180"
     wcs_version: "1.0.0"
     crs: EPSG:4326
     native_bbox: [-70.5, 11.0, 43.0, 90.0]
@@ -37,7 +36,6 @@ datasets:
     dataset_id: "emodnet:mean_2022"
     variable: elevation
     native_resolution: 3.75 arc-second
-    lon_convention: "-180..180"
     wcs_version: "1.0.0"
     crs: EPSG:4326
     native_bbox: [-70.5, 11.0, 43.0, 90.0]
@@ -51,7 +49,6 @@ datasets:
     dataset_id: "emodnet:mean_2020"
     variable: elevation
     native_resolution: 3.75 arc-second
-    lon_convention: "-180..180"
     wcs_version: "1.0.0"
     crs: EPSG:4326
     native_bbox: [-70.5, 11.0, 43.0, 90.0]
@@ -65,7 +62,6 @@ datasets:
     dataset_id: "emodnet:mean_2018"
     variable: elevation
     native_resolution: 3.75 arc-second
-    lon_convention: "-180..180"
     wcs_version: "1.0.0"
     crs: EPSG:4326
     native_bbox: [-70.5, 11.0, 43.0, 90.0]
@@ -79,7 +75,6 @@ datasets:
     dataset_id: "emodnet:mean_2016"
     variable: elevation
     native_resolution: 3.75 arc-second
-    lon_convention: "-180..180"
     wcs_version: "1.0.0"
     crs: EPSG:4326
     native_bbox: [-70.5, 11.0, 43.0, 90.0]

--- a/libs/providers/land/src/earthlens/bathymetry/catalog/emodnet.yaml
+++ b/libs/providers/land/src/earthlens/bathymetry/catalog/emodnet.yaml
@@ -51,7 +51,7 @@ datasets:
     native_resolution: 3.75 arc-second
     wcs_version: "1.0.0"
     crs: EPSG:4326
-    native_bbox: [-70.5, 11.0, 43.0, 90.0]
+    native_bbox: [-36.0, 15.0, 43.0, 90.0]
     license_note: >-
       EMODnet Digital Bathymetry (DTM 2020), EMODnet Bathymetry Consortium; EMODnet use conditions,
       attribution required — https://emodnet.ec.europa.eu/en/terms-use-emodnet-online-services-data-and-data-products.
@@ -64,7 +64,7 @@ datasets:
     native_resolution: 3.75 arc-second
     wcs_version: "1.0.0"
     crs: EPSG:4326
-    native_bbox: [-70.5, 11.0, 43.0, 90.0]
+    native_bbox: [-36.0, 15.0, 43.0, 90.0]
     license_note: >-
       EMODnet Digital Bathymetry (DTM 2018), EMODnet Bathymetry Consortium; EMODnet use conditions,
       attribution required — https://emodnet.ec.europa.eu/en/terms-use-emodnet-online-services-data-and-data-products.
@@ -77,7 +77,7 @@ datasets:
     native_resolution: 3.75 arc-second
     wcs_version: "1.0.0"
     crs: EPSG:4326
-    native_bbox: [-70.5, 11.0, 43.0, 90.0]
+    native_bbox: [-36.0, 25.0, 43.0, 85.0]
     license_note: >-
       EMODnet Digital Bathymetry (DTM 2016), EMODnet Bathymetry Consortium; EMODnet use conditions,
       attribution required — https://emodnet.ec.europa.eu/en/terms-use-emodnet-online-services-data-and-data-products.

--- a/libs/providers/land/tests/bathymetry/test_catalog.py
+++ b/libs/providers/land/tests/bathymetry/test_catalog.py
@@ -80,6 +80,13 @@ def test_unknown_id_raises_did_you_mean(catalog: Catalog):
         catalog.get("gebco2020")
 
 
+def test_get_catalog_returns_dataset_map(catalog: Catalog):
+    """get_catalog() returns the id→Dataset map backing the catalog."""
+    mapping = catalog.get_catalog()
+    assert mapping is catalog.datasets
+    assert mapping["emodnet"].transport == "wcs"
+
+
 def test_get_returns_frozen_dataset(catalog: Catalog):
     """get() returns a frozen Dataset row that rejects mutation."""
     row = catalog.get("etopo1_ice")

--- a/libs/providers/land/tests/bathymetry/test_catalog.py
+++ b/libs/providers/land/tests/bathymetry/test_catalog.py
@@ -121,20 +121,32 @@ def test_emodnet_licence_recorded(catalog: Catalog):
 
 
 @pytest.mark.parametrize(
-    "dataset_id, coverage",
+    "dataset_id, coverage, native_bbox",
     [
-        ("emodnet_2016", "emodnet:mean_2016"),
-        ("emodnet_2018", "emodnet:mean_2018"),
-        ("emodnet_2020", "emodnet:mean_2020"),
-        ("emodnet_2022", "emodnet:mean_2022"),
+        ("emodnet_2016", "emodnet:mean_2016", (-36.0, 25.0, 43.0, 85.0)),
+        ("emodnet_2018", "emodnet:mean_2018", (-36.0, 15.0, 43.0, 90.0)),
+        ("emodnet_2020", "emodnet:mean_2020", (-36.0, 15.0, 43.0, 90.0)),
+        ("emodnet_2022", "emodnet:mean_2022", (-70.5, 11.0, 43.0, 90.0)),
     ],
 )
-def test_emodnet_release_variants(catalog: Catalog, dataset_id: str, coverage: str):
-    """Each year-stamped release resolves to its own colon coverage id."""
+def test_emodnet_release_variants(
+    catalog: Catalog,
+    dataset_id: str,
+    coverage: str,
+    native_bbox: tuple[float, float, float, float],
+):
+    """Each release resolves to its own coverage id and advertised extent.
+
+    The per-release `native_bbox` is pinned from each coverage's live WCS
+    `DescribeCoverage` envelope — the older releases cover a smaller domain
+    than the latest, so copying one extent to all rows would fail the guard
+    open for the older ones.
+    """
     row = catalog.get(dataset_id)
     assert row.transport == "wcs"
     assert row.dataset_id == coverage
     assert row.wcs_version == "1.0.0"
+    assert row.native_bbox == native_bbox
 
 
 def test_wcs_row_missing_version_rejected():

--- a/libs/providers/land/tests/bathymetry/test_catalog.py
+++ b/libs/providers/land/tests/bathymetry/test_catalog.py
@@ -94,6 +94,78 @@ def test_dataset_requires_core_fields():
         Dataset(endpoint="https://x/erddap")
 
 
+def test_emodnet_row_fields(catalog: Catalog):
+    """The EMODnet row carries the live-pinned WCS transport fields."""
+    row = catalog.get("emodnet")
+    assert row.transport == "wcs"
+    assert row.endpoint == "https://ows.emodnet-bathymetry.eu/wcs"
+    assert row.dataset_id == "emodnet:mean"
+    assert row.wcs_version == "1.0.0"
+    assert row.crs == "EPSG:4326"
+    assert row.native_bbox == (-70.5, 11.0, 43.0, 90.0)
+    assert row.variable == "elevation"
+
+
+def test_emodnet_licence_recorded(catalog: Catalog):
+    """The EMODnet row records the required attribution / DOI licence note."""
+    note = catalog.get("emodnet").license_note
+    assert "EMODnet" in note
+    assert "doi:10.12770" in note
+
+
+@pytest.mark.parametrize(
+    "dataset_id, coverage",
+    [
+        ("emodnet_2016", "emodnet:mean_2016"),
+        ("emodnet_2018", "emodnet:mean_2018"),
+        ("emodnet_2020", "emodnet:mean_2020"),
+        ("emodnet_2022", "emodnet:mean_2022"),
+    ],
+)
+def test_emodnet_release_variants(catalog: Catalog, dataset_id: str, coverage: str):
+    """Each year-stamped release resolves to its own colon coverage id."""
+    row = catalog.get(dataset_id)
+    assert row.transport == "wcs"
+    assert row.dataset_id == coverage
+    assert row.wcs_version == "1.0.0"
+
+
+def test_wcs_row_missing_version_rejected():
+    """A wcs row without wcs_version fails validation."""
+    with pytest.raises(ValidationError, match="wcs_version"):
+        Dataset(
+            transport="wcs",
+            endpoint="https://x/wcs",
+            dataset_id="c:mean",
+            variable="elevation",
+            native_bbox=(-1.0, -1.0, 1.0, 1.0),
+        )
+
+
+def test_wcs_row_missing_native_bbox_rejected():
+    """A wcs row without native_bbox fails validation."""
+    with pytest.raises(ValidationError, match="native_bbox"):
+        Dataset(
+            transport="wcs",
+            endpoint="https://x/wcs",
+            dataset_id="c:mean",
+            variable="elevation",
+            wcs_version="1.0.0",
+        )
+
+
+def test_griddap_row_needs_no_wcs_fields():
+    """A griddap row builds without the WCS-only fields (they stay defaulted)."""
+    row = Dataset(
+        transport="erddap-griddap",
+        endpoint="https://x/erddap",
+        dataset_id="A",
+        variable="z",
+    )
+    assert row.wcs_version == ""
+    assert row.native_bbox is None
+
+
 def test_load_from_single_file(tmp_path: Path):
     """The loader accepts a single YAML file, not only a directory."""
     one = tmp_path / "one.yaml"

--- a/libs/providers/land/tests/bathymetry/test_catalog.py
+++ b/libs/providers/land/tests/bathymetry/test_catalog.py
@@ -167,8 +167,16 @@ def test_wcs_row_blank_version_rejected():
         )
 
 
-def test_wcs_row_degenerate_bbox_rejected():
-    """A wcs row with a zero-area native_bbox fails validation."""
+@pytest.mark.parametrize(
+    "native_bbox",
+    [
+        (0.0, 0.0, 0.0, 0.0),  # zero area
+        (1.0, 0.0, -1.0, 1.0),  # west > east (inverted longitude)
+        (-1.0, 1.0, 1.0, -1.0),  # south > north (inverted latitude)
+    ],
+)
+def test_wcs_row_degenerate_bbox_rejected(native_bbox):
+    """A wcs row with a non-positive-area native_bbox fails validation."""
     with pytest.raises(ValidationError, match="degenerate native_bbox"):
         Dataset(
             transport="wcs",
@@ -176,7 +184,7 @@ def test_wcs_row_degenerate_bbox_rejected():
             dataset_id="c:mean",
             variable="elevation",
             wcs_version="1.0.0",
-            native_bbox=(0.0, 0.0, 0.0, 0.0),
+            native_bbox=native_bbox,
         )
 
 

--- a/libs/providers/land/tests/bathymetry/test_catalog.py
+++ b/libs/providers/land/tests/bathymetry/test_catalog.py
@@ -154,6 +154,32 @@ def test_wcs_row_missing_native_bbox_rejected():
         )
 
 
+def test_wcs_row_blank_version_rejected():
+    """A wcs row whose wcs_version is only whitespace fails validation."""
+    with pytest.raises(ValidationError, match="wcs_version"):
+        Dataset(
+            transport="wcs",
+            endpoint="https://x/wcs",
+            dataset_id="c:mean",
+            variable="elevation",
+            wcs_version="  ",
+            native_bbox=(-1.0, -1.0, 1.0, 1.0),
+        )
+
+
+def test_wcs_row_degenerate_bbox_rejected():
+    """A wcs row with a zero-area native_bbox fails validation."""
+    with pytest.raises(ValidationError, match="degenerate native_bbox"):
+        Dataset(
+            transport="wcs",
+            endpoint="https://x/wcs",
+            dataset_id="c:mean",
+            variable="elevation",
+            wcs_version="1.0.0",
+            native_bbox=(0.0, 0.0, 0.0, 0.0),
+        )
+
+
 def test_griddap_row_needs_no_wcs_fields():
     """A griddap row builds without the WCS-only fields (they stay defaulted)."""
     row = Dataset(

--- a/libs/providers/land/tests/bathymetry/test_catalog.py
+++ b/libs/providers/land/tests/bathymetry/test_catalog.py
@@ -23,9 +23,18 @@ def catalog() -> Catalog:
     return Catalog()
 
 
-def test_catalog_loads_three_dems(catalog: Catalog):
-    """The shipped catalog carries the three curated DEM rows."""
-    assert sorted(catalog.datasets) == ["etopo1_bedrock", "etopo1_ice", "gebco_2020"]
+def test_catalog_loads_curated_dems(catalog: Catalog):
+    """The shipped catalog carries the GEBCO, ETOPO, and EMODnet rows."""
+    assert sorted(catalog.datasets) == [
+        "emodnet",
+        "emodnet_2016",
+        "emodnet_2018",
+        "emodnet_2020",
+        "emodnet_2022",
+        "etopo1_bedrock",
+        "etopo1_ice",
+        "gebco_2020",
+    ]
 
 
 def test_available_datasets_matches_curated(catalog: Catalog):

--- a/libs/providers/land/tests/bathymetry/test_emodnet_wcs_e2e.py
+++ b/libs/providers/land/tests/bathymetry/test_emodnet_wcs_e2e.py
@@ -1,0 +1,78 @@
+"""Live end-to-end test for the EMODnet Bathymetry WCS row.
+
+Hits the real, public EMODnet Bathymetry OGC WCS (no credentials), so it is
+gated behind the `e2e` + `bathymetry` pytest markers plus network availability.
+A default `pytest` invocation skips it.
+
+Run with:
+
+    uv run --active pytest -m "e2e and bathymetry" libs/providers/land/tests/bathymetry
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from earthlens.earthlens import EarthLens
+
+pytestmark = [pytest.mark.e2e, pytest.mark.bathymetry]
+
+#: The EMODnet Bathymetry OGC WCS endpoint.
+_WCS_URL = "https://ows.emodnet-bathymetry.eu/wcs"
+
+#: A tiny North Sea AOI well inside the EMODnet coverage — small enough to fetch
+#: in seconds and reliably below sea level (so depths come back negative).
+_LAT_LIM = [53.0, 54.0]
+_LON_LIM = [2.0, 3.0]
+
+
+def _wcs_reachable() -> bool:
+    """Return whether the EMODnet WCS answers a quick GetCapabilities GET."""
+    url = f"{_WCS_URL}?service=WCS&request=GetCapabilities&version=1.0.0"
+    try:
+        with urllib.request.urlopen(url, timeout=15) as response:
+            return response.status == 200
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _skip_when_offline() -> None:
+    """Skip the live test cleanly when the EMODnet WCS host is unreachable."""
+    if not _wcs_reachable():
+        pytest.skip("EMODnet Bathymetry WCS unreachable (offline)")
+
+
+def _elevation_stats(path: Path) -> tuple[float, float]:
+    """Return the `(min, max)` finite elevation of a written GeoTIFF."""
+    from pyramids.dataset import Dataset
+
+    dataset = Dataset.read_file(str(path))
+    array = dataset.read_array()
+    finite = array[np.isfinite(array)]
+    return float(finite.min()), float(finite.max())
+
+
+class TestEmodnetLiveFetch:
+    """Live EMODnet DTM subset over OGC WCS (no credentials)."""
+
+    def test_emodnet_subset_writes_ocean_geotiff(self, tmp_path: Path):
+        """A small EMODnet pull lands one GeoTIFF of plausible North Sea depths."""
+        paths = EarthLens(
+            data_source="bathymetry",
+            dataset="emodnet",
+            lat_lim=_LAT_LIM,
+            lon_lim=_LON_LIM,
+            path=str(tmp_path),
+        ).download(progress_bar=False)
+
+        assert len(paths) == 1, f"expected one GeoTIFF, got {paths}"
+        assert paths[0].suffix == ".tif" and paths[0].exists()
+        low, high = _elevation_stats(paths[0])
+        assert -11000 < low <= high < 100, f"implausible depths: {low}..{high}"
+        assert low < 0, "a North Sea AOI must carry sub-sea-level depths"

--- a/libs/providers/land/tests/bathymetry/test_emodnet_wcs_e2e.py
+++ b/libs/providers/land/tests/bathymetry/test_emodnet_wcs_e2e.py
@@ -72,7 +72,8 @@ class TestEmodnetLiveFetch:
         ).download(progress_bar=False)
 
         assert len(paths) == 1, f"expected one GeoTIFF, got {paths}"
-        assert paths[0].suffix == ".tif" and paths[0].exists()
+        assert paths[0].suffix == ".tif", f"expected a .tif, got {paths[0]}"
+        assert paths[0].exists(), f"the GeoTIFF was not written: {paths[0]}"
         low, high = _elevation_stats(paths[0])
         assert -11000 < low <= high < 100, f"implausible depths: {low}..{high}"
         assert low < 0, "a North Sea AOI must carry sub-sea-level depths"

--- a/libs/providers/land/tests/bathymetry/test_no_xarray.py
+++ b/libs/providers/land/tests/bathymetry/test_no_xarray.py
@@ -1,0 +1,22 @@
+"""Guard that the bathymetry backend never imports xarray (the competitor rule)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import earthlens.bathymetry as bathymetry_pkg
+
+pytestmark = pytest.mark.bathymetry
+
+
+def test_no_xarray_import_in_src():
+    """No source file under earthlens.bathymetry imports xarray."""
+    package_dir = Path(bathymetry_pkg.__file__).parent
+    offenders = [
+        path.name
+        for path in package_dir.rglob("*.py")
+        if "import xarray" in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == [], f"xarray imported in: {offenders}"

--- a/libs/providers/land/tests/bathymetry/test_wcs.py
+++ b/libs/providers/land/tests/bathymetry/test_wcs.py
@@ -97,7 +97,8 @@ def test_polygon_aoi_masks_before_write(tmp_path: Path, fake_from_wcs: dict):
     Bathymetry(dataset="emodnet", aoi=wkt, path=tmp_path).download()
     masked = fake_from_wcs.get("masked")
     assert masked is not None, "crop(mask=) should be applied for a polygon aoi"
-    assert masked["mask"] is not None and masked["touch"] is True
+    assert masked["mask"] is not None, "a polygon mask must be passed to crop()"
+    assert masked["touch"] is True, "touch=True should be forwarded to crop()"
 
 
 def test_out_of_domain_raises_before_request(tmp_path: Path, fake_from_wcs: dict):
@@ -196,8 +197,9 @@ def test_from_wcs_failure_is_wrapped(tmp_path: Path, monkeypatch: pytest.MonkeyP
         raise RuntimeError("server exploded")
 
     monkeypatch.setattr(pyramids_dataset.Dataset, "from_wcs", staticmethod(_boom))
+    backend = _make("emodnet", tmp_path)
     with pytest.raises(ValueError, match="WCS request for 'emodnet'"):
-        _make("emodnet", tmp_path).download()
+        backend.download()
 
 
 def test_griddap_row_never_calls_from_wcs(

--- a/libs/providers/land/tests/bathymetry/test_wcs.py
+++ b/libs/providers/land/tests/bathymetry/test_wcs.py
@@ -10,6 +10,7 @@ import requests
 
 from earthlens.bathymetry import backend as backend_module
 from earthlens.bathymetry.backend import Bathymetry
+from earthlens.bathymetry.catalog import Dataset
 
 pytestmark = pytest.mark.bathymetry
 
@@ -159,6 +160,24 @@ def test_domain_guard_noops_without_native_bbox(tmp_path: Path, fake_from_wcs: d
     assert griddap_row.native_bbox is None
     # A row with no advertised extent cannot be guarded — this must not raise.
     backend._guard_wcs_domain(griddap_row, (0.0, 0.0, 1.0, 1.0))
+
+
+def test_non_wgs84_row_skips_numeric_guard(tmp_path: Path, fake_from_wcs: dict):
+    """A wcs row in a projected CRS skips the lon/lat guard rather than mis-reject."""
+    projected = Dataset(
+        id="proj",
+        transport="wcs",
+        endpoint="https://x/wcs",
+        dataset_id="proj:mean",
+        variable="elevation",
+        wcs_version="1.0.0",
+        crs="EPSG:3857",
+        native_bbox=(0.0, 0.0, 1.0, 1.0),
+    )
+    backend = _make("emodnet", tmp_path)
+    # This bbox is far outside native_bbox and would be rejected under EPSG:4326;
+    # a projected-CRS row must skip the numeric comparison and not raise.
+    backend._guard_wcs_domain(projected, (100.0, 100.0, 200.0, 200.0))
 
 
 def test_from_wcs_failure_is_wrapped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/libs/providers/land/tests/bathymetry/test_wcs.py
+++ b/libs/providers/land/tests/bathymetry/test_wcs.py
@@ -14,7 +14,7 @@ from earthlens.bathymetry.catalog import Dataset
 
 pytestmark = pytest.mark.bathymetry
 
-#: A North Sea AOI well inside the EMODnet coverage (west, east / south, north).
+#: A North Sea AOI well inside the EMODnet coverage (lat 53..55, lon 2..4).
 _NORTH_SEA = {"lat_lim": [53.0, 55.0], "lon_lim": [2.0, 4.0]}
 
 
@@ -133,7 +133,7 @@ def test_partial_overlap_warns_but_proceeds(
     """An AOI straddling the coverage edge warns about zero-fill but still fetches."""
     seen: list[str] = []
     monkeypatch.setattr(backend_module.logger, "warning", seen.append)
-    # East edge of the EMODnet extent is 43.0; this AOI poks past it to 45.0.
+    # East edge of the EMODnet extent is 43.0; this AOI pokes past it to 45.0.
     Bathymetry(
         dataset="emodnet",
         lat_lim=[40.0, 42.0],

--- a/libs/providers/land/tests/bathymetry/test_wcs.py
+++ b/libs/providers/land/tests/bathymetry/test_wcs.py
@@ -154,6 +154,14 @@ def test_fully_contained_aoi_does_not_warn(
     assert not any("extends beyond" in message for message in seen)
 
 
+def test_http_client_is_built_once_and_reused(tmp_path: Path, fake_from_wcs: dict):
+    """The pooled HttpClient is created once and reused across calls."""
+    backend = _make("emodnet", tmp_path)
+    first = backend._client()
+    second = backend._client()
+    assert first is second, "the client must be cached on the instance, not rebuilt"
+
+
 def test_domain_guard_noops_without_native_bbox(tmp_path: Path, fake_from_wcs: dict):
     """The domain guard is a no-op for a row that declares no native_bbox."""
     backend = _make("emodnet", tmp_path)

--- a/libs/providers/land/tests/bathymetry/test_wcs.py
+++ b/libs/providers/land/tests/bathymetry/test_wcs.py
@@ -1,0 +1,170 @@
+"""Unit tests for the bathymetry WCS transport (faked pyramids from_wcs)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyramids.dataset as pyramids_dataset
+import pytest
+import requests
+
+from earthlens.bathymetry import backend as backend_module
+from earthlens.bathymetry.backend import Bathymetry
+
+pytestmark = pytest.mark.bathymetry
+
+#: A North Sea AOI well inside the EMODnet coverage (west, east / south, north).
+_NORTH_SEA = {"lat_lim": [53.0, 55.0], "lon_lim": [2.0, 4.0]}
+
+
+class _FakeWcsDataset:
+    """Stand-in for the Dataset from `from_wcs`: records crop, writes a stub tif."""
+
+    def __init__(self, recorder: dict):
+        self._recorder = recorder
+
+    def crop(self, mask=None, touch: bool = True):
+        """Record the polygon-mask call and return the (masked) dataset."""
+        self._recorder["masked"] = {"mask": mask, "touch": touch}
+        return self
+
+    def to_file(self, path: str) -> None:
+        """Write a tiny stub GeoTIFF and record the destination."""
+        Path(path).write_bytes(b"II*\x00stub-geotiff")
+        self._recorder.setdefault("written", []).append(path)
+
+
+@pytest.fixture
+def fake_from_wcs(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Patch pyramids `Dataset.from_wcs` to record its call and return a stub."""
+    recorder: dict = {}
+
+    def _fake(endpoint, *, coverage, bbox, crs="EPSG:4326", version=None, **kwargs):
+        recorder["call"] = {
+            "endpoint": endpoint,
+            "coverage": coverage,
+            "bbox": bbox,
+            "crs": crs,
+            "version": version,
+            "timeout": kwargs.get("timeout"),
+        }
+        return _FakeWcsDataset(recorder)
+
+    monkeypatch.setattr(pyramids_dataset.Dataset, "from_wcs", staticmethod(_fake))
+    return recorder
+
+
+def _make(dataset: str, tmp_path: Path, **kwargs) -> Bathymetry:
+    """Construct an EMODnet-region Bathymetry writing under tmp_path."""
+    params = dict(_NORTH_SEA)
+    params.update(kwargs)
+    return Bathymetry(dataset=dataset, path=tmp_path, **params)
+
+
+def test_emodnet_download_calls_from_wcs_and_writes(
+    tmp_path: Path, fake_from_wcs: dict
+):
+    """An EMODnet request routes through from_wcs and returns a .tif path."""
+    result = _make("emodnet", tmp_path).download()
+    call = fake_from_wcs["call"]
+    assert call["endpoint"] == "https://ows.emodnet-bathymetry.eu/wcs"
+    assert call["coverage"] == "emodnet:mean"
+    assert call["bbox"] == (2.0, 53.0, 4.0, 55.0)
+    assert call["crs"] == "EPSG:4326"
+    assert call["version"] == "1.0.0"
+    assert result == [tmp_path.absolute() / "emodnet.tif"]
+    assert result[0].exists()
+
+
+def test_release_variant_uses_year_coverage(tmp_path: Path, fake_from_wcs: dict):
+    """A year-stamped release row requests its own colon coverage id."""
+    _make("emodnet_2020", tmp_path).download()
+    assert fake_from_wcs["call"]["coverage"] == "emodnet:mean_2020"
+
+
+def test_bbox_only_request_is_not_masked(tmp_path: Path, fake_from_wcs: dict):
+    """A plain bbox request trusts the WCS subset — no client-side mask."""
+    _make("emodnet", tmp_path).download()
+    assert "masked" not in fake_from_wcs
+    assert fake_from_wcs["written"], "the dataset was still written"
+
+
+def test_polygon_aoi_masks_before_write(tmp_path: Path, fake_from_wcs: dict):
+    """A polygon aoi= is honoured via crop(mask=) before the write."""
+    wkt = "POLYGON ((2 53, 4 53, 4 55, 2 55, 2 53))"
+    Bathymetry(dataset="emodnet", aoi=wkt, path=tmp_path).download()
+    masked = fake_from_wcs.get("masked")
+    assert masked is not None, "crop(mask=) should be applied for a polygon aoi"
+    assert masked["mask"] is not None and masked["touch"] is True
+
+
+def test_out_of_domain_raises_before_request(tmp_path: Path, fake_from_wcs: dict):
+    """A mid-Pacific AOI is rejected by the domain guard before any request."""
+    backend = Bathymetry(
+        dataset="emodnet",
+        lat_lim=[-5.0, -3.0],
+        lon_lim=[-140.0, -138.0],
+        path=tmp_path,
+    )
+    with pytest.raises(ValueError, match="outside the 'emodnet' coverage"):
+        backend.download()
+    assert "call" not in fake_from_wcs, "from_wcs must not be called out of domain"
+
+
+def test_out_of_domain_message_points_at_global_dems(
+    tmp_path: Path, fake_from_wcs: dict
+):
+    """The out-of-domain error names the global GEBCO / ETOPO fallback."""
+    backend = Bathymetry(
+        dataset="emodnet",
+        lat_lim=[-5.0, -3.0],
+        lon_lim=[-140.0, -138.0],
+        path=tmp_path,
+    )
+    with pytest.raises(ValueError, match="gebco_2020"):
+        backend.download()
+
+
+def test_domain_guard_noops_without_native_bbox(tmp_path: Path, fake_from_wcs: dict):
+    """The domain guard is a no-op for a row that declares no native_bbox."""
+    backend = _make("emodnet", tmp_path)
+    griddap_row = backend._catalog.get("gebco_2020")
+    assert griddap_row.native_bbox is None
+    # A row with no advertised extent cannot be guarded — this must not raise.
+    backend._guard_wcs_domain(griddap_row, (0.0, 0.0, 1.0, 1.0))
+
+
+def test_from_wcs_failure_is_wrapped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A from_wcs error surfaces as a clear ValueError, not a raw exception."""
+
+    def _boom(endpoint, *, coverage, bbox, **kwargs):
+        raise RuntimeError("server exploded")
+
+    monkeypatch.setattr(pyramids_dataset.Dataset, "from_wcs", staticmethod(_boom))
+    with pytest.raises(ValueError, match="WCS request for 'emodnet'"):
+        _make("emodnet", tmp_path).download()
+
+
+def test_griddap_row_never_calls_from_wcs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A GEBCO (griddap) request never touches the WCS path."""
+
+    def _guard(*args, **kwargs):
+        raise AssertionError("from_wcs must not be called for a griddap row")
+
+    def _no_network(*args, **kwargs):
+        raise requests.exceptions.ConnectionError("offline")
+
+    monkeypatch.setattr(pyramids_dataset.Dataset, "from_wcs", staticmethod(_guard))
+    monkeypatch.setattr(backend_module.requests, "get", _no_network)
+    backend = Bathymetry(
+        dataset="gebco_2020",
+        lat_lim=[25.0, 26.0],
+        lon_lim=[-18.0, -17.0],
+        path=tmp_path,
+    )
+    # The griddap GET is stubbed offline; the point is that from_wcs (guarded
+    # above) is never reached for a griddap row.
+    with pytest.raises(ValueError):
+        backend.download()

--- a/libs/providers/land/tests/bathymetry/test_wcs.py
+++ b/libs/providers/land/tests/bathymetry/test_wcs.py
@@ -125,6 +125,33 @@ def test_out_of_domain_message_points_at_global_dems(
         backend.download()
 
 
+def test_partial_overlap_warns_but_proceeds(
+    tmp_path: Path, fake_from_wcs: dict, monkeypatch: pytest.MonkeyPatch
+):
+    """An AOI straddling the coverage edge warns about zero-fill but still fetches."""
+    seen: list[str] = []
+    monkeypatch.setattr(backend_module.logger, "warning", seen.append)
+    # East edge of the EMODnet extent is 43.0; this AOI poks past it to 45.0.
+    Bathymetry(
+        dataset="emodnet",
+        lat_lim=[40.0, 42.0],
+        lon_lim=[42.0, 45.0],
+        path=tmp_path,
+    ).download()
+    assert any("extends beyond the coverage extent" in message for message in seen)
+    assert "call" in fake_from_wcs, "a partial-overlap AOI must still fetch"
+
+
+def test_fully_contained_aoi_does_not_warn(
+    tmp_path: Path, fake_from_wcs: dict, monkeypatch: pytest.MonkeyPatch
+):
+    """A fully in-coverage AOI fetches with no out-of-domain warning."""
+    seen: list[str] = []
+    monkeypatch.setattr(backend_module.logger, "warning", seen.append)
+    _make("emodnet", tmp_path).download()
+    assert not any("extends beyond" in message for message in seen)
+
+
 def test_domain_guard_noops_without_native_bbox(tmp_path: Path, fake_from_wcs: dict):
     """The domain guard is a no-op for a row that declares no native_bbox."""
     backend = _make("emodnet", tmp_path)

--- a/libs/providers/land/tests/bathymetry/test_wcs.py
+++ b/libs/providers/land/tests/bathymetry/test_wcs.py
@@ -73,6 +73,7 @@ def test_emodnet_download_calls_from_wcs_and_writes(
     assert call["bbox"] == (2.0, 53.0, 4.0, 55.0)
     assert call["crs"] == "EPSG:4326"
     assert call["version"] == "1.0.0"
+    assert call["timeout"] == 120.0
     assert result == [tmp_path.absolute() / "emodnet.tif"]
     assert result[0].exists()
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -644,6 +644,7 @@ nav:
       - Shaded relief (live): examples/bathymetry/05_shaded_relief.ipynb
       - Depth distribution (live): examples/bathymetry/06_depth_histogram.ipynb
       - EMODnet European DTM — OGC WCS (live): examples/bathymetry/07_emodnet_european_bathymetry.ipynb
+      - EMODnet WCS deep dive — transport, releases, domain guard (live): examples/bathymetry/08_emodnet_wcs_deep_dive.ipynb
     - Copernicus DEM (global land elevation):
       - DEM quickstart (live): examples/dem/01_dem_quickstart.ipynb
       - Catalog & tile math (no network): examples/dem/02_catalog_and_tile_math.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -643,6 +643,7 @@ nav:
       - GEBCO vs ETOPO1 resolution (live): examples/bathymetry/04_gebco_vs_etopo_resolution.ipynb
       - Shaded relief (live): examples/bathymetry/05_shaded_relief.ipynb
       - Depth distribution (live): examples/bathymetry/06_depth_histogram.ipynb
+      - EMODnet European DTM — OGC WCS (live): examples/bathymetry/07_emodnet_european_bathymetry.ipynb
     - Copernicus DEM (global land elevation):
       - DEM quickstart (live): examples/dem/01_dem_quickstart.ipynb
       - Catalog & tile math (no network): examples/dem/02_catalog_and_tile_math.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -411,7 +411,7 @@ markers = [
     "ptree: e2e-only selector for the live P-Tree Himawari HSD FTP fetch (needs $JAXA_PTREE_USERNAME + $JAXA_PTREE_PASSWORD; 30-day rolling archive; the no-network ptree unit tests carry `@pytest.mark.jaxa + @pytest.mark.unit` instead so `-m ptree` does not pick them up).",
     "argo: tests for the Argo float-profile backend (requires the `argo` extra: argopy; open data, no auth).",
     "erddap: tests for the generic ERDDAP backend (requires the `erddap` extra: erddapy; griddap raster via direct .nc download + pyramids, tabledap tabular via to_pandas; public servers only).",
-    "bathymetry: tests for the bathymetry DEM backend (GEBCO 2020 + ETOPO1 ice/bedrock via NOAA ERDDAP griddap; no extra SDK — core requests + pyramids).",
+    "bathymetry: tests for the bathymetry DEM backend (GEBCO 2020 + ETOPO1 ice/bedrock via NOAA ERDDAP griddap; EMODnet Bathymetry European DTM via OGC WCS; no extra SDK — core requests + pyramids).",
     "fabdem: tests for the FABDEM V1-2 bare-earth DEM backend (Forest And Buildings removed Copernicus DEM, ~30m; open HTTPS from the University of Bristol, no extra SDK — core requests + pyramids; CC-BY-NC-SA 4.0 non-commercial).",
     "jrc_flood: tests for the JRC European Flood Hazard Map backend (river-flood water depth per return period, Europe + Mediterranean; open HTTPS from the JRC, no extra SDK — core requests + pyramids `/vsicurl` windowed reads; CC-BY 4.0).",
     "solar_wind_atlas: tests for the Solar & Wind Atlas backend (Global Solar Atlas + Global Wind Atlas climatology layers; no extra SDK — core requests + pyramids; GWA windowed /vsicurl COG read, GSA download-then-localise).",


### PR DESCRIPTION
# Description

Adds **EMODnet Bathymetry** as a second transport (`wcs`) on the existing `bathymetry` land backend, alongside the
NOAA ERDDAP `griddap` DEMs (GEBCO / ETOPO). The European high-resolution Digital Terrain Model (mean sea-floor
depth, ~3.75 arc-second) is read over **OGC WCS** through pyramids `Dataset.from_wcs`, cropped to the AOI, and
written as GeoTIFF — the coastal / shelf complement to the global DEMs. It rides the backend's existing
`download() -> list[Path]` raster contract.

- Five curated rows: `emodnet` (latest DTM 2024) + year-stamped `emodnet_2022/_2020/_2018/_2016`.
- The `Dataset` model gains a `wcs` transport plus `wcs_version` / `crs` / `native_bbox` fields and a
  `_check_wcs_fields` validator; the backend dispatches on transport (`_fetch_griddap` / `_fetch_wcs`) with an
  out-of-domain guard (reject fully-outside, warn on partial overlap, skip for non-EPSG:4326 rows).
- **Transport fact (pinned live):** GDAL's WCS driver reads this GeoServer only at **WCS `1.0.0`** with coverage
  id **`emodnet:mean`** (colon) — the 2.0.1 `emodnet__mean` id fails GDAL subsetting.

Dependencies: none new — pyramids (WCS reader, 0.46.0) and the core `HttpClient` are already core. No `xarray`.
The RGB colour coverages (`*_atlas_land` / `_multicolour` / `_rainbowcolour`) are deliberately out of scope
(rendered images, not depth data). The ERDDAP-griddap path is unchanged.

# Issues

- Closes #1005 — A1 gate: pin the EMODnet WCS coverage id / `from_wcs` signature / CRS / licence
- Closes #1006 — C1 catalog rows (`emodnet.yaml` + `_index.yaml` + `Dataset` wcs fields)
- Closes #1007 — C2 backend `transport: wcs` branch via pyramids `from_wcs`
- Closes #1008 — A2 conformance sweep
- Closes #1009 — C3 EMODnet WCS unit tests (no network)
- Closes #1010 — C4 docs + gated e2e + example notebook

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- **Full non-e2e suite:** `pytest -m "not e2e"` → **8925 passed, 15 skipped**.
- **Bathymetry unit tests:** 89 passed; bathymetry `src/` coverage **99%** (WCS additions fully covered), all offline
  (faked `pyramids.Dataset.from_wcs`).
- **Gated e2e (live EMODnet WCS):** `pytest -m "e2e and bathymetry"` → **1 passed** — a live North Sea AOI cutout
  returns a real cropped DTM GeoTIFF (depths −88..−5 m).
- **Example notebook** `docs/examples/bathymetry/07_emodnet_european_bathymetry.ipynb` executed end-to-end against
  the live WCS.
- ruff check + ruff format + mypy clean on the touched files; doctests green.

Reproduce:

```bash
uv sync --extra all --group dev
pytest -m "not e2e" -q                              # unit + integration
pytest -m "e2e and bathymetry" -q                   # live EMODnet WCS
```

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
