### PR TITLE
fix(osm): treat ohsome 403/429 as a typed public-endpoint throttle

### DIFF
--- a/libs/providers/hazards/pyproject.toml
+++ b/libs/providers/hazards/pyproject.toml
@@ -52,7 +52,12 @@ emdat = ["earthaccess >=0.17.0"]
 fdsn = ["obspy >=1.5.0"]
 hdx = ["hdx-python-api >=6,<7"]
 overture = ["overturemaps >=1.0.0", "duckdb >=1.0.0"]
-osm = ["overpy >=0.7", "ohsome >=0.4.0"]
+# `urllib3` is imported directly by the ohsome path (backend.py builds a
+# `urllib3.util.retry.Retry` to give the SDK's transport a repo-standard
+# 429/5xx retry policy), so it is a declared direct dependency here — never
+# relied on transitively — per the repository's hard dependency rule. `>=1.26`
+# for the `allowed_methods` Retry argument (it replaced `method_whitelist`).
+osm = ["overpy >=0.7", "ohsome >=0.4.0", "urllib3 >=1.26"]
 osm-pbf = ["pyrosm >=0.11.0", "osmium >=4.3.1"]
 
 # This distribution's slice of the facade's data-source table.

--- a/libs/providers/hazards/pyproject.toml
+++ b/libs/providers/hazards/pyproject.toml
@@ -55,9 +55,11 @@ overture = ["overturemaps >=1.0.0", "duckdb >=1.0.0"]
 # `urllib3` is imported directly by the ohsome path (backend.py builds a
 # `urllib3.util.retry.Retry` to give the SDK's transport a repo-standard
 # 429/5xx retry policy), so it is a declared direct dependency here — never
-# relied on transitively — per the repository's hard dependency rule. `>=1.26`
-# for the `allowed_methods` Retry argument (it replaced `method_whitelist`).
-osm = ["overpy >=0.7", "ohsome >=0.4.0", "urllib3 >=1.26"]
+# relied on transitively — per the repository's hard dependency rule. `>=2` for
+# the `backoff_max` / `retry_after_max` Retry constructor args (2.0 promoted
+# them from class attributes), which cap a hostile `Retry-After` to match
+# HttpClient's 300 s ceiling.
+osm = ["overpy >=0.7", "ohsome >=0.4.0", "urllib3 >=2"]
 osm-pbf = ["pyrosm >=0.11.0", "osmium >=4.3.1"]
 
 # This distribution's slice of the facade's data-source table.

--- a/libs/providers/hazards/src/earthlens/osm/__init__.py
+++ b/libs/providers/hazards/src/earthlens/osm/__init__.py
@@ -40,6 +40,9 @@ Public surface (re-exported from this package):
 * `download_extract` / `read_pbf` / `geofabrik_url` / `GEOFABRIK_BASE_URL` —
   the `pbf` fetch-and-cache + layer-read helpers (`G13` / `G14`).
 * `LicenseWarning` — the ODbL share-alike warning (`G5`).
+* `OhsomeUnavailableError` / `ohsome_http_status` — the typed public-endpoint
+  throttle/block error the ohsome path raises on a `403` / `429`, and the
+  helper that recovers the HTTP status from the SDK's opaque failure.
 * `CATALOG_PATH` — path to the bundled named-query YAML; monkey-patchable in
   tests.
 
