### PR TITLE
ci(e2e): run the full suite on merge to main, plus concurrency + docs-ignore hardening

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,16 @@ on:
     branches: [main]
   pull_request:
 
+# A PR supersedes its own in-flight lint run (group keyed on the PR ref); a push
+# to `main` gets a unique group per run (keyed on run_id) so no main run cancels
+# another. `cancel-in-progress: false` alone is not enough: GitHub cancels any
+# *pending* run in a shared group when a newer one queues, so a shared
+# `github.ref` group would drop the middle of three quick merges, leaving that
+# commit with no lint result. Mirrors tests.yml. See that file for the full note.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name == 'pull_request'
+    && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/tests-e2e-atmosphere.yml
+++ b/.github/workflows/tests-e2e-atmosphere.yml
@@ -28,6 +28,11 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/tests-e2e-atmosphere.yml'
       - '.github/workflows/tests-e2e-reusable.yml'
+      # A markdown-only change (e.g. a provider README) matches libs/** above
+      # but cannot affect an e2e result, so exclude it — a code+docs change
+      # still matches a non-md path and runs. (paths-ignore can't combine with
+      # paths, hence the ! negation.)
+      - '!**/*.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests-e2e-core.yml
+++ b/.github/workflows/tests-e2e-core.yml
@@ -25,6 +25,11 @@ on:
       - 'uv.lock'
       - 'pyproject.toml'
       - '.github/workflows/tests-e2e-core.yml'
+      # A markdown-only change (e.g. a provider README) matches libs/** above
+      # but cannot affect an e2e result, so exclude it — a code+docs change
+      # still matches a non-md path and runs. (paths-ignore can't combine with
+      # paths, hence the ! negation.)
+      - '!**/*.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests-e2e-hazards.yml
+++ b/.github/workflows/tests-e2e-hazards.yml
@@ -28,6 +28,11 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/tests-e2e-hazards.yml'
       - '.github/workflows/tests-e2e-reusable.yml'
+      # A markdown-only change (e.g. a provider README) matches libs/** above
+      # but cannot affect an e2e result, so exclude it — a code+docs change
+      # still matches a non-md path and runs. (paths-ignore can't combine with
+      # paths, hence the ! negation.)
+      - '!**/*.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests-e2e-imagery.yml
+++ b/.github/workflows/tests-e2e-imagery.yml
@@ -28,6 +28,11 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/tests-e2e-imagery.yml'
       - '.github/workflows/tests-e2e-reusable.yml'
+      # A markdown-only change (e.g. a provider README) matches libs/** above
+      # but cannot affect an e2e result, so exclude it — a code+docs change
+      # still matches a non-md path and runs. (paths-ignore can't combine with
+      # paths, hence the ! negation.)
+      - '!**/*.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests-e2e-land.yml
+++ b/.github/workflows/tests-e2e-land.yml
@@ -28,6 +28,11 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/tests-e2e-land.yml'
       - '.github/workflows/tests-e2e-reusable.yml'
+      # A markdown-only change (e.g. a provider README) matches libs/** above
+      # but cannot affect an e2e result, so exclude it — a code+docs change
+      # still matches a non-md path and runs. (paths-ignore can't combine with
+      # paths, hence the ! negation.)
+      - '!**/*.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests-e2e-ocean.yml
+++ b/.github/workflows/tests-e2e-ocean.yml
@@ -28,6 +28,11 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/tests-e2e-ocean.yml'
       - '.github/workflows/tests-e2e-reusable.yml'
+      # A markdown-only change (e.g. a provider README) matches libs/** above
+      # but cannot affect an e2e result, so exclude it — a code+docs change
+      # still matches a non-md path and runs. (paths-ignore can't combine with
+      # paths, hence the ! negation.)
+      - '!**/*.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -2,13 +2,14 @@ name: Tests - E2E (live CDS + GEE + STAC)
 
 # Live end-to-end suites against external services (Copernicus Climate
 # Data Store; Google Earth Engine). These hit real servers / queue
