### PR TITLE
fix(ghsl): fail an unresponsive JRC host fast with a split connect/read timeout

### DIFF
--- a/libs/core/src/earthlens/base/__init__.py
+++ b/libs/core/src/earthlens/base/__init__.py
@@ -37,6 +37,7 @@ from earthlens.base.http import (
     HttpClient,
     HttpRangeFile,
     RangeReadError,
+    Timeout,
     redact_url,
 )
 from earthlens.base.leaves import FluxableLeaf
@@ -96,6 +97,7 @@ __all__ = [
     "SpatialExtent",
     "split_time",
     "TemporalExtent",
+    "Timeout",
     "to_datetime",
     "warn_if_egress",
     "WHOLE_WINDOW",

--- a/libs/core/src/earthlens/base/http.py
+++ b/libs/core/src/earthlens/base/http.py
@@ -26,7 +26,9 @@ throttle policy.
 
 `requests` and `tqdm` are already core earthlens dependencies, so this
 module adds none. The public imports are
-`from earthlens.base.http import HttpClient, HttpRangeFile`.
+`from earthlens.base.http import HttpClient, HttpRangeFile, Timeout`
+(`Timeout` is the `float | tuple[float, float]` alias every timeout
+parameter accepts).
 """
 
 from __future__ import annotations

--- a/libs/core/src/earthlens/base/http.py
+++ b/libs/core/src/earthlens/base/http.py
@@ -1047,7 +1047,7 @@ class HttpRangeFile(io.RawIOBase):
         *,
         client: HttpClient | None = None,
         size: int | None = None,
-        timeout: float | None = None,
+        timeout: Timeout | None = None,
     ) -> None:
         """Open the remote object and resolve its length.
 
@@ -1061,8 +1061,10 @@ class HttpRangeFile(io.RawIOBase):
             size: Total object size when the caller already knows it (e.g.
                 from a catalog row). Skips the size probe entirely — one
                 fewer round trip.
-            timeout: Per-request timeout override in seconds, applied to
-                the size probe and every read.
+            timeout: Per-request timeout override in seconds — a single float
+                or a `(connect, read)` pair — applied to the size probe and
+                every read. The pair fails a dead host on the short connect
+                budget without shortening the read budget a range read needs.
 
         Raises:
             ValueError: When the object's size cannot be determined —

--- a/libs/core/src/earthlens/base/http.py
+++ b/libs/core/src/earthlens/base/http.py
@@ -47,8 +47,15 @@ import requests
 from loguru import logger
 from tqdm import tqdm
 
+#: A `requests`-style timeout: either a single float applied to both the
+#: connect and read phases, or a `(connect, read)` pair that bounds them
+#: separately. A short connect budget fails a dead or blocked host in seconds
+#: — a TCP handshake that will never complete is not worth the read budget —
+#: while a long read budget still lets a large transfer run to completion.
+Timeout = float | tuple[float, float]
+
 #: Per-request timeout (seconds) applied when a call passes no `timeout`.
-DEFAULT_TIMEOUT = 60.0
+DEFAULT_TIMEOUT: Timeout = 60.0
 
 #: Maximum retries for a retryable status before the last response's
 #: error is raised.
@@ -418,7 +425,7 @@ class HttpClient:
         session: requests.Session | None = None,
         user_agent: str | None = None,
         headers: dict[str, str] | None = None,
-        timeout: float = DEFAULT_TIMEOUT,
+        timeout: Timeout = DEFAULT_TIMEOUT,
         max_retries: int = DEFAULT_MAX_RETRIES,
         backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
         status_forcelist: tuple[int, ...] = DEFAULT_STATUS_FORCELIST,
@@ -442,7 +449,10 @@ class HttpClient:
             headers: Extra default headers merged onto every request
                 (e.g. `{"X-API-Key": ...}`). Override per call with a
                 request-level `headers=`.
-            timeout: Per-request timeout in seconds.
+            timeout: Per-request timeout in seconds — a single float bounds
+                both the connect and read phases, or pass a `(connect, read)`
+                pair to bound them separately (a short connect budget fails a
+                dead host fast without shortening the read budget).
             max_retries: Maximum retries on a retryable status before the
                 last response's error is raised.
             backoff_factor: Base seconds for exponential back-off when a
@@ -519,7 +529,7 @@ class HttpClient:
         url: str,
         *,
         headers: dict[str, str] | None = None,
-        timeout: float | None = None,
+        timeout: Timeout | None = None,
         raise_for_status: bool | None = None,
         **kwargs: Any,
     ) -> requests.Response:
@@ -529,8 +539,9 @@ class HttpClient:
             method: HTTP verb (`"GET"`, `"POST"`, ...).
             url: Absolute request URL.
             headers: Per-request headers merged over the client defaults.
-            timeout: Per-request timeout override (seconds). Defaults to
-                the client's `timeout`.
+            timeout: Per-request timeout override (seconds), as a single
+                float or a `(connect, read)` pair. Defaults to the client's
+                `timeout`.
             raise_for_status: Per-request override of the client's
                 `raise_for_status` policy. `None` (default) uses the
                 client setting.