@@ -59,9 +62,11 @@ from __future__ import annotations
 
 from earthlens.osm._helpers import (
     LicenseWarning,
+    OhsomeUnavailableError,
     bbox_swne,
     bbox_wsen,
     empty_fc,
+    ohsome_http_status,
     overpy_to_gdf,
     shapely_bbox,
     to_fc,
@@ -82,11 +87,13 @@ __all__ = [
     "Dataset",
     "LicenseWarning",
     "OSM",
+    "OhsomeUnavailableError",
     "bbox_swne",
     "bbox_wsen",
     "download_extract",
     "empty_fc",
     "geofabrik_url",
+    "ohsome_http_status",
     "overpy_to_gdf",
     "read_pbf",
     "shapely_bbox",

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -16,6 +16,12 @@ Three concerns are factored here so `osm/backend.py` only routes:
   `FeatureCollection` (`G7`), normalising the CRS to EPSG:4326. The ohsome
   path's `.as_dataframe()` is already a `GeoDataFrame`, so it goes straight to
   `to_fc`.
+* `OhsomeUnavailableError` / `ohsome_http_status` — turn the `ohsome` SDK's
+  opaque failure on a throttled/blocked public endpoint into a clear, typed,
+  actionable error. The SDK does not surface a clean status on a non-JSON error
+  body (the HTML `403` an overloaded `api.ohsome.org` front proxy returns makes
+  it leak a bare `requests.exceptions.JSONDecodeError`), so the status is dug
+  out of the exception chain here.
 
 All GIS containerisation stays inside the pyramids `FeatureCollection` per the
 repository's pyramids policy; earthlens only assembles the plain attribute rows
@@ -47,6 +53,72 @@ OSM_CRS = "EPSG:4326"
 #: The minimal identity columns every overpy-built row carries, ahead of the
 #: element's own tags.
 _ID_COLUMNS = ["osm_id", "osm_type"]
+
+
+class OhsomeUnavailableError(RuntimeError):
+    """The public ohsome endpoint refused a request with a retry-worthy status.
+
+    Raised by the OSM backend when `api.ohsome.org` answers a `403` (its front
+    proxy blocking / throttling this client — the endpoint is public and
+    keyless, so it is never a credential problem) or a `429` that outlived the
+    SDK's automatic retries. Carries the HTTP `status_code` so a caller (or the
+    live e2e test) can tell a transient public-endpoint throttle apart from a
+    genuine request error and back off rather than fail hard.
+    """
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        """Store the actionable message and the originating HTTP status.
+
+        Args:
+            message: Human-facing explanation — what happened and what to do.
+            status_code: The HTTP status that triggered it (`403` / `429`), or
+                `None` when it could not be recovered from the SDK error.
+        """
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def ohsome_http_status(exc: BaseException) -> int | None:
+    """Best-effort HTTP status behind an `ohsome` SDK failure.
+
+    The SDK does not surface a clean status on every error: an `OhsomeException`
+    carries `error_code`, but a non-JSON error body — such as the HTML `403` an
+    overloaded `api.ohsome.org` front proxy returns — makes it leak a bare
+    `requests.exceptions.JSONDecodeError` whose originating `requests.HTTPError`
+    (and its `403` status) is only reachable through the exception chain. This
+    walks `exc` and its `__cause__` / `__context__` predecessors and returns
+    the first HTTP status it finds.
+
+    Args:
+        exc: The exception raised by an `ohsome` SDK call.
+
+    Returns:
+        int | None: The HTTP status code, or `None` when none is discoverable.
+
+    Examples:
+        - An `OhsomeException`-like error exposes its `error_code` directly:
+            ```python
+            >>> from earthlens.osm import ohsome_http_status
+            >>> class _Err(Exception):
+            ...     error_code = 429
+            >>> ohsome_http_status(_Err())
+            429
+
+            ```
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        error_code = getattr(current, "error_code", None)
+        if isinstance(error_code, int):
+            return error_code
+        response = getattr(current, "response", None)
+        status = getattr(response, "status_code", None)
+        if isinstance(status, int):
+            return status
+        current = current.__cause__ or current.__context__
+    return None
 
 
 def bbox_swne(space: SpatialExtent) -> tuple[float, float, float, float]:

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -61,9 +61,9 @@ class OhsomeUnavailableError(RuntimeError):
     Raised by the OSM backend when `api.ohsome.org` answers a `403` (its front
     proxy blocking / throttling this client — the endpoint is public and
     keyless, so it is never a credential problem) or a `429` that outlived the
-    SDK's automatic retries. Carries the HTTP `status_code` so a caller (or the
-    live e2e test) can tell a transient public-endpoint throttle apart from a
-    genuine request error and back off rather than fail hard.
+    SDK's automatic retries. Carries the HTTP `status_code` so a caller can tell
+    a transient public-endpoint throttle apart from a genuine request error and
+    back off rather than fail hard.
     """
 
     def __init__(self, message: str, status_code: int | None = None) -> None:

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -18,14 +18,9 @@ Three concerns are factored here so `osm/backend.py` only routes:
   `to_fc`.
 * `OhsomeUnavailableError` / `ohsome_http_status` — turn the `ohsome` SDK's
   opaque failure on a throttled/blocked public endpoint into a clear, typed,
-  actionable error. On the HTML `403` an overloaded `api.ohsome.org` front proxy
-  returns, the SDK exposes the status inconsistently: usually it wraps the
-  failure into an `OhsomeException` carrying `error_code`, but on some
-  environments its non-JSON-body handling misfires (its
-  `except json.decoder.JSONDecodeError` does not catch the `simplejson`-based
-  `requests.exceptions.JSONDecodeError`) and it leaks a bare `JSONDecodeError`
-  whose status is only reachable through the exception chain. `ohsome_http_status`
-  handles both shapes, so the status is recovered either way here.
+  actionable error. The SDK exposes the HTTP status inconsistently (see
+  `ohsome_http_status` for the two shapes), so the status is recovered from the
+  exception chain here.
 
 All GIS containerisation stays inside the pyramids `FeatureCollection` per the
 repository's pyramids policy; earthlens only assembles the plain attribute rows

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -18,10 +18,14 @@ Three concerns are factored here so `osm/backend.py` only routes:
   `to_fc`.
 * `OhsomeUnavailableError` / `ohsome_http_status` — turn the `ohsome` SDK's
   opaque failure on a throttled/blocked public endpoint into a clear, typed,
-  actionable error. The SDK does not surface a clean status on a non-JSON error
-  body (the HTML `403` an overloaded `api.ohsome.org` front proxy returns makes
-  it leak a bare `requests.exceptions.JSONDecodeError`), so the status is dug
-  out of the exception chain here.
+  actionable error. On the HTML `403` an overloaded `api.ohsome.org` front proxy
+  returns, the SDK exposes the status inconsistently: usually it wraps the
+  failure into an `OhsomeException` carrying `error_code`, but on some
+  environments its non-JSON-body handling misfires (its
+  `except json.decoder.JSONDecodeError` does not catch the `simplejson`-based
+  `requests.exceptions.JSONDecodeError`) and it leaks a bare `JSONDecodeError`
+  whose status is only reachable through the exception chain. `ohsome_http_status`
+  handles both shapes, so the status is recovered either way here.
 
 All GIS containerisation stays inside the pyramids `FeatureCollection` per the
 repository's pyramids policy; earthlens only assembles the plain attribute rows
@@ -81,13 +85,16 @@ class OhsomeUnavailableError(RuntimeError):
 def ohsome_http_status(exc: BaseException) -> int | None:
     """Best-effort HTTP status behind an `ohsome` SDK failure.
 
-    The SDK does not surface a clean status on every error: an `OhsomeException`
-    carries `error_code`, but a non-JSON error body — such as the HTML `403` an
-    overloaded `api.ohsome.org` front proxy returns — makes it leak a bare
-    `requests.exceptions.JSONDecodeError` whose originating `requests.HTTPError`
-    (and its `403` status) is only reachable through the exception chain. This
-    walks `exc` and its `__cause__` / `__context__` predecessors and returns
-    the first HTTP status it finds.
+    The SDK exposes the status inconsistently. Usually it wraps the failure into
+    an `OhsomeException` carrying `error_code` (recovered by the first check
+    below). But on the HTML `403` an overloaded `api.ohsome.org` front proxy
+    returns, its non-JSON-body handling can misfire (its
+    `except json.decoder.JSONDecodeError` misses the `simplejson`-based
+    `requests.exceptions.JSONDecodeError`) and leak a bare `JSONDecodeError`
+    whose originating `requests.HTTPError` — and its `403` status — is only
+    reachable through the exception chain. This walks `exc` and its `__cause__` /
+    `__context__` predecessors and returns the first HTTP status it finds, so
+    both shapes are handled.
 
     Args:
         exc: The exception raised by an `ohsome` SDK call.

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -118,14 +118,31 @@ def ohsome_http_status(exc: BaseException) -> int | None:
     while current is not None and id(current) not in seen:
         seen.add(id(current))
         error_code = getattr(current, "error_code", None)
-        if isinstance(error_code, int):
+        if _is_http_status(error_code):
             return error_code
         response = getattr(current, "response", None)
         status = getattr(response, "status_code", None)
-        if isinstance(status, int):
+        if _is_http_status(status):
             return status
         current = current.__cause__ or current.__context__
     return None
+
+
+def _is_http_status(value: object) -> bool:
+    """Return whether `value` is a real integer HTTP status (not a `bool`).
+
+    `bool` is a subclass of `int`, so a plain `isinstance(value, int)` would
+    accept `True` / `False` and report a nonsensical status `1` / `0`; this
+    excludes them.
+
+    Args:
+        value: A candidate status pulled off an exception (`error_code` or a
+            response's `status_code`).
+
+    Returns:
+        bool: `True` when `value` is an `int` and not a `bool`.
+    """
+    return isinstance(value, int) and not isinstance(value, bool)
 
 
 def bbox_swne(space: SpatialExtent) -> tuple[float, float, float, float]:

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -619,12 +619,12 @@ class OSM(AbstractDataSource):
         """
         try:
             from ohsome import OhsomeClient
+            from urllib3.util.retry import Retry
         except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
             raise ImportError(
-                "The OSM ohsome protocol requires the `ohsome` SDK. Install it "
-                "with `pip install earthlens[osm]`."
+                "The OSM ohsome protocol requires the `ohsome` SDK (and "
+                "`urllib3`). Install them with `pip install earthlens[osm]`."
             ) from exc
-        from urllib3.util.retry import Retry
 
         ohsome_filter = self._filter or dataset.ohsome_filter
         west, south, east, north = bbox_wsen(self.space)

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -663,7 +663,9 @@ class OSM(AbstractDataSource):
                 endpoint="elements/geometry",
             )
             gdf = response.as_dataframe()
-        except Exception as exc:  # noqa: BLE001 - classify -> typed raise, else propagate
+        # Broad by design: classify a throttle/block into a typed error, else
+        # re-raise the original failure unchanged.
+        except Exception as exc:  # noqa: BLE001
             self._raise_ohsome_unavailable(exc)
             raise
         # `as_dataframe()` carries a (@osmId, @snapshotTimestamp) MultiIndex;

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -13,9 +13,11 @@ query protocols and returns the result as a pyramids
   `overpy.Overpass().query(...)` deliberately: overpy 0.7 sends no custom UA,
   so its `.query()` cannot reach overpass-api.de (see the A1 capture).
 * **ohsome** (`ohsome`) — OSM **history + analytics** via the
-  `elements/geometry` endpoint. `OhsomeClient().elements.geometry.post(...)
-  .as_dataframe()` already returns a geopandas `GeoDataFrame`, wrapped straight
-  into a `FeatureCollection` (no `xarray`, `G7`).
+  `elements/geometry` endpoint. `OhsomeClient(...).post(endpoint=
+  "elements/geometry", ...).as_dataframe()` already returns a geopandas
+  `GeoDataFrame`, wrapped straight into a `FeatureCollection` (no `xarray`,
+  `G7`); a `403` / `429` throttle from the public endpoint is surfaced as a
+  typed `OhsomeUnavailableError` (`_fetch_ohsome`).
 * **pbf** (`pyrosm` / `pyosmium`) — **bulk / regional** reads from a Geofabrik
   `.osm.pbf` extract (`G9`, `G10`). The backend fetch-and-caches the extract
   for the request's `region=` (via `download_extract`) and reads the row's
@@ -60,9 +62,11 @@ from earthlens.base import (
 from earthlens.base.http import DEFAULT_TIMEOUT, HttpClient
 from earthlens.osm._helpers import (
     LicenseWarning,
+    OhsomeUnavailableError,
     bbox_swne,
     bbox_wsen,
     empty_fc,
+    ohsome_http_status,
     overpy_to_gdf,
     to_fc,
 )
@@ -168,6 +172,15 @@ class OSM(AbstractDataSource):
     #: HttpClient and no call site ever set it, so nothing in earthlens
     #: paced itself against any provider.
     MIN_REQUEST_INTERVAL: float = 1.0
+
+    #: Retry budget for the ohsome `elements/geometry` request. `api.ohsome.org`
+    #: throttles anonymous callers with `429` (and can `5xx` transiently), so the
+    #: SDK's transport is handed a urllib3 `Retry` with this many attempts,
+    #: exponential `backoff_factor` growth, and `Retry-After` honoured — the same
+    #: policy the repo-wide `HttpClient` applies. `403` is deliberately *not*
+    #: retried: on a public, keyless endpoint it is a hard block, not transient.
+    MAX_OHSOME_RETRIES: int = 5
+    OHSOME_BACKOFF_FACTOR: float = 1.0
 
     AGGREGATE_REFUSAL_REASON = "OSM features are vector, not gridded rasters, so there is no meaningful gridded reduction. Call download() without aggregate= and post-process the returned FeatureCollection (a GeoDataFrame) directly"
 
@@ -565,12 +578,25 @@ class OSM(AbstractDataSource):
     def _fetch_ohsome(self, query_id: str, dataset: Dataset) -> FeatureCollection:
         """Fetch one ohsome `elements/geometry` query into a FeatureCollection.
 
-        Calls `OhsomeClient().elements.geometry.post(bboxes=..., time=...,
-        filter=...)` with the bbox in ohsome order `W,S,E,N` and the request
-        time window, then wraps the `.as_dataframe()` `GeoDataFrame` directly
-        (no `xarray`, `G7`). The result's `(@osmId, @snapshotTimestamp)`
-        MultiIndex is reset into columns so the history fields survive into
-        the `FeatureCollection`.
+        POSTs to the ohsome `elements/geometry` endpoint with the bbox in
+        ohsome order `W,S,E,N` and the request time window, then wraps the
+        `.as_dataframe()` `GeoDataFrame` directly (no `xarray`, `G7`). The
+        result's `(@osmId, @snapshotTimestamp)` MultiIndex is reset into columns
+        so the history fields survive into the `FeatureCollection`.
+
+        The request is issued via `OhsomeClient(...).post(endpoint=
+        "elements/geometry")` rather than the chained `.elements.geometry.post`:
+        the chained form spawns a fresh sub-client that silently drops the
+        `retry` and `user_agent` set on the root client, so only the direct
+        `post(endpoint=...)` actually applies our transport policy. That policy
+        gives the SDK's session a urllib3 `Retry` (`MAX_OHSOME_RETRIES` attempts,
+        exponential `OHSOME_BACKOFF_FACTOR` growth, `Retry-After` honoured) so a
+        `429`/`5xx` throttle is retried with backoff — matching the repo-wide
+        `HttpClient`. A `403` (and any leftover `429` after the retries) is *not*
+        a transient error on this public, keyless endpoint, so it is turned into
+        a clear, typed `OhsomeUnavailableError` instead of the SDK's opaque
+        failure (an HTML `403` body makes the SDK leak a bare
+        `requests.exceptions.JSONDecodeError`).
 
         Args:
             query_id: The named-query id (for logging).
@@ -582,6 +608,9 @@ class OSM(AbstractDataSource):
 
         Raises:
             ImportError: If `ohsome` is not installed (`earthlens[osm]`).
+            OhsomeUnavailableError: If `api.ohsome.org` blocks/throttles the
+                request with a `403` (or a `429` outlasting the retries) — a
+                public-endpoint denial, not a credential error.
             ValueError: If no `start` (and `time`) was supplied — ohsome
                 requires a time.
         """
@@ -592,6 +621,7 @@ class OSM(AbstractDataSource):
                 "The OSM ohsome protocol requires the `ohsome` SDK. Install it "
                 "with `pip install earthlens[osm]`."
             ) from exc
+        from urllib3.util.retry import Retry
 
         ohsome_filter = self._filter or dataset.ohsome_filter
         west, south, east, north = bbox_wsen(self.space)
@@ -600,15 +630,69 @@ class OSM(AbstractDataSource):
         logger.info(
             f"Querying ohsome for {query_id!r} over bbox ({bboxes}) at time {time!r}"
         )
-        response = OhsomeClient().elements.geometry.post(
-            bboxes=bboxes, time=time, filter=ohsome_filter
+        retry = Retry(
+            total=self.MAX_OHSOME_RETRIES,
+            status_forcelist=(429, 500, 502, 503, 504),
+            allowed_methods=frozenset({"GET", "POST"}),
+            backoff_factor=self.OHSOME_BACKOFF_FACTOR,
+            respect_retry_after_header=True,
         )
-        gdf = response.as_dataframe()
+        # `log=False` keeps the SDK from writing an `ohsome_log/` directory into
+        # the caller's CWD on every failed query.
+        client = OhsomeClient(user_agent=self._user_agent, retry=retry, log=False)
+        try:
+            response = client.post(
+                bboxes=bboxes,
+                time=time,
+                filter=ohsome_filter,
+                endpoint="elements/geometry",
+            )
+            gdf = response.as_dataframe()
+        except Exception as exc:  # noqa: BLE001 - classify -> typed raise, else propagate
+            self._raise_ohsome_unavailable(exc)
+            raise
         # `as_dataframe()` carries a (@osmId, @snapshotTimestamp) MultiIndex;
         # reset it so the history fields become ordinary columns on the FC.
         if gdf.index.names and any(name is not None for name in gdf.index.names):
             gdf = gdf.reset_index()
         return to_fc(gdf)
+
+    def _raise_ohsome_unavailable(self, exc: Exception) -> None:
+        """Re-raise an ohsome throttle/block as a typed `OhsomeUnavailableError`.
+
+        Inspects the SDK failure for an HTTP status (`ohsome_http_status` digs
+        it out of the exception chain, since a non-JSON error body makes the SDK
+        leak a bare `requests.exceptions.JSONDecodeError`). A `401`/`403`, or a
+        `429` that outlived the retries, becomes a clear, actionable
+        `OhsomeUnavailableError`; any other failure is left for the caller to
+        re-raise unchanged.
+
+        Args:
+            exc: The exception raised by the ohsome SDK call.
+
+        Raises:
+            OhsomeUnavailableError: When the status is a public-endpoint
+                throttle/block (`401` / `403` / `429`).
+        """
+        status = ohsome_http_status(exc)
+        if status in (401, 403):
+            raise OhsomeUnavailableError(
+                f"ohsome refused the elements/geometry request with HTTP {status}. "
+                "api.ohsome.org is a public, keyless endpoint, so this is its "
+                "front proxy blocking or throttling this client (an IP / "
+                "rate-limit block), not a credential problem. Wait and retry "
+                "later, shrink the bbox or time window, or try from a different "
+                "network.",
+                status_code=status,
+            ) from exc
+        if status == 429:
+            raise OhsomeUnavailableError(
+                "ohsome refused the elements/geometry request with HTTP 429 (Too "
+                "Many Requests) after automatic retries. api.ohsome.org is "
+                "rate-limiting this client; wait before retrying, or reduce the "
+                "request frequency and size.",
+                status_code=status,
+            ) from exc
 
     def _fetch_pbf(self, query_id: str, dataset: Dataset) -> FeatureCollection:
         """Fetch one `pbf` layer: resolve region, fetch-cache, read, bbox-clip.

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -662,22 +662,24 @@ class OSM(AbstractDataSource):
 
         Inspects the SDK failure for an HTTP status (`ohsome_http_status` digs
         it out of the exception chain, since a non-JSON error body makes the SDK
-        leak a bare `requests.exceptions.JSONDecodeError`). A `401`/`403`, or a
-        `429` that outlived the retries, becomes a clear, actionable
-        `OhsomeUnavailableError`; any other failure is left for the caller to
-        re-raise unchanged.
+        leak a bare `requests.exceptions.JSONDecodeError`). A `403`, or a `429`
+        that outlived the retries, becomes a clear, actionable
+        `OhsomeUnavailableError`; any other failure — including a `401`, which on
+        this keyless endpoint signals a real auth-contract change, not a
+        throttle — is left for the caller to re-raise unchanged so a genuine
+        regression still surfaces loudly.
 
         Args:
             exc: The exception raised by the ohsome SDK call.
 
         Raises:
             OhsomeUnavailableError: When the status is a public-endpoint
-                throttle/block (`401` / `403` / `429`).
+                throttle/block (`403` / `429`).
         """
         status = ohsome_http_status(exc)
-        if status in (401, 403):
+        if status == 403:
             raise OhsomeUnavailableError(
-                f"ohsome refused the elements/geometry request with HTTP {status}. "
+                "ohsome refused the elements/geometry request with HTTP 403. "
                 "api.ohsome.org is a public, keyless endpoint, so this is its "
                 "front proxy blocking or throttling this client (an IP / "
                 "rate-limit block), not a credential problem. Wait and retry "

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -184,6 +184,13 @@ class OSM(AbstractDataSource):
     MAX_OHSOME_RETRIES: int = 5
     OHSOME_BACKOFF_FACTOR: float = 1.0
 
+    #: Ceiling (whole seconds) on any single ohsome retry wait — the exponential
+    #: backoff and a server-sent `Retry-After` alike — mirroring HttpClient's
+    #: `DEFAULT_MAX_BACKOFF` (300 s) so a hostile/misconfigured `Retry-After`
+    #: cannot pin the calling thread for an unbounded interval. Kept an `int`
+    #: because urllib3's `retry_after_max` is integer-typed.
+    OHSOME_MAX_BACKOFF: int = 300
+
     AGGREGATE_REFUSAL_REASON = "OSM features are vector, not gridded rasters, so there is no meaningful gridded reduction. Call download() without aggregate= and post-process the returned FeatureCollection (a GeoDataFrame) directly"
 
     #: An Overpass current-state query has no window; ohsome supplies its own, so a
@@ -639,6 +646,11 @@ class OSM(AbstractDataSource):
             allowed_methods=frozenset({"GET", "POST"}),
             backoff_factor=self.OHSOME_BACKOFF_FACTOR,
             respect_retry_after_header=True,
+            # Ceiling on any single wait — the exponential backoff *and* a
+            # server-sent `Retry-After` — so a hostile/misconfigured `Retry-After`
+            # cannot pin the calling thread. Mirrors HttpClient's DEFAULT_MAX_BACKOFF.
+            backoff_max=self.OHSOME_MAX_BACKOFF,
+            retry_after_max=self.OHSOME_MAX_BACKOFF,
         )
         # `log=False` keeps the SDK from writing an `ohsome_log/` directory into
         # the caller's CWD on every failed query.

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -175,10 +175,12 @@ class OSM(AbstractDataSource):
 
     #: Retry budget for the ohsome `elements/geometry` request. `api.ohsome.org`
     #: throttles anonymous callers with `429` (and can `5xx` transiently), so the
-    #: SDK's transport is handed a urllib3 `Retry` with this many attempts,
+    #: SDK's transport is handed a urllib3 `Retry` with this many retries,
     #: exponential `backoff_factor` growth, and `Retry-After` honoured — the same
     #: policy the repo-wide `HttpClient` applies. `403` is deliberately *not*
     #: retried: on a public, keyless endpoint it is a hard block, not transient.
+    #: (The ohsome SDK adds one final no-retry attempt of its own after a
+    #: `RetryError`, so the effective request count is this budget plus one.)
     MAX_OHSOME_RETRIES: int = 5
     OHSOME_BACKOFF_FACTOR: float = 1.0
 
@@ -589,14 +591,15 @@ class OSM(AbstractDataSource):
         the chained form spawns a fresh sub-client that silently drops the
         `retry` and `user_agent` set on the root client, so only the direct
         `post(endpoint=...)` actually applies our transport policy. That policy
-        gives the SDK's session a urllib3 `Retry` (`MAX_OHSOME_RETRIES` attempts,
+        gives the SDK's session a urllib3 `Retry` (`MAX_OHSOME_RETRIES` retries,
         exponential `OHSOME_BACKOFF_FACTOR` growth, `Retry-After` honoured) so a
         `429`/`5xx` throttle is retried with backoff — matching the repo-wide
         `HttpClient`. A `403` (and any leftover `429` after the retries) is *not*
         a transient error on this public, keyless endpoint, so it is turned into
-        a clear, typed `OhsomeUnavailableError` instead of the SDK's opaque
-        failure (an HTML `403` body makes the SDK leak a bare
-        `requests.exceptions.JSONDecodeError`).
+        a clear, typed `OhsomeUnavailableError` (via `_raise_ohsome_unavailable`)
+        instead of the SDK's opaque failure — which exposes the status
+        inconsistently, sometimes as an `OhsomeException` and sometimes as a bare
+        leaked `JSONDecodeError`.
 
         Args:
             query_id: The named-query id (for logging).
@@ -660,9 +663,9 @@ class OSM(AbstractDataSource):
     def _raise_ohsome_unavailable(self, exc: Exception) -> None:
         """Re-raise an ohsome throttle/block as a typed `OhsomeUnavailableError`.
 
-        Inspects the SDK failure for an HTTP status (`ohsome_http_status` digs
-        it out of the exception chain, since a non-JSON error body makes the SDK
-        leak a bare `requests.exceptions.JSONDecodeError`). A `403`, or a `429`
+        Inspects the SDK failure for an HTTP status (`ohsome_http_status`
+        recovers it whether the SDK wrapped the failure into an `OhsomeException`
+        or leaked a bare `JSONDecodeError`). A `403`, or a `429`
         that outlived the retries, becomes a clear, actionable
         `OhsomeUnavailableError`; any other failure — including a `401`, which on
         this keyless endpoint signals a real auth-contract change, not a

--- a/libs/providers/hazards/tests/osm/conftest.py
+++ b/libs/providers/hazards/tests/osm/conftest.py
@@ -170,27 +170,52 @@ def fake_overpass_post(monkeypatch: pytest.MonkeyPatch) -> FakePostState:
 
 @dataclass
 class FakeOhsomeState:
-    """Records the `elements.geometry.post` kwargs and serves a fixture frame."""
+    """Records the client-construction + post kwargs and serves a fixture frame.
+
+    The backend issues the request as `OhsomeClient(...).post(endpoint=
+    "elements/geometry", ...)`, so both the constructor kwargs (`user_agent` /
+    `retry` / `log`) and the post kwargs are captured; `error` lets a test make
+    the post raise instead of returning a frame.
+    """
 
     frame: gpd.GeoDataFrame = field(default_factory=make_ohsome_frame)
     post_kwargs: dict[str, Any] = field(default_factory=dict)
+    client_kwargs: dict[str, Any] = field(default_factory=dict)
+    error: BaseException | None = None
 
 
 @pytest.fixture
 def fake_ohsome(monkeypatch: pytest.MonkeyPatch) -> FakeOhsomeState:
-    """Replace the `ohsome` module with a recording fake."""
+    """Replace the `ohsome` module with a recording fake.
+
+    Mirrors both SDK call forms: the root `OhsomeClient(...).post(endpoint=
+    "elements/geometry", ...)` the backend uses (recording the construction
+    kwargs so a test can assert the retry / user-agent policy) and the chained
+    `.elements.geometry.post(...)` form.
+    """
     state = FakeOhsomeState()
+
+    def _record_post(**kwargs: Any):
+        state.post_kwargs = kwargs
+        if state.error is not None:
+            raise state.error
+        return types.SimpleNamespace(as_dataframe=lambda: state.frame)
 
     class _Geometry:
         def post(self, **kwargs: Any):
-            state.post_kwargs = kwargs
-            return types.SimpleNamespace(as_dataframe=lambda: state.frame)
+            return _record_post(**kwargs)
 
     class _Elements:
         geometry = _Geometry()
 
     class _OhsomeClient:
         elements = _Elements()
+
+        def __init__(self, **kwargs: Any) -> None:
+            state.client_kwargs = kwargs
+
+        def post(self, **kwargs: Any):
+            return _record_post(**kwargs)
 
     module = types.ModuleType("ohsome")
     module.OhsomeClient = _OhsomeClient

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -205,15 +205,17 @@ class TestOhsomeRoute:
         assert 429 in retry.status_forcelist
         assert 403 not in retry.status_forcelist
 
-    def test_forbidden_becomes_unavailable_error(self, osm_kwargs, fake_ohsome):
-        """A 403 (leaked through the SDK's chain) surfaces as a typed skip signal."""
+    def test_forbidden_via_leaked_jsondecodeerror_becomes_unavailable(
+        self, osm_kwargs, fake_ohsome
+    ):
+        """A 403 leaked as a bare JSONDecodeError is recovered via the chain."""
         import requests
 
         from earthlens.osm import OhsomeUnavailableError
 
-        # Mirror the real leak: the SDK's HTML-403 handling raises a bare
-        # JSONDecodeError whose originating HTTPError (status 403) is only in
-        # the __context__ chain.
+        # One of the two SDK shapes: the HTML-403 body leaks a bare
+        # JSONDecodeError whose originating HTTPError (status 403) is only in the
+        # __context__ chain.
         http_error = requests.HTTPError("403 Forbidden")
         http_error.response = types.SimpleNamespace(status_code=403)
         leaked = ValueError("Expecting value: line 1 column 1 (char 0)")
@@ -231,6 +233,46 @@ class TestOhsomeRoute:
         assert excinfo.value.status_code == 403
         assert "public" in str(excinfo.value)
         assert excinfo.value.__cause__ is leaked
+
+    def test_forbidden_via_ohsome_exception_becomes_unavailable(
+        self, osm_kwargs, fake_ohsome
+    ):
+        """A 403 wrapped as OhsomeException(error_code=403) is also classified."""
+        from earthlens.osm import OhsomeUnavailableError
+
+        # The other SDK shape: the failure is wrapped into an OhsomeException-like
+        # error exposing error_code directly (no leaked JSONDecodeError).
+        ohsome_error = RuntimeError("Forbidden")
+        ohsome_error.error_code = 403
+        fake_ohsome.error = ohsome_error
+
+        with pytest.raises(OhsomeUnavailableError) as excinfo:
+            OSM(
+                **{
+                    **osm_kwargs(),
+                    "variables": ["ohsome:buildings"],
+                    "start": "2020-01-01",
+                }
+            ).download()
+        assert excinfo.value.status_code == 403
+
+    def test_unauthorized_propagates_unchanged(self, osm_kwargs, fake_ohsome):
+        """A 401 is a real auth-contract change, not a throttle, so it propagates."""
+        from earthlens.osm import OhsomeUnavailableError
+
+        ohsome_error = RuntimeError("Unauthorized")
+        ohsome_error.error_code = 401
+        fake_ohsome.error = ohsome_error
+
+        with pytest.raises(RuntimeError, match="Unauthorized") as excinfo:
+            OSM(
+                **{
+                    **osm_kwargs(),
+                    "variables": ["ohsome:buildings"],
+                    "start": "2020-01-01",
+                }
+            ).download()
+        assert not isinstance(excinfo.value, OhsomeUnavailableError)
 
     def test_rate_limited_becomes_unavailable_error(self, osm_kwargs, fake_ohsome):
         """A 429 outliving the retries surfaces as a typed skip signal."""

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -181,6 +182,85 @@ class TestOhsomeRoute:
         ).download()
         assert "index" not in fc.columns
         assert len(fc) == 1
+
+    def test_request_targets_elements_geometry_endpoint(self, osm_kwargs, fake_ohsome):
+        """The request goes through the root client's post(endpoint=...) form."""
+        OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        ).download()
+        assert fake_ohsome.post_kwargs["endpoint"] == "elements/geometry"
+
+    def test_retry_and_user_agent_policy_applied(self, osm_kwargs, fake_ohsome):
+        """The client carries our UA, log=False, and a 429/5xx (not 403) retry."""
+        from earthlens.osm.backend import USER_AGENT
+
+        OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        ).download()
+        client_kwargs = fake_ohsome.client_kwargs
+        assert client_kwargs["user_agent"] == USER_AGENT
+        assert client_kwargs["log"] is False
+        retry = client_kwargs["retry"]
+        assert retry.total == 5
+        assert 429 in retry.status_forcelist
+        assert 403 not in retry.status_forcelist
+
+    def test_forbidden_becomes_unavailable_error(self, osm_kwargs, fake_ohsome):
+        """A 403 (leaked through the SDK's chain) surfaces as a typed skip signal."""
+        import requests
+
+        from earthlens.osm import OhsomeUnavailableError
+
+        # Mirror the real leak: the SDK's HTML-403 handling raises a bare
+        # JSONDecodeError whose originating HTTPError (status 403) is only in
+        # the __context__ chain.
+        http_error = requests.HTTPError("403 Forbidden")
+        http_error.response = types.SimpleNamespace(status_code=403)
+        leaked = ValueError("Expecting value: line 1 column 1 (char 0)")
+        leaked.__context__ = http_error
+        fake_ohsome.error = leaked
+
+        with pytest.raises(OhsomeUnavailableError) as excinfo:
+            OSM(
+                **{
+                    **osm_kwargs(),
+                    "variables": ["ohsome:buildings"],
+                    "start": "2020-01-01",
+                }
+            ).download()
+        assert excinfo.value.status_code == 403
+        assert "public" in str(excinfo.value)
+        assert excinfo.value.__cause__ is leaked
+
+    def test_rate_limited_becomes_unavailable_error(self, osm_kwargs, fake_ohsome):
+        """A 429 outliving the retries surfaces as a typed skip signal."""
+        from earthlens.osm import OhsomeUnavailableError
+
+        ohsome_error = RuntimeError("Too Many Requests")
+        ohsome_error.error_code = 429
+        fake_ohsome.error = ohsome_error
+
+        with pytest.raises(OhsomeUnavailableError) as excinfo:
+            OSM(
+                **{
+                    **osm_kwargs(),
+                    "variables": ["ohsome:buildings"],
+                    "start": "2020-01-01",
+                }
+            ).download()
+        assert excinfo.value.status_code == 429
+
+    def test_non_throttle_error_propagates_unchanged(self, osm_kwargs, fake_ohsome):
+        """An error with no throttle status propagates as-is (not masked)."""
+        fake_ohsome.error = RuntimeError("some genuine bug")
+        with pytest.raises(RuntimeError, match="some genuine bug"):
+            OSM(
+                **{
+                    **osm_kwargs(),
+                    "variables": ["ohsome:buildings"],
+                    "start": "2020-01-01",
+                }
+            ).download()
 
 
 class TestDownloadContract:

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -227,14 +227,11 @@ class TestOhsomeRoute:
         leaked.__context__ = http_error
         fake_ohsome.error = leaked
 
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
         with pytest.raises(OhsomeUnavailableError) as excinfo:
-            OSM(
-                **{
-                    **osm_kwargs(),
-                    "variables": ["ohsome:buildings"],
-                    "start": "2020-01-01",
-                }
-            ).download()
+            backend.download()
         assert excinfo.value.status_code == 403
         assert "public" in str(excinfo.value)
         assert excinfo.value.__cause__ is leaked
@@ -251,14 +248,11 @@ class TestOhsomeRoute:
         ohsome_error.error_code = 403
         fake_ohsome.error = ohsome_error
 
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
         with pytest.raises(OhsomeUnavailableError) as excinfo:
-            OSM(
-                **{
-                    **osm_kwargs(),
-                    "variables": ["ohsome:buildings"],
-                    "start": "2020-01-01",
-                }
-            ).download()
+            backend.download()
         assert excinfo.value.status_code == 403
 
     def test_unauthorized_propagates_unchanged(self, osm_kwargs, fake_ohsome):
@@ -269,14 +263,11 @@ class TestOhsomeRoute:
         ohsome_error.error_code = 401
         fake_ohsome.error = ohsome_error
 
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
         with pytest.raises(RuntimeError, match="Unauthorized") as excinfo:
-            OSM(
-                **{
-                    **osm_kwargs(),
-                    "variables": ["ohsome:buildings"],
-                    "start": "2020-01-01",
-                }
-            ).download()
+            backend.download()
         assert not isinstance(excinfo.value, OhsomeUnavailableError)
 
     def test_rate_limited_becomes_unavailable_error(self, osm_kwargs, fake_ohsome):