-# server-side, so running on every push/PR would burn quota and slow
-# CI. So:
+# server-side, so running on every push to any branch or every PR would burn
+# quota and slow CI. So the triggers are deliberately scoped:
 #
 #   * push to `main`: every merge to the default branch runs the FULL live
 #     e2e suite, so what actually landed is validated end-to-end (the
 #     per-provider `tests-e2e-<theme>.yml` gates only run the affected lane on
-#     a PR; this is the complete post-merge check).
+#     a PR; this is the complete post-merge check). Docs-/markdown-/CI-only
+#     merges are skipped via `paths-ignore` on the trigger below.
 #   * schedule: weekly on Sunday at 04:00 UTC
 #   * workflow_dispatch: manual trigger from the Actions tab
 #

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -5,6 +5,10 @@ name: Tests - E2E (live CDS + GEE + STAC)
 # server-side, so running on every push/PR would burn quota and slow
 # CI. So:
 #
+#   * push to `main`: every merge to the default branch runs the FULL live
+#     e2e suite, so what actually landed is validated end-to-end (the
+#     per-provider `tests-e2e-<theme>.yml` gates only run the affected lane on
+#     a PR; this is the complete post-merge check).
 #   * schedule: weekly on Sunday at 04:00 UTC
 #   * workflow_dispatch: manual trigger from the Actions tab
 #
@@ -16,9 +20,11 @@ permissions:
   contents: read
 
 # This workflow has no `pull_request` trigger, so the expression below is
-# always false and the block only SERIALISES: two dispatches on the same ref
-# queue instead of burning CDS quota twice over, which is what you want
-# against rate- and quota-limited services.
+# always false and the block only SERIALISES: two runs on the same ref (e.g.
+# back-to-back merges to `main`, or a merge overlapping the weekly cron) queue
+# instead of burning CDS quota twice over, which is what you want against rate-
+# and quota-limited services. Not cancelling a half-finished live run mid-flight
+# is the right call for this suite.
 #
 # The expression is kept rather than hard-coded `false` so the PR-cancel half
 # switches on by itself if a `pull_request` trigger is ever added - at which
@@ -29,6 +35,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
+  push:
+    branches: [main]
   schedule:
     - cron: '0 4 * * 0'
   workflow_dispatch:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -47,6 +47,15 @@ concurrency:
 on:
   push:
     branches: [main]
+    # A merge that changes only docs / markdown / mkdocs config / CI workflow
+    # files cannot affect an e2e result, so it skips the full live suite (which
+    # burns rate/quota-limited services). `paths-ignore` skips only when EVERY
+    # changed path matches, so a mixed merge (docs + code) still runs.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'mkdocs.yml'
+      - '.github/**'
   schedule:
     - cron: '0 4 * * 0'
   workflow_dispatch:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -19,12 +19,22 @@ name: Tests - E2E (live CDS + GEE + STAC)
 permissions:
   contents: read
 
-# This workflow has no `pull_request` trigger, so the expression below is
-# always false and the block only SERIALISES: two runs on the same ref (e.g.
-# back-to-back merges to `main`, or a merge overlapping the weekly cron) queue
-# instead of burning CDS quota twice over, which is what you want against rate-
-# and quota-limited services. Not cancelling a half-finished live run mid-flight
-# is the right call for this suite.
+# This workflow has no `pull_request` trigger, so the expression below is always
+# false: `cancel-in-progress: false` protects a live run that is already IN
+# PROGRESS, so an active suite is never cancelled mid-flight against the rate-
+# and quota-limited services — which is the point.
+#
+# It does NOT guarantee a run for every merge, though. All main pushes and the
+# weekly cron share one group (github.ref is `refs/heads/main` for both), and
+# GitHub cancels any *pending* run in a shared group when a newer one queues,
+# even with cancel-in-progress: false. So if merges pile up faster than a run
+# finishes (~20-30 min) — A in progress, B queued, C arrives — B is superseded
+# before it starts and that commit gets no e2e run. This is a deliberate
+# quota-first trade-off: serialise (never two full live runs at once) and, when
+# merges collide, run the latest main state rather than every intermediate; the
+# weekly cron backstops. To instead guarantee a run per merge, key the group on
+# github.run_id for non-PR events (as tests.yml does) — but that runs colliding
+# merges in PARALLEL and doubles the live-quota spend, which this suite avoids.
 #
 # The expression is kept rather than hard-coded `false` so the PR-cancel half
 # switches on by itself if a `pull_request` trigger is ever added - at which

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -5,8 +5,8 @@ name: Tests - E2E (live CDS + GEE + STAC)
 # server-side, so running on every push to any branch or every PR would burn
 # quota and slow CI. So the triggers are deliberately scoped:
 #