@@ -648,7 +659,7 @@ class HttpClient:
         atomic: bool = True,
         expect_magic: bytes | tuple[bytes, ...] | None = None,
         headers: dict[str, str] | None = None,
-        timeout: float | None = None,
+        timeout: Timeout | None = None,
         **kwargs: Any,
     ) -> Path:
         """Stream `url` to `dest` atomically, optionally showing a `tqdm` bar.
@@ -685,7 +696,10 @@ class HttpClient:
                 discarded, so an HTML error page served with a 200 status never
                 lands as a `.nc`. `None` (the default) skips the check.
             headers: Per-request headers merged over the client defaults.
-            timeout: Per-request timeout override (seconds).
+            timeout: Per-request timeout override (seconds), as a single
+                float or a `(connect, read)` pair — the latter fails a dead
+                host on the short connect budget without shortening the long
+                read budget a large download needs.
             **kwargs: Extra keyword arguments forwarded to `requests`.
 
         Returns:

--- a/libs/core/src/earthlens/base/http.py
+++ b/libs/core/src/earthlens/base/http.py
@@ -401,7 +401,8 @@ class HttpClient:
     subclassing.
 
     Attributes:
-        timeout: Per-request timeout in seconds.
+        timeout: Per-request timeout in seconds — a single float, or a
+            `(connect, read)` pair bounding the two phases separately.
         max_retries: Maximum retries on a retryable status before raising.
         backoff_factor: Base seconds for exponential back-off when no
             `Retry-After` header is present.

--- a/libs/core/tests/base/test_http.py
+++ b/libs/core/tests/base/test_http.py
@@ -300,6 +300,18 @@ class TestRequest:
         client.get("http://x", timeout=3.0)
         assert session.calls[0][2]["timeout"] == 3.0
 
+    def test_get_default_tuple_timeout_is_forwarded(self):
+        """A client's (connect, read) default reaches the session unchanged."""
+        client, session, _ = _client([_Resp(body={})], timeout=(3.05, 27.0))
+        client.get("http://x")
+        assert session.calls[0][2]["timeout"] == (3.05, 27.0)
+
+    def test_get_tuple_timeout_override_is_forwarded(self):
+        """A per-request (connect, read) tuple overrides a scalar default."""
+        client, session, _ = _client([_Resp(body={})], timeout=12.0)
+        client.get("http://x", timeout=(5.0, 120.0))
+        assert session.calls[0][2]["timeout"] == (5.0, 120.0)
+
     def test_post_dispatches_to_session_post(self):
         """post() routes to the session's post verb."""
         client, session, _ = _client([_Resp(body={})])
@@ -655,6 +667,22 @@ class TestDownload:
         session = _RecordingSession([_Resp(blocks=[b"a"])])
         HttpClient(session=session).download("http://x", tmp_path / "f", progress=False)
         assert session.calls[0][2]["stream"] is True
+
+    def test_download_forwards_tuple_timeout(self, tmp_path):
+        """download forwards a (connect, read) timeout pair to the streaming GET."""
+        session = _RecordingSession([_Resp(blocks=[b"ok"])])
+        HttpClient(session=session).download(
+            "http://x", tmp_path / "f", progress=False, timeout=(5.0, 120.0)
+        )
+        assert session.calls[0][2]["timeout"] == (5.0, 120.0)
+
+    def test_download_uses_default_tuple_timeout(self, tmp_path):
+        """download streams with the client's default tuple when none is given."""
+        session = _RecordingSession([_Resp(blocks=[b"ok"])])
+        HttpClient(session=session, timeout=(3.05, 60.0)).download(
+            "http://x", tmp_path / "f", progress=False
+        )
+        assert session.calls[0][2]["timeout"] == (3.05, 60.0)
 
     def test_download_closes_response(self, tmp_path):
         """download closes the streaming response when finished."""

--- a/libs/core/tests/base/test_http_range_file.py
+++ b/libs/core/tests/base/test_http_range_file.py
@@ -235,6 +235,16 @@ class TestRead:
 
         assert session.get_calls[0][1]["headers"]["Accept-Encoding"] == "identity"
 
+    def test_split_timeout_reaches_the_probe_and_reads(self):
+        """A (connect, read) timeout is forwarded to the size probe and the read."""
+        session = _RangeSession(b"0123456789")
+        handle = _range_file(session, timeout=(5.0, 30.0))
+
+        handle.read(4)
+
+        assert session.head_kwargs[0]["timeout"] == (5.0, 30.0)
+        assert session.get_calls[0][1]["timeout"] == (5.0, 30.0)
+
     def test_counters_track_requests_and_bytes(self):
         """The cost of a range-read session is observable, probe included."""
         handle = _range_file(_RangeSession(b"0123456789"))

--- a/libs/core/tests/test_distribution_boundaries.py
+++ b/libs/core/tests/test_distribution_boundaries.py
@@ -303,6 +303,14 @@ class TestSharedHelpersAreNotReimplemented:
 
         assert callable(close_quietly)
 