@@ -287,27 +278,21 @@ class TestOhsomeRoute:
         ohsome_error.error_code = 429
         fake_ohsome.error = ohsome_error
 
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
         with pytest.raises(OhsomeUnavailableError) as excinfo:
-            OSM(
-                **{
-                    **osm_kwargs(),
-                    "variables": ["ohsome:buildings"],
-                    "start": "2020-01-01",
-                }
-            ).download()
+            backend.download()
         assert excinfo.value.status_code == 429
 
     def test_non_throttle_error_propagates_unchanged(self, osm_kwargs, fake_ohsome):
         """An error with no throttle status propagates as-is (not masked)."""
         fake_ohsome.error = RuntimeError("some genuine bug")
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
         with pytest.raises(RuntimeError, match="some genuine bug"):
-            OSM(
-                **{
-                    **osm_kwargs(),
-                    "variables": ["ohsome:buildings"],
-                    "start": "2020-01-01",
-                }
-            ).download()
+            backend.download()
 
 
 class TestDownloadContract:

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -191,7 +191,7 @@ class TestOhsomeRoute:
         assert fake_ohsome.post_kwargs["endpoint"] == "elements/geometry"
 
     def test_retry_and_user_agent_policy_applied(self, osm_kwargs, fake_ohsome):
-        """The client carries our UA, log=False, and a 429/5xx (not 403) retry."""
+        """The client carries our UA, log=False, and a capped 429/5xx (not 403) retry."""
         from earthlens.osm.backend import USER_AGENT
 
         OSM(
@@ -201,9 +201,14 @@ class TestOhsomeRoute:
         assert client_kwargs["user_agent"] == USER_AGENT
         assert client_kwargs["log"] is False
         retry = client_kwargs["retry"]
-        assert retry.total == 5
+        assert retry.total == OSM.MAX_OHSOME_RETRIES
+        assert retry.backoff_factor == OSM.OHSOME_BACKOFF_FACTOR
         assert 429 in retry.status_forcelist
         assert 403 not in retry.status_forcelist
+        # The wait ceiling matches HttpClient's, so a hostile Retry-After cannot
+        # pin the thread — both the backoff and the Retry-After are capped.
+        assert retry.backoff_max == OSM.OHSOME_MAX_BACKOFF
+        assert retry.retry_after_max == OSM.OHSOME_MAX_BACKOFF
 
     def test_forbidden_via_leaked_jsondecodeerror_becomes_unavailable(
         self, osm_kwargs, fake_ohsome

--- a/libs/providers/hazards/tests/osm/test_helpers.py
+++ b/libs/providers/hazards/tests/osm/test_helpers.py
@@ -172,6 +172,12 @@ class TestOhsomeHttpStatus:
         """A plain error with no status anywhere yields None."""
         assert ohsome_http_status(RuntimeError("no status here")) is None
 
+    def test_bool_error_code_is_not_a_status(self):
+        """A bool error_code is rejected (bool is an int subclass), yielding None."""
+        exc = RuntimeError("weird")
+        exc.error_code = True
+        assert ohsome_http_status(exc) is None
+
     def test_survives_a_cyclic_chain(self):
         """A self-referential __context__ cycle terminates instead of looping."""
         first = RuntimeError("a")

--- a/libs/providers/hazards/tests/osm/test_helpers.py
+++ b/libs/providers/hazards/tests/osm/test_helpers.py
@@ -12,6 +12,7 @@ from earthlens.osm._helpers import (
     bbox_swne,
     bbox_wsen,
     empty_fc,
+    ohsome_http_status,
     overpy_to_gdf,
     shapely_bbox,
     to_fc,
@@ -136,6 +137,48 @@ class TestEmptyFc:
         assert len(fc) == 0
         assert {"osm_id", "osm_type"} <= set(fc.columns)
         assert fc.crs.to_epsg() == 4326
+
+
+class TestOhsomeHttpStatus:
+    """Recovering the HTTP status behind an ohsome SDK failure."""
+
+    def test_reads_error_code_directly(self):
+        """An OhsomeException-like error exposes its error_code."""
+
+        class _Err(Exception):
+            error_code = 429
+
+        assert ohsome_http_status(_Err()) == 429
+
+    def test_reads_response_status_code(self):
+        """An error carrying a response object yields its status_code."""
+        import types
+
+        exc = RuntimeError("boom")
+        exc.response = types.SimpleNamespace(status_code=503)
+        assert ohsome_http_status(exc) == 503
+
+    def test_walks_context_chain_to_http_error(self):
+        """A leaked JSONDecodeError exposes the 403 via its __context__ chain."""
+        import types
+
+        http_error = RuntimeError("403 Forbidden")
+        http_error.response = types.SimpleNamespace(status_code=403)
+        leaked = ValueError("Expecting value")
+        leaked.__context__ = http_error
+        assert ohsome_http_status(leaked) == 403
+
+    def test_returns_none_without_a_status(self):
+        """A plain error with no status anywhere yields None."""
+        assert ohsome_http_status(RuntimeError("no status here")) is None
+
+    def test_survives_a_cyclic_chain(self):
+        """A self-referential __context__ cycle terminates instead of looping."""
+        first = RuntimeError("a")
+        second = RuntimeError("b")
+        first.__context__ = second
+        second.__context__ = first
+        assert ohsome_http_status(first) is None
 
 
 class TestWayGeometry:

--- a/libs/providers/hazards/tests/osm/test_osm_e2e.py
+++ b/libs/providers/hazards/tests/osm/test_osm_e2e.py
@@ -18,6 +18,7 @@ import pytest
 import requests
 
 from earthlens.earthlens import EarthLens
+from earthlens.osm import OhsomeUnavailableError
 
 pytestmark = [pytest.mark.e2e, pytest.mark.osm]
 
@@ -29,9 +30,18 @@ _LON_LIM = [8.67, 8.71]
 
 
 def _skip_on_network(exc: Exception) -> None:
-    """Skip (not fail) when the failure is a transport problem, else re-raise."""
+    """Skip (not fail) when the failure is a transport problem, else re-raise.
+
+    Transport dropouts (offline / a throttled mirror) skip, and so does a
+    public-endpoint throttle/block: a `403` / `429` from `api.ohsome.org` (a
+    keyless service) is the CI runner's IP being rate-limited, not a regression,
+    so the backend's typed `OhsomeUnavailableError` skips the lane rather than
+    reddening it (issue #1025). Anything else re-raises and fails.
+    """
     if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
         pytest.skip(f"OSM service unreachable: {exc}")
+    if isinstance(exc, OhsomeUnavailableError) and exc.status_code in (403, 429):
+        pytest.skip(f"ohsome public endpoint throttled/blocked this runner: {exc}")
     raise exc
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2432,7 +2432,7 @@ requires-dist = [
     { name = "overpy", marker = "extra == 'osm'", specifier = ">=0.7" },
     { name = "overturemaps", marker = "extra == 'overture'", specifier = ">=1.0.0" },
     { name = "pyrosm", marker = "extra == 'osm-pbf'", specifier = ">=0.11.0" },
-    { name = "urllib3", marker = "extra == 'osm'", specifier = ">=1.26" },
+    { name = "urllib3", marker = "extra == 'osm'", specifier = ">=2" },
 ]
 provides-extras = ["emdat", "fdsn", "hdx", "overture", "osm", "osm-pbf"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2408,6 +2408,7 @@ hdx = [
 osm = [
     { name = "ohsome" },
     { name = "overpy" },
+    { name = "urllib3" },
 ]
 osm-pbf = [
     { name = "osmium" },
@@ -2431,6 +2432,7 @@ requires-dist = [
     { name = "overpy", marker = "extra == 'osm'", specifier = ">=0.7" },
     { name = "overturemaps", marker = "extra == 'overture'", specifier = ">=1.0.0" },
     { name = "pyrosm", marker = "extra == 'osm-pbf'", specifier = ">=0.11.0" },
+    { name = "urllib3", marker = "extra == 'osm'", specifier = ">=1.26" },
 ]
 provides-extras = ["emdat", "fdsn", "hdx", "overture", "osm", "osm-pbf"]
 


### PR DESCRIPTION
# Description

The OSM `ohsome` path bypassed the shared `HttpClient` and leaned on the ohsome SDK's default transport, so a
public-endpoint throttle surfaced badly to both users and CI:

- On the HTML `403` that an overloaded `api.ohsome.org` front proxy returns, the ohsome SDK's error handling
  misfires — its `except json.decoder.JSONDecodeError` does not catch the `simplejson`-based
  `requests.exceptions.JSONDecodeError` — and it leaks a bewildering `JSONDecodeError: Expecting value: line 1
  column 1 (char 0)` with no hint that the real cause is a `403` block. A `429` rate-limit was likewise opaque.
- `api.ohsome.org` is a public, keyless endpoint, so a `403` / `429` from it is the service throttling/blocking the
  caller's IP, not a credential problem — but the code treated it as a hard, unexplained failure.

This PR routes the request through the root `OhsomeClient(...).post(endpoint="elements/geometry")` form (the chained
`.elements.geometry.post` spawns a sub-client that silently drops any `retry` / `user_agent`), and then:

- **Retry (transient `429` / `5xx`):** gives the SDK transport an explicit `urllib3` `Retry` matching the repo-wide
  `HttpClient` policy — 5 attempts, exponential backoff, `Retry-After` honoured, `403` deliberately **not** in the
  forcelist (on a keyless public endpoint it is a hard block, not transient).
- **Clear error (`403` / `429`):** classifies the failure via a new `ohsome_http_status()` helper (which recovers the
  status from the SDK's opaque exception chain) and raises a typed, actionable `OhsomeUnavailableError` explaining
  that a public-endpoint `403` is a throttle/block, not an auth failure — while a genuine non-throttle error
  propagates unchanged.
- Sends our descriptive `User-Agent` and `log=False` (no `ohsome_log/` directory written into the caller's CWD).
- **e2e self-skip:** the `ohsome` live test now skips (not fails) on that typed `403` / `429` signal.

**Dependencies:** `urllib3 >=1.26` is now a declared direct dependency of the `osm` extra (the ohsome path imports
`urllib3.util.retry.Retry`), per the repository's hard dependency rule. `uv.lock` regenerated.

# Issues

- Fixes #1025 — the `osm` `ohsome` e2e now skips on a public-endpoint `403` / `429`, a genuine auth/permission
  regression still fails, and the same throttle now reaches real users as a clear typed error rather than an opaque
  `JSONDecodeError`.

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run against the per-worktree env; the `ohsome` public endpoint was live-throttling this client with a `403`, which
made it a real end-to-end check of the new path.

- [x] **Live e2e** — `pytest -m "osm and e2e"
  tests/osm/test_osm_e2e.py::TestOhsomeLive::test_buildings_snapshot_returns_features` → `SKIPPED` with the typed
  `OhsomeUnavailableError` message (previously this errored with a raw `403` / `JSONDecodeError`).
- [x] **Unit suite** — `pytest -m "not e2e" tests/osm` → 106 passed, including new coverage: the retry / User-Agent /
  `log=False` policy on the client, `403` and `429` → typed `OhsomeUnavailableError`, a non-throttle error propagating
  unchanged, and the `ohsome_http_status` classifier (direct `error_code`, `response.status_code`, `__context__`
  chain-walk, `None`, and cycle-safety).
- [x] **Lint gate** — `ruff check` + `ruff format --check` clean; `mypy` clean (342 source files); `--doctest-modules`
  on the changed source passes; `uv lock` is up to date.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