-#   * push to `main`: every merge to the default branch runs the FULL live
-#     e2e suite, so what actually landed is validated end-to-end (the
+#   * push to `main`: every non-docs/non-CI merge to the default branch runs
+#     the FULL live e2e suite, so what actually landed is validated end-to-end (the
 #     per-provider `tests-e2e-<theme>.yml` gates only run the affected lane on
 #     a PR; this is the complete post-merge check). Docs-/markdown-/CI-only
 #     merges are skipped via `paths-ignore` on the trigger below.
@@ -25,9 +25,11 @@ permissions:
 # an active suite is never cancelled mid-flight against rate/quota-limited
 # services, which is the point.
 #
-# The one shared `github.ref` group is deliberate: every non-PR event — a merge
-# to `main`, the weekly cron, and a manual dispatch (all `refs/heads/main`) —
-# serialises, so two full live runs never overlap. The cost is that it does NOT
+# The one shared `github.ref` group is deliberate: the non-PR events that run as
+# `refs/heads/main` — a merge to `main`, the weekly cron, and a dispatch from
+# `main` — serialise, so two full live runs never overlap. (A dispatch launched
+# from another branch runs as that ref, a separate group, and would not
+# serialise against a `main` run — an accepted edge for a manual action.) The cost is that it does NOT
 # guarantee a run per merge: GitHub cancels a *pending* run when a newer one
 # queues in the same group (see tests.yml for the full note), so during a burst
 # — merge A in progress, B pending, C queued — B is superseded before it starts,
@@ -52,6 +54,12 @@ on:
     # files cannot affect an e2e result, so it skips the full live suite (which
     # burns rate/quota-limited services). `paths-ignore` skips only when EVERY
     # changed path matches, so a mixed merge (docs + code) still runs.
+    #
+    # Trade-off: a merge touching ONLY `.github/**` — including this workflow
+    # itself — is not re-run on the merge push; a CI-config change is validated
+    # only by the next weekly cron or a manual dispatch, never by its own merge.
+    # Acceptable: a workflow-YAML change cannot alter the shipped code's e2e
+    # result, and the e2e jobs use no local composite actions under `.github/`.
     paths-ignore:
       - 'docs/**'
       - '**/*.md'

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -20,22 +20,22 @@ name: Tests - E2E (live CDS + GEE + STAC)
 permissions:
   contents: read
 
-# This workflow has no `pull_request` trigger, so the expression below is always
-# false: `cancel-in-progress: false` protects a live run that is already IN
-# PROGRESS, so an active suite is never cancelled mid-flight against the rate-
-# and quota-limited services — which is the point.
+# There is no `pull_request` trigger, so the expression is always false and
+# `cancel-in-progress: false` protects a live run that is already IN PROGRESS —
+# an active suite is never cancelled mid-flight against rate/quota-limited
+# services, which is the point.
 #