+    def test_timeout_is_exported(self):
+        """The public timeout alias is re-exported from the base package."""
+        from earthlens.base import Timeout, __all__
+        from earthlens.base.http import Timeout as HttpTimeout
+
+        assert Timeout is HttpTimeout
+        assert "Timeout" in __all__
+
 
 class TestCatalogParseCacheIsBounded:
     """Every backend's parse cache evicts superseded generations."""

--- a/libs/providers/atmosphere/src/earthlens/airnow/client.py
+++ b/libs/providers/atmosphere/src/earthlens/airnow/client.py
@@ -70,7 +70,8 @@ class AirnowClient:
             max_retries: Maximum `429` retries before raising.
             backoff_factor: Base seconds for exponential back-off when the
                 response carries no `Retry-After` header.
-            timeout: Per-request timeout in seconds — a float or a `(connect, read)` pair.
+            timeout: Per-request timeout in seconds — a float or a
+                `(connect, read)` pair.
             sleep: The sleep function used between retries. Defaults to
                 `time.sleep`; injectable so tests run without real delays.
         """

--- a/libs/providers/atmosphere/src/earthlens/airnow/client.py
+++ b/libs/providers/atmosphere/src/earthlens/airnow/client.py
@@ -47,7 +47,7 @@ class AirnowClient:
             response's error is raised.
         backoff_factor: Base seconds for exponential back-off when no
             `Retry-After` header is present (wait = factor * 2**attempt).
-        timeout: Per-request timeout in seconds.
+        timeout: Per-request timeout in seconds — a float or a `(connect, read)` pair.
     """
 
     def __init__(
@@ -57,7 +57,7 @@ class AirnowClient:
         session: requests.Session | None = None,
         max_retries: int = 5,
         backoff_factor: float = 1.0,
-        timeout: float = 60.0,
+        timeout: Timeout = 60.0,
         sleep: Callable[[float], None] = time.sleep,
     ) -> None:
         """Build a client bound to one API key.
@@ -70,7 +70,7 @@ class AirnowClient:
             max_retries: Maximum `429` retries before raising.
             backoff_factor: Base seconds for exponential back-off when the
                 response carries no `Retry-After` header.
-            timeout: Per-request timeout in seconds.
+            timeout: Per-request timeout in seconds — a float or a `(connect, read)` pair.
             sleep: The sleep function used between retries. Defaults to
                 `time.sleep`; injectable so tests run without real delays.
         """

--- a/libs/providers/atmosphere/src/earthlens/airnow/client.py
+++ b/libs/providers/atmosphere/src/earthlens/airnow/client.py
@@ -28,7 +28,7 @@ from typing import Any
 
 import requests
 
-from earthlens.base.http import HttpClient
+from earthlens.base.http import HttpClient, Timeout
 
 #: AirNow bounding-box observations endpoint.
 BASE_URL = "https://www.airnowapi.org/aq/data/"
@@ -96,8 +96,8 @@ class AirnowClient:
         return self._http.backoff_factor
 
     @property
-    def timeout(self) -> float:
-        """Per-request timeout in seconds."""
+    def timeout(self) -> Timeout:
+        """Per-request timeout in seconds (a float or a `(connect, read)` pair)."""
         return self._http.timeout
 
     def get_data(self, params: dict[str, Any]) -> list[dict[str, Any]]:

--- a/libs/providers/atmosphere/src/earthlens/openaq/client.py
+++ b/libs/providers/atmosphere/src/earthlens/openaq/client.py
@@ -65,7 +65,7 @@ class OpenaqClient:
             response's error is raised.
         backoff_factor: Base seconds for exponential back-off when no
             `Retry-After` header is present (wait = factor * 2**attempt).
-        timeout: Per-request timeout in seconds.
+        timeout: Per-request timeout in seconds — a float or a `(connect, read)` pair.
     """
 
     def __init__(
@@ -75,7 +75,7 @@ class OpenaqClient:
         session: requests.Session | None = None,
         max_retries: int = 5,
         backoff_factor: float = 1.0,
-        timeout: float = 60.0,
+        timeout: Timeout = 60.0,
         sleep: Callable[[float], None] = time.sleep,
     ) -> None:
         """Build a client bound to one API key.
@@ -88,7 +88,7 @@ class OpenaqClient:
             max_retries: Maximum `429` retries before raising.
             backoff_factor: Base seconds for exponential back-off when
                 the response carries no `Retry-After` header.
-            timeout: Per-request timeout in seconds.
+            timeout: Per-request timeout in seconds — a float or a `(connect, read)` pair.
             sleep: The sleep function used between retries. Defaults to
                 :func:`time.sleep`; injectable so tests run without
                 real delays.

--- a/libs/providers/atmosphere/src/earthlens/openaq/client.py
+++ b/libs/providers/atmosphere/src/earthlens/openaq/client.py
@@ -88,7 +88,8 @@ class OpenaqClient:
             max_retries: Maximum `429` retries before raising.
             backoff_factor: Base seconds for exponential back-off when
                 the response carries no `Retry-After` header.
-            timeout: Per-request timeout in seconds — a float or a `(connect, read)` pair.
+            timeout: Per-request timeout in seconds — a float or a
+                `(connect, read)` pair.
             sleep: The sleep function used between retries. Defaults to
                 :func:`time.sleep`; injectable so tests run without
                 real delays.

--- a/libs/providers/atmosphere/src/earthlens/openaq/client.py
+++ b/libs/providers/atmosphere/src/earthlens/openaq/client.py
@@ -29,7 +29,7 @@ from typing import Any, cast
 
 import requests
 
-from earthlens.base.http import HttpClient
+from earthlens.base.http import HttpClient, Timeout
 
 #: OpenAQ v3 API base URL. All endpoint paths are joined onto this.
 BASE_URL = "https://api.openaq.org/v3"
@@ -115,8 +115,8 @@ class OpenaqClient:
         return self._http.backoff_factor
 
     @property
-    def timeout(self) -> float:
-        """Per-request timeout in seconds."""
+    def timeout(self) -> Timeout:
+        """Per-request timeout in seconds (a float or a `(connect, read)` pair)."""
         return self._http.timeout
 
     def _request(self, path: str, params: dict[str, Any]) -> dict[str, Any]:

--- a/libs/providers/atmosphere/src/earthlens/sensor_community/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/sensor_community/_helpers.py
@@ -26,7 +26,7 @@ import pandas as pd
 import requests
 from loguru import logger
 
-from earthlens.base.http import HttpClient
+from earthlens.base.http import HttpClient, Timeout
 
 #: Live JSON API: the last ~5 minutes of every sensor, globally.
 LIVE_URL = "https://data.sensor.community/static/v2/data.json"
@@ -120,8 +120,8 @@ class SensorCommunityClient:
         return self._http.backoff_factor
 
     @property
-    def timeout(self) -> float:
-        """Per-request timeout in seconds."""
+    def timeout(self) -> Timeout:
+        """Per-request timeout in seconds (a float or a `(connect, read)` pair)."""
         return self._http.timeout
 
     def live_snapshot(self) -> list[dict[str, Any]]:

--- a/libs/providers/atmosphere/src/earthlens/sensor_community/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/sensor_community/_helpers.py
@@ -95,7 +95,8 @@ class SensorCommunityClient:
                 fresh session. Injectable so tests supply a fake transport.
             max_retries: Maximum `429` retries before raising.
             backoff_factor: Base seconds for exponential back-off.
-            timeout: Per-request timeout in seconds — a float or a `(connect, read)` pair.
+            timeout: Per-request timeout in seconds — a float or a
+                `(connect, read)` pair.
             sleep: The sleep function used between retries. Defaults to
                 `time.sleep`; injectable so tests run without real delays.
         """

--- a/libs/providers/atmosphere/src/earthlens/sensor_community/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/sensor_community/_helpers.py
@@ -76,7 +76,7 @@ class SensorCommunityClient:
         max_retries: Maximum number of `429` retries before raising.
         backoff_factor: Base seconds for exponential back-off when no
             `Retry-After` header is present (wait = factor * 2**attempt).
-        timeout: Per-request timeout in seconds.
+        timeout: Per-request timeout in seconds — a float or a `(connect, read)` pair.
     """
 
     def __init__(
@@ -85,7 +85,7 @@ class SensorCommunityClient:
         session: requests.Session | None = None,
         max_retries: int = 3,
         backoff_factor: float = 1.0,
-        timeout: float = 60.0,
+        timeout: Timeout = 60.0,
         sleep: Callable[[float], None] = time.sleep,
     ) -> None:
         """Build a client over both Sensor.Community hosts.
@@ -95,7 +95,7 @@ class SensorCommunityClient:
                 fresh session. Injectable so tests supply a fake transport.
             max_retries: Maximum `429` retries before raising.
             backoff_factor: Base seconds for exponential back-off.
-            timeout: Per-request timeout in seconds.
+            timeout: Per-request timeout in seconds — a float or a `(connect, read)` pair.
             sleep: The sleep function used between retries. Defaults to
                 `time.sleep`; injectable so tests run without real delays.
         """

--- a/libs/providers/atmosphere/tests/openaq/test_backend.py
+++ b/libs/providers/atmosphere/tests/openaq/test_backend.py
@@ -90,6 +90,13 @@ class TestConstruction:
         backend = _backend(tmp_path)
         assert backend._bbox() == "-118.5,34.0,-118.1,34.3"
 
+    def test_client_accepts_split_timeout(self):
+        """The client constructor accepts and exposes a (connect, read) timeout."""
+        from earthlens.openaq.client import OpenaqClient
+
+        client = OpenaqClient("key", timeout=(5.0, 30.0))
+        assert client.timeout == (5.0, 30.0)
+
 
 @pytest.mark.openaq
 class TestSearch:

--- a/libs/providers/land/src/earthlens/ghsl/_helpers.py
+++ b/libs/providers/land/src/earthlens/ghsl/_helpers.py
@@ -45,6 +45,8 @@ BASE_URL: str = "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL"
 #: budget on a connection that will never open. Retrying a connect that times
 #: out rarely turns into success, so three attempts of a 120 s connect wait
 #: previously spent ~6 minutes per file waiting on a dead host (issue #932).
+#: 9.15 s follows the `requests` timeout guidance of a value slightly larger
+#: than a multiple of the 3 s TCP packet-retransmission window (3 x 3.05).
 _CONNECT_TIMEOUT: float = 9.15
 
 #: Read-phase timeout (seconds) for a GHSL file download. Generous on purpose: a

--- a/libs/providers/land/src/earthlens/ghsl/_helpers.py
+++ b/libs/providers/land/src/earthlens/ghsl/_helpers.py
@@ -33,11 +33,31 @@ from typing import cast
 import requests
 
 from earthlens.base.archive import extract_members
-from earthlens.base.http import HttpClient, thread_local_session
+from earthlens.base.http import HttpClient, Timeout, thread_local_session
 from earthlens.ghsl.catalog import RES_TO_TOKEN, native_source_crs
 
 #: Root of the JRC open-data GHSL file tree (anonymous HTTPS, no auth).
 BASE_URL: str = "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL"
+
+#: Connect-phase timeout (seconds) for every GHSL request. Kept short so a JRC
+#: host that never completes the TCP handshake — an upstream outage, or egress
+#: blocked from a CI runner — fails in seconds rather than burning the full read
+#: budget on a connection that will never open. Retrying a connect that times
+#: out rarely turns into success, so three attempts of a 120 s connect wait
+#: previously spent ~6 minutes per file waiting on a dead host (issue #932).
+_CONNECT_TIMEOUT: float = 9.15
+
+#: Read-phase timeout (seconds) for a GHSL file download. Generous on purpose: a
+#: whole-globe artefact is hundreds of megabytes, so a slow-but-live transfer
+#: must not be cut off mid-stream.
+_DOWNLOAD_READ_TIMEOUT: float = 120.0
+
+#: `(connect, read)` timeout for a GHSL `.zip` download.
+_DOWNLOAD_TIMEOUT: tuple[float, float] = (_CONNECT_TIMEOUT, _DOWNLOAD_READ_TIMEOUT)
+
+#: `(connect, read)` timeout for a JRC Apache-autoindex directory listing — a
+#: small response, so its read budget is shorter than a file download's.
+_LISTING_TIMEOUT: tuple[float, float] = (_CONNECT_TIMEOUT, 60.0)
 
 #: Path to the bundled 18×36 Mollweide land tile schema (375 tiles, ESRI:54009).
 TILE_SCHEMA_PATH: Path = Path(__file__).parent / "tile_schema.geojson"
@@ -213,7 +233,7 @@ def download_and_unzip(
     session: requests.Session | None = None,
     retries: int = 3,
     backoff: float = 2.0,
-    timeout: float = 120.0,
+    timeout: Timeout = _DOWNLOAD_TIMEOUT,
     chunk_size: int = 1 << 20,
 ) -> Path:
     """Stream a GHSL `.zip` to `dest_dir`, unzip it, return the `.tif` inside.
@@ -227,7 +247,10 @@ def download_and_unzip(
         session: Optional shared `requests.Session` for connection reuse.
         retries: Number of attempts before giving up.
         backoff: Base seconds for exponential backoff between retries.
-        timeout: Per-request timeout in seconds.
+        timeout: Per-request timeout in seconds — a single float, or a
+            `(connect, read)` pair (the default) that fails a dead host on the
+            short connect budget without shortening the long read budget a
+            large download needs.
         chunk_size: Streaming chunk size in bytes.
 
     Returns:
@@ -261,14 +284,19 @@ _HREF_RE = re.compile(r'href="([^"?][^"]*)"')
 
 
 def list_remote_dir(
-    url: str, *, session: requests.Session | None = None, timeout: float = 60.0
+    url: str,
+    *,
+    session: requests.Session | None = None,
+    timeout: Timeout = _LISTING_TIMEOUT,
 ) -> list[str]:
     """List the entry names in a JRC Apache-autoindex directory.
 
     Args:
         url: Directory URL (with or without a trailing slash).
         session: Optional shared `requests.Session`.