-# It does NOT guarantee a run for every merge, though. All main pushes and the
-# weekly cron share one group (github.ref is `refs/heads/main` for both), and
-# GitHub cancels any *pending* run in a shared group when a newer one queues,
-# even with cancel-in-progress: false. So if merges pile up faster than a run
-# finishes (~20-30 min) — A in progress, B queued, C arrives — B is superseded
-# before it starts and that commit gets no e2e run. This is a deliberate
-# quota-first trade-off: serialise (never two full live runs at once) and, when
-# merges collide, run the latest main state rather than every intermediate; the
-# weekly cron backstops. To instead guarantee a run per merge, key the group on
-# github.run_id for non-PR events (as tests.yml does) — but that runs colliding
-# merges in PARALLEL and doubles the live-quota spend, which this suite avoids.
+# The one shared `github.ref` group is deliberate: every non-PR event — a merge
+# to `main`, the weekly cron, and a manual dispatch (all `refs/heads/main`) —
+# serialises, so two full live runs never overlap. The cost is that it does NOT
+# guarantee a run per merge: GitHub cancels a *pending* run when a newer one
+# queues in the same group (see tests.yml for the full note), so during a burst
+# — merge A in progress, B pending, C queued — B is superseded before it starts,
+# and any non-PR event (a dispatch/cron, not just a later merge) can drop a
+# pending run this way. This is quota-first by choice: run the latest main state,
+# not every intermediate; the weekly cron backstops. Guaranteeing a run per merge
+# needs a run_id-keyed group (as tests.yml uses), which runs collisions in
+# PARALLEL and doubles the live-quota spend — exactly what this suite avoids.
 #
 # The expression is kept rather than hard-coded `false` so the PR-cancel half
 # switches on by itself if a `pull_request` trigger is ever added - at which


### PR DESCRIPTION
# Description

A CI-only change (GitHub Actions workflow YAML) that does three related things to the e2e workflows and one
concurrency fix to lint:

1. **Full live e2e on every merge to `main`.** `tests-e2e.yml` (the complete live suite — every distribution's
   suite plus the dedicated CDS/GEE/STAC/… lanes) previously ran only on the weekly cron and manual dispatch. Add
   a `push: branches: [main]` trigger so what actually lands on `main` is validated end-to-end (the per-provider
   `tests-e2e-<theme>.yml` gates only run the affected lane on a PR).

2. **Skip e2e for docs-/CI-only changes.**
   - `tests-e2e.yml` push trigger gets `paths-ignore` (`docs/**`, `**/*.md`, `mkdocs.yml`, `.github/**`), so a
     merge that changes only docs/markdown/mkdocs/CI cannot spend a full live run. `paths-ignore` skips only when
     every changed path matches, so a mixed docs+code merge still runs.
   - The 6 per-provider callers use `paths:` **include** filters (which can't be combined with `paths-ignore`), and
     `libs/<theme>/**` sweeps in each provider's `README.md` — so a README-only PR triggered the lane. Add a
     `- '!**/*.md'` negation to each caller's `paths` to exclude markdown; a code+docs change still matches a
     non-md path and runs. Their intentional `.github/workflows/*` includes are kept so a workflow change still
     re-validates on a PR.

3. **Concurrency.**
   - `lint.yml`: change the group to the `tests.yml` formula
     (`…-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}`) so a push to `main` gets a
     unique group per run. With the old shared `github.ref` group, GitHub cancels a *pending* run when a newer
     merge queues, so three back-to-back merges dropped the middle commit's lint result.
   - `tests-e2e.yml`: concurrency block **unchanged** (deliberately serialises against quota-limited services —
     never two full live runs at once). Only the explanatory comment is corrected to describe the real behaviour
     (in-progress run protected; a rapid intermediate merge may be superseded while pending; the run_id alternative
     and its parallel-quota cost noted).

No dependencies, no source/test changes. Fork-safety unchanged (jobs gated to the main repo; suites self-skip
without credentials).

# Issues
- Closes #1038 — validate every merge to main, skip e2e on docs-only changes, harden concurrency

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- All eight workflow files validated as parseable YAML; trigger/concurrency expressions verified by hand against
  every event; `paths-ignore` and the `!**/*.md` negation confirmed to place the exclusion after the positives; no
  line exceeds 120 chars; blobs are LF-only.
- Reviewed via two `/review-rounds` passes (findings all resolved); lint + unit CI matrices green on the branch.
- The live e2e suites themselves run on merge / cron, not in this PR's checks.

- [x] Workflow YAML validated; 26/26 lint + unit CI checks green

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.