-        timeout: Request timeout in seconds.
+        timeout: Request timeout in seconds — a single float, or a
+            `(connect, read)` pair (the default) so an unreachable host fails
+            on the short connect budget.
 
     Returns:
         list[str]: The `href` entry names (sub-directories keep their trailing
@@ -328,7 +356,7 @@ def download_and_extract(
     session: requests.Session | None = None,
     retries: int = 3,
     backoff: float = 2.0,
-    timeout: float = 120.0,
+    timeout: Timeout = _DOWNLOAD_TIMEOUT,
     chunk_size: int = 1 << 20,
 ) -> list[Path]:
     """Stream a `.zip` to `dest_dir` and extract **all** members (tabular path).
@@ -343,7 +371,8 @@ def download_and_extract(
         session: Optional shared `requests.Session`.
         retries: Attempts before giving up.
         backoff: Base backoff seconds.
-        timeout: Per-request timeout.
+        timeout: Per-request timeout — a single float, or a `(connect, read)`
+            pair (the default).
         chunk_size: Streaming chunk size.
 
     Returns:
@@ -366,7 +395,7 @@ def _download(
     session: requests.Session | None,
     retries: int,
     backoff: float,
-    timeout: float,
+    timeout: Timeout,
     chunk_size: int,
 ) -> None:
     """Stream `url` to `zip_path` with retry + exponential backoff.
@@ -388,7 +417,8 @@ def _download(
         session: Optional shared session.
         retries: Attempts before giving up.
         backoff: Base backoff seconds.
-        timeout: Per-request timeout.
+        timeout: Per-request timeout — a single float, or a `(connect, read)`
+            pair.
         chunk_size: Streaming chunk size.
 
     Raises:

--- a/libs/providers/land/src/earthlens/ghsl/_helpers.py
+++ b/libs/providers/land/src/earthlens/ghsl/_helpers.py
@@ -39,14 +39,17 @@ from earthlens.ghsl.catalog import RES_TO_TOKEN, native_source_crs
 #: Root of the JRC open-data GHSL file tree (anonymous HTTPS, no auth).
 BASE_URL: str = "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL"
 
-#: Connect-phase timeout (seconds) for every GHSL request. Kept short so a JRC
-#: host that never completes the TCP handshake — an upstream outage, or egress
-#: blocked from a CI runner — fails in seconds rather than burning the full read
-#: budget on a connection that will never open. Retrying a connect that times
-#: out rarely turns into success, so three attempts of a 120 s connect wait
-#: previously spent ~6 minutes per file waiting on a dead host (issue #932).
-#: 9.15 s follows the `requests` timeout guidance of a value slightly larger
-#: than a multiple of the 3 s TCP packet-retransmission window (3 x 3.05).
+#: Connect-phase timeout (seconds) for every GHSL request. Kept short so each
+#: attempt at a JRC host that never completes the TCP handshake — an upstream
+#: outage, or egress blocked from a CI runner — fails in seconds rather than
+#: burning the full read budget on a connection that will never open. The
+#: `_download` retry loop still makes its usual attempts (a shorter connect
+#: budget does not turn a dead host into a live one), so a dead host costs
+#: ~3 attempts x 9.15 s plus back-off — tens of seconds per file, versus the
+#: ~6 minutes the old 120 s connect budget spent on the same three attempts
+#: (issue #932). 9.15 s follows the `requests` timeout guidance of a value
+#: slightly larger than a multiple of the 3 s TCP packet-retransmission window
+#: (3 x 3.05).
 _CONNECT_TIMEOUT: float = 9.15
 
 #: Read-phase timeout (seconds) for a GHSL file download. Generous on purpose: a

--- a/libs/providers/land/tests/ghsl/conftest.py
+++ b/libs/providers/land/tests/ghsl/conftest.py
@@ -85,10 +85,12 @@ class FakeSession:
     def __init__(self, routes: dict[str, _FakeResponse] | None = None):
         self.routes: dict[str, _FakeResponse] = routes or {}
         self.requested: list[str] = []
+        self.calls: list[dict[str, Any]] = []
 
     def get(self, url: str, **kwargs: Any):
         """Return the canned response for `url` (404 when unrouted)."""
         self.requested.append(url)
+        self.calls.append(kwargs)
         return self.routes.get(url, _FakeResponse(status=404))
 
     def close(self) -> None:

--- a/libs/providers/land/tests/ghsl/test_ghsl_e2e.py
+++ b/libs/providers/land/tests/ghsl/test_ghsl_e2e.py
@@ -12,6 +12,7 @@ Run with:
 
 from __future__ import annotations
 
+import socket
 from pathlib import Path
 
 import pytest
@@ -19,10 +20,30 @@ import pytest
 from earthlens.aggregate import AggregationConfig
 from earthlens.earthlens import EarthLens
 
+#: The JRC host every GHSL fetch talks to.
+_GHSL_HOST = "jeodpp.jrc.ec.europa.eu"
+
 #: A tiny Moroccan-coast AOI inside the verified R6_C18 tile — small enough to
 #: fetch one 100 m tile in seconds and reliably over land.
 _LAT_LIM = [30.5, 30.8]
 _LON_LIM = [-9.0, -8.7]
+
+
+def _host_ok(host: str) -> bool:
+    """Return True when `host` accepts a TCP connection on port 443."""
+    try:
+        socket.create_connection((host, 443), timeout=5).close()
+        return True
+    except OSError:
+        return False
+
+
+#: Skip the live class fast when the JRC host does not answer — an outage or a
+#: runner whose egress is blocked would otherwise exhaust every download's
+#: retries on connect timeouts before failing (issue #932).
+_offline_skip = pytest.mark.skipif(
+    not _host_ok(_GHSL_HOST), reason=f"JRC GHSL host {_GHSL_HOST} unreachable"
+)
 
 
 def _nonempty_geotiff(path: Path) -> bool:
@@ -33,6 +54,7 @@ def _nonempty_geotiff(path: Path) -> bool:
     return dataset.rows > 0 and dataset.columns > 0
 
 
+@_offline_skip
 @pytest.mark.e2e
 @pytest.mark.ghsl
 class TestGhslLiveFetch:

--- a/libs/providers/land/tests/ghsl/test_ghsl_e2e.py
+++ b/libs/providers/land/tests/ghsl/test_ghsl_e2e.py
@@ -38,14 +38,6 @@ def _host_ok(host: str) -> bool:
         return False
 
 
-#: Skip the live class fast when the JRC host does not answer — an outage or a
-#: runner whose egress is blocked would otherwise exhaust every download's
-#: retries on connect timeouts before failing (issue #932).
-_offline_skip = pytest.mark.skipif(
-    not _host_ok(_GHSL_HOST), reason=f"JRC GHSL host {_GHSL_HOST} unreachable"
-)
-
-
 def _nonempty_geotiff(path: Path) -> bool:
     """Return whether `path` reads back as a non-empty pyramids raster."""
     from pyramids.dataset import Dataset
@@ -54,11 +46,23 @@ def _nonempty_geotiff(path: Path) -> bool:
     return dataset.rows > 0 and dataset.columns > 0
 
 
-@_offline_skip
 @pytest.mark.e2e
 @pytest.mark.ghsl
 class TestGhslLiveFetch:
     """Live GHSL fetches (open HTTPS — no credentials needed)."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def _require_jrc_host(self):
+        """Skip the live class when the JRC host does not answer.
+
+        A class-scoped autouse fixture rather than a module-level `skipif`, so
+        the reachability probe fires only once, and only when an e2e run
+        actually selects this class — never during collection of the default
+        `not e2e` suite (an outage or blocked-egress runner would otherwise
+        exhaust every download's retries on connect timeouts; issue #932).
+        """
+        if not _host_ok(_GHSL_HOST):
+            pytest.skip(f"JRC GHSL host {_GHSL_HOST} unreachable")
 
     def test_population_100m_lands_cropped_geotiff(self, tmp_path: Path):
         """A small GHS-POP 2020 100 m pull lands one cropped EPSG:4326 GeoTIFF."""

--- a/libs/providers/land/tests/ghsl/test_helpers.py
+++ b/libs/providers/land/tests/ghsl/test_helpers.py
@@ -127,6 +127,21 @@ class TestDownloadAndUnzip:
                 url, tmp_path / "dl", session=session, retries=2, backoff=0.0
             )
 
+    def test_default_split_connect_read_timeout(
+        self, tmp_path, fake_session, make_response
+    ):
+        """The default download passes a short-connect (connect, read) tuple."""
+        tif = make_tiny_tif(tmp_path / "src.tif", epsg=4326)
+        zpath = zip_with_tif(tif, tmp_path / "GHS_POP_t_V1_0.zip")
+        payload = zpath.read_bytes()
+        zpath.unlink()
+        url = "https://x/GHS_POP_t_V1_0.zip"
+        session = fake_session({url: make_response(content=payload)})
+        download_and_unzip(url, tmp_path / "dl", session=session)
+        connect, read = session.calls[-1]["timeout"]
+        assert connect < read, "connect budget must be shorter than the read budget"
+        assert (connect, read) == _helpers._DOWNLOAD_TIMEOUT
+
 
 @pytest.mark.ghsl
 class TestRemoteListing:

--- a/libs/providers/land/tests/ghsl/test_helpers.py
+++ b/libs/providers/land/tests/ghsl/test_helpers.py
@@ -130,7 +130,7 @@ class TestDownloadAndUnzip:
     def test_default_split_connect_read_timeout(
         self, tmp_path, fake_session, make_response
     ):
-        """The default download passes a short-connect (connect, read) tuple."""
+        """The default download passes the split (connect, read) tuple to get."""
         tif = make_tiny_tif(tmp_path / "src.tif", epsg=4326)
         zpath = zip_with_tif(tif, tmp_path / "GHS_POP_t_V1_0.zip")
         payload = zpath.read_bytes()
@@ -138,9 +138,21 @@ class TestDownloadAndUnzip:
         url = "https://x/GHS_POP_t_V1_0.zip"
         session = fake_session({url: make_response(content=payload)})
         download_and_unzip(url, tmp_path / "dl", session=session)
-        connect, read = session.calls[-1]["timeout"]
-        assert connect < read, "connect budget must be shorter than the read budget"
-        assert (connect, read) == _helpers._DOWNLOAD_TIMEOUT
+        assert session.calls[-1]["timeout"] == _helpers._DOWNLOAD_TIMEOUT
+
+
+@pytest.mark.ghsl
+class TestTimeoutConstants:
+    """The split (connect, read) timeout constants (issue #932)."""
+
+    @pytest.mark.parametrize(
+        "pair", [_helpers._DOWNLOAD_TIMEOUT, _helpers._LISTING_TIMEOUT]
+    )
+    def test_connect_budget_is_shorter_than_read(self, pair):
+        """Each timeout is a (connect, read) pair with a shorter connect budget."""
+        connect, read = pair
+        assert connect == _helpers._CONNECT_TIMEOUT
+        assert connect < read
 
 
 @pytest.mark.ghsl
@@ -160,6 +172,13 @@ class TestRemoteListing:
         names = list_remote_dir(url, session=session)
         assert "V1-0/" in names and "copyright.txt" in names
         assert not any(n.startswith("?") or n.startswith("/") for n in names)
+
+    def test_list_remote_dir_uses_split_timeout(self, fake_session, make_response):
+        """A directory listing passes the split (connect, read) listing tuple."""
+        url = "https://x/fam"
+        session = fake_session({url + "/": make_response(text=self._HTML)})
+        list_remote_dir(url, session=session)
+        assert session.calls[-1]["timeout"] == _helpers._LISTING_TIMEOUT
 
     def test_latest_version_dir(self, fake_session, make_response):
         """The highest V{maj}-{min} directory is returned."""
@@ -188,6 +207,18 @@ class TestRemoteListing:
         names = {p.name for p in out}
         assert names == {"duc.csv", "readme.txt"}
         assert (tmp_path / "ex" / "duc.csv").exists()
+
+    def test_download_and_extract_uses_split_timeout(
+        self, tmp_path, fake_session, make_response
+    ):
+        """The tabular extract path passes the split (connect, read) tuple."""
+        zpath = tmp_path / "table_V2_0.zip"
+        with zipfile.ZipFile(zpath, "w") as archive:
+            archive.writestr("duc.csv", b"a,b\n1,2\n")
+        url = "https://x/table_V2_0.zip"
+        session = fake_session({url: make_response(content=zpath.read_bytes())})
+        download_and_extract(url, tmp_path / "ex", session=session)
+        assert session.calls[-1]["timeout"] == _helpers._DOWNLOAD_TIMEOUT
 
 
 @pytest.mark.ghsl


### PR DESCRIPTION
# Description

GHSL downloads passed a single `120 s` timeout, which `requests` applies to **both** the connect and read phases.
So when the JRC host `jeodpp.jrc.ec.europa.eu` never completes the TCP handshake — an upstream outage, or egress
blocked from a CI runner — each attempt waited the full 120 s on connect. With 3 attempts per file plus backoff
that is ~6 minutes per file, and a whole e2e lane spent ~21 minutes before failing on connect timeouts
(see #932).

This splits the timeout into a `(connect, read)` pair:

- a short **9.15 s connect** budget fails a dead/blocked host in seconds — retrying a connect that never opens
  rarely turns into success;
- the long **120 s read** budget large tile transfers actually need is retained.

`HttpClient`'s timeout type is widened to `float | tuple[float, float]` (a new `Timeout` alias) so the pair
type-checks through the shared client and its three passthrough `timeout` properties (airnow / openaq /
sensor_community). The GHSL download / listing helpers now default to the split tuple.

The live e2e class also gains a fast **reachability skip**: a TCP probe of the JRC host on 443 skips the suite
cleanly when the host does not answer, instead of exhausting every download's retries first — matching the
reachability-skip convention the other e2e suites already use (`climate_indices`, `drought`, `nrel`, …).

Note this does not by itself decide *why* CI failed: the host answers fine from a laptop today (HTTP 200,
connect 0.13 s), so the root cause is CI-side — either a transient JRC outage at run time or GitHub-runner egress
blocking — which needs a from-CI probe to pin down. The change makes either case fail (or skip) in seconds rather
than ~21 minutes.

No dependencies added — `requests` already accepts a `(connect, read)` tuple.

# Issues

- Fixes #932 — GHSL live tests wait 21 minutes on connect timeouts when the JRC host does not answer

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run against a per-worktree env (base + dev group):

```bash
uv run --active pytest libs/core/tests/base/test_http.py libs/providers/land/tests/ghsl -m "not e2e"
uv run --active pytest -m "e2e and ghsl"   # live; skips cleanly if the JRC host is unreachable
```

- [x] Unit — `HttpClient` forwards a `(connect, read)` tuple through the verb path and `download()`, both as a
  per-call override and as the client default; the GHSL download / listing helpers pass their split-timeout
  constants to the transport; the constants keep `connect < read`.
- [x] Regression — full `test_http.py` (+ range file) and the GHSL unit suite: **267 passed, 3 e2e deselected**.
- [x] Live — the fast GHSL e2e population fetch passed end-to-end against the real JRC host (~10 s), exercising
  the split timeout.
- [x] Lint / types / doctests — `ruff check` + `ruff format` clean, `mypy` clean (342 files), `--doctest-modules`
  on the changed modules pass.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
