### PR TITLE
feat(eea_aq): distinguish empty-era from empty-window in download logs

### DIFF
--- a/.github/workflows/tests-e2e-atmosphere.yml
+++ b/.github/workflows/tests-e2e-atmosphere.yml
@@ -41,7 +41,10 @@ jobs:
     with:
       theme: atmosphere
       # Atmosphere's live CDS/ECMWF hosts sit in server-side queues that can
-      # wait far longer than the other themes' hosts; give the lane more
-      # headroom than the 45-minute default.
-      timeout_minutes: 90
+      # wait far longer than the other themes' hosts: a single CDS request has
+      # been observed queueing ~43 min, and the whole-lane sweep overran the
+      # earlier 90-minute cap at ~77% (cancelled mid-test). Give the lane
+      # generous headroom over the 45-minute default so a queue backlog does
+      # not fail an otherwise-passing run.
+      timeout_minutes: 180
     secrets: inherit

--- a/.github/workflows/tests-e2e-reusable.yml
+++ b/.github/workflows/tests-e2e-reusable.yml
@@ -63,10 +63,19 @@ jobs:
           atmosphere)
             providers=(
             '{"name":"nwp","path":"libs/providers/atmosphere/(src/earthlens|tests)/nwp/","marker":"e2e and nwp","groups":"groups: dev, extras: nwp","pkg":"libs/providers/atmosphere/tests/nwp"}'
+            # ECMWF/CDS gets its own lane: its live datastore requests queue
+            # server-side for tens of minutes, so bundling them into the catch-all
+            # made the whole atmosphere sweep overrun the lane timeout. Its tests
+            # live under `tests/test_ecmwf/` (not `tests/ecmwf/`), so the path and
+            # dedicated_backends spell that directory out explicitly. Uses
+            # `extras: all` (the env the catch-all already ran these tests in)
+            # because ECMWF spans both the `ecmwf` (cdsapi) and `ecmwf-modern`
+            # (ecmwf-datastores-client) extras.
+            '{"name":"ecmwf","path":"libs/providers/atmosphere/(src/earthlens/ecmwf|tests/test_ecmwf)/","marker":"e2e and ecmwf","groups":"groups: dev, extras: all","pkg":"libs/providers/atmosphere/tests/test_ecmwf"}'
             )
-            catchall_marker="e2e and not nwp"
+            catchall_marker="e2e and not nwp and not ecmwf"
             catchall_deselect=""
-            dedicated_backends="nwp"
+            dedicated_backends="nwp|ecmwf|test_ecmwf"
             ;;
           ocean)
             providers=(

--- a/libs/providers/atmosphere/src/earthlens/eea_aq/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/_helpers.py
@@ -90,6 +90,17 @@ EEA_DATASET_YEARS: dict[str, tuple[int, int]] = {
     "Unverified": (2023, 9999),
 }
 
+#: Verified <-> Unverified adjacency, used only for the empty-primary-era
+#: fallback (`adjacent_eras`). The two live eras hold the same measurements at
+#: different validation stages: the EEA promotes a year from `Unverified`
+#: (E2a/UTD) into `Verified` (E1a) once validated, so a boundary year can be
+#: missing from one while still present in the other. `Historical` has no
+#: adjacency — it is a frozen archive with no live counterpart.
+_ADJACENT_ERAS: dict[str, str] = {
+    "Verified": "Unverified",
+    "Unverified": "Verified",
+}
+
 #: Long-format schema (column -> dtype) the backend returns, even for an
 #: empty result, so callers always get the same shape.
 SCHEMA: dict[str, str] = {
@@ -182,6 +193,47 @@ def datasets_for_years(start_year: int, end_year: int) -> list[str]:
         for name, (first, last) in EEA_DATASET_YEARS.items()
         if start_year <= last and end_year >= first
     ]
+
+
+def adjacent_eras(datasets: list[str]) -> list[str]:
+    """Return the Verified/Unverified era(s) adjacent to `datasets`, untried.
+
+    The fallback target when a primary sweep returns zero files: the live era
+    (`Verified` / `Unverified`) paired with one already selected but not itself
+    in `datasets`. A boundary year can be missing from its primary era yet
+    present in the adjacent one — a year still awaiting promotion sits in
+    `Unverified` only, and a `Verified` export can be transiently empty — so
+    retrying the neighbour recovers it. Returns `[]` when there is nothing new
+    to try: a recent-year request already spans both live eras, and a
+    `Historical`-only request has no live neighbour.
+
+    Args:
+        datasets: The eras already swept, as returned by `datasets_for_years`.
+
+    Returns:
+        list[str]: The adjacent live era(s) not in `datasets`, order-stable and
+            de-duplicated.
+
+    Examples:
+        - A `Verified`-only (2013–2022) sweep falls back to `Unverified`:
+            ```python
+            >>> from earthlens.eea_aq._helpers import adjacent_eras
+            >>> adjacent_eras(["Verified"])
+            ['Unverified']
+            >>> adjacent_eras(["Verified", "Unverified"])
+            []
+            >>> adjacent_eras(["Historical"])
+            []
+
+            ```
+    """
+    already = set(datasets)
+    out: list[str] = []
+    for name in datasets:
+        neighbour = _ADJACENT_ERAS.get(name)
+        if neighbour is not None and neighbour not in already and neighbour not in out:
+            out.append(neighbour)
+    return out
 
 
 def shape_frame(

--- a/libs/providers/atmosphere/src/earthlens/eea_aq/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/_helpers.py
@@ -101,6 +101,15 @@ _ADJACENT_ERAS: dict[str, str] = {
     "Unverified": "Verified",
 }
 
+#: Promotion-lag margin (years) by which a neighbour era's declared span is
+#: widened when testing the empty-primary-era fallback. The EEA promotes a year
+#: from `Unverified` into `Verified` ~September of the following year, so the
+#: boundary year immediately below `Unverified`'s declared start can still be
+#: sitting in the live `Unverified` stream; a one-year margin lets the fallback
+#: reach it without falling back for genuinely out-of-range years (e.g. 2015),
+#: which the neighbour era cannot hold and would only bulk-download in vain.
+_PROMOTION_LAG_YEARS: int = 1
+
 #: Long-format schema (column -> dtype) the backend returns, even for an
 #: empty result, so callers always get the same shape.
 SCHEMA: dict[str, str] = {
@@ -195,43 +204,57 @@ def datasets_for_years(start_year: int, end_year: int) -> list[str]:
     ]
 
 
-def adjacent_eras(datasets: list[str]) -> list[str]:
-    """Return the Verified/Unverified era(s) adjacent to `datasets`, untried.
+def adjacent_eras(datasets: list[str], start_year: int, end_year: int) -> list[str]:
+    """Return the live era(s) adjacent to `datasets` that could hold the request.
 
-    The fallback target when a primary sweep returns zero files: the live era
-    (`Verified` / `Unverified`) paired with one already selected but not itself
-    in `datasets`. A boundary year can be missing from its primary era yet
-    present in the adjacent one — a year still awaiting promotion sits in
-    `Unverified` only, and a `Verified` export can be transiently empty — so
-    retrying the neighbour recovers it. Returns `[]` when there is nothing new
-    to try: a recent-year request already spans both live eras, and a
-    `Historical`-only request has no live neighbour.
+    The fallback target when a primary sweep returns zero files: a live era
+    (`Verified` / `Unverified`) paired with one already swept, not itself in
+    `datasets`, and whose year span can plausibly cover `[start_year, end_year]`.
+    A year straddling the promotion frontier can be missing from its primary era
+    yet still present in the neighbour — a not-yet-promoted year sits in
+    `Unverified` before it lands in `Verified` — so retrying the neighbour
+    recovers it. The neighbour's declared span is widened by
+    `_PROMOTION_LAG_YEARS` so that boundary year is reachable; a request whose
+    years fall outside even that widened span is not returned, because the
+    neighbour cannot hold it and would only be bulk-downloaded in vain.
+
+    Returns `[]` when there is nothing worth trying: a recent-year request
+    already spans both live eras, a `Historical`-only request has no live
+    neighbour, and an out-of-range year (e.g. 2015 against `Unverified` 2023+)
+    is filtered out.
 
     Args:
         datasets: The eras already swept, as returned by `datasets_for_years`.
+        start_year: First calendar year of the request (inclusive).
+        end_year: Last calendar year of the request (inclusive).
 
     Returns:
-        list[str]: The adjacent live era(s) not in `datasets`, order-stable and
+        list[str]: The adjacent live era(s) worth retrying, order-stable and
             de-duplicated.
 
     Examples:
-        - A `Verified`-only (2013–2022) sweep falls back to `Unverified`:
+        - A `Verified`-only request at the promotion boundary falls back, an
+          out-of-range one does not, and a dual-era request has nothing to add:
             ```python
             >>> from earthlens.eea_aq._helpers import adjacent_eras
-            >>> adjacent_eras(["Verified"])
+            >>> adjacent_eras(["Verified"], 2022, 2022)
             ['Unverified']
-            >>> adjacent_eras(["Verified", "Unverified"])
+            >>> adjacent_eras(["Verified"], 2015, 2015)
             []
-            >>> adjacent_eras(["Historical"])
+            >>> adjacent_eras(["Verified", "Unverified"], 2024, 2024)
             []
 
             ```
     """
     already = set(datasets)
+    lo, hi = sorted((start_year, end_year))
     out: list[str] = []
     for name in datasets:
         neighbour = _ADJACENT_ERAS.get(name)
-        if neighbour is not None and neighbour not in already and neighbour not in out:
+        if neighbour is None or neighbour in already or neighbour in out:
+            continue
+        first, last = EEA_DATASET_YEARS[neighbour]
+        if lo <= last and hi >= first - _PROMOTION_LAG_YEARS:
             out.append(neighbour)
     return out
 

--- a/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
@@ -350,7 +350,22 @@ class EEA_AQ(AbstractDataSource):
         )
         lower, upper = self._window()
         mask = (combined["datetime_utc"] >= lower) & (combined["datetime_utc"] < upper)
-        return combined[mask].reset_index(drop=True)
+        windowed = combined[mask].reset_index(drop=True)
+        if windowed.empty:
+            # Files were downloaded and carried rows, but every row fell outside
+            # [start, end). This is a genuine no-data *window* — the era(s) hold
+            # data, just not for the requested dates — logged at INFO to keep it
+            # deliberately distinct from the WARNING an empty era raises in
+            # `_iter_dataset_frames`. That split is the whole point: a caller
+            # facing an empty frame can tell "the export returned no files"
+            # (possible upstream outage) from "the dates are simply empty".
+            logger.info(
+                f"EEA download: {len(combined)} observation(s) were downloaded "
+                f"but none fell within [{lower}, {upper}); the era(s) hold data "
+                f"for {countries} / {polls}, so the requested date window is the "
+                f"empty part, not the upstream export."
+            )
+        return windowed
 
     def _iter_dataset_frames(
         self,
@@ -385,9 +400,21 @@ class EEA_AQ(AbstractDataSource):
                 download_request(request, tmp)
                 parquets = sorted(Path(tmp).rglob("*.parquet"))
                 if not parquets:
-                    logger.info(
-                        f"EEA download: dataset {dataset!r} returned no Parquet "
-                        f"files for {countries} / {polls}."
+                    # This is the whole era for every requested country and
+                    # pollutant at once (airbase requests them in one call), so
+                    # zero files is notable, not routine: it is the shape of an
+                    # upstream EEA export outage when a major reporter is asked
+                    # for a populated era (as in 2026-08, when Verified /
+                    # Unverified served zero files platform-wide). It can also be
+                    # a genuine absence for a small country / rare pollutant, so
+                    # the message names both causes rather than asserting either.
+                    logger.warning(
+                        f"EEA download: era {dataset!r} returned no Parquet files "
+                        f"for countries {countries} / pollutants {polls}. A major "
+                        f"reporter returning zero files usually means the EEA "
+                        f"export is temporarily unavailable upstream; it can also "
+                        f"mean these countries/pollutants are genuinely absent "
+                        f"from this era."
                     )
                 for parquet in parquets:
                     yield shape_frame(pd.read_parquet(parquet), dataset, code_to_name)

--- a/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
@@ -366,9 +366,9 @@ class EEA_AQ(AbstractDataSource):
             # genuine absence. A per-era WARNING would instead fire even when a
             # sibling era satisfied the request.
             logger.warning(
-                f"EEA download: no era returned any files for countries "
-                f"{countries} / pollutants {polls} across {swept}; the EEA export "
-                f"may be temporarily unavailable upstream, or these "
+                f"EEA download: no era returned any usable observations for "
+                f"countries {countries} / pollutants {polls} across {swept}; the "
+                f"EEA export may be temporarily unavailable upstream, or these "
                 f"countries/pollutants are genuinely absent from these eras. "
                 f"Returning an empty frame."
             )

--- a/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
@@ -404,7 +404,7 @@ class EEA_AQ(AbstractDataSource):
 
     def _sweep(
         self,
-        datasets: list[Any],
+        datasets: list[str],
         client: Any,
         countries: list[str],
         polls: list[str],
@@ -433,7 +433,7 @@ class EEA_AQ(AbstractDataSource):
 
     def _iter_dataset_frames(
         self,
-        datasets: list[Any],
+        datasets: list[str],
         client: Any,
         countries: list[str],
         polls: list[str],

--- a/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
@@ -333,6 +333,7 @@ class EEA_AQ(AbstractDataSource):
         # separate bulk download of every matching Parquet, so a cap met by the
         # Verified era means the Unverified one is never requested at all.
         non_empty = self._sweep(datasets, client, countries, polls, code_to_name)
+        swept = list(datasets)
         if not non_empty:
             # The primary era(s) returned zero files. Retry the adjacent live
             # era(s) not already swept (Verified <-> Unverified) whose year span
@@ -344,18 +345,33 @@ class EEA_AQ(AbstractDataSource):
             # cannot be satisfied by. This runs *only* on a fully-empty primary
             # sweep, so the normal success path never double-downloads, and a
             # recent-year request — already spanning both live eras — has no
-            # adjacent era left to try.
+            # adjacent era left to try. Logged at INFO: the fallback often
+            # recovers the data, so it is not on its own an alarm.
             fallback = adjacent_eras(datasets, start_year, end_year)
             if fallback:
-                logger.warning(
+                logger.info(
                     f"EEA download: primary era(s) {datasets} returned no files "
                     f"for countries {countries} / pollutants {polls}; retrying the "
                     f"adjacent era(s) {fallback}."
                 )
+                swept += fallback
                 non_empty = self._sweep(
                     fallback, client, countries, polls, code_to_name
                 )
         if not non_empty:
+            # Nothing from any era, primary or fallback. Only here — with the
+            # whole sweep in — is the outage-framed WARNING warranted: zero files
+            # across every swept era for the requested countries/pollutants is
+            # the shape of an upstream EEA export outage, though it can also be a
+            # genuine absence. A per-era WARNING would instead fire even when a
+            # sibling era satisfied the request.
+            logger.warning(
+                f"EEA download: no era returned any files for countries "
+                f"{countries} / pollutants {polls} across {swept}; the EEA export "
+                f"may be temporarily unavailable upstream, or these "
+                f"countries/pollutants are genuinely absent from these eras. "
+                f"Returning an empty frame."
+            )
             return empty_frame()
         combined = pd.concat(non_empty, ignore_index=True)
         # A recently-promoted year can appear in both Verified and Unverified,
@@ -448,21 +464,16 @@ class EEA_AQ(AbstractDataSource):
                 download_request(request, tmp)
                 parquets = sorted(Path(tmp).rglob("*.parquet"))
                 if not parquets:
-                    # This is the whole era for every requested country and
-                    # pollutant at once (airbase requests them in one call), so
-                    # zero files is notable, not routine: it is the shape of an
-                    # upstream EEA export outage when a major reporter is asked
-                    # for a populated era (as in 2026-08, when Verified /
-                    # Unverified served zero files platform-wide). It can also be
-                    # a genuine absence for a small country / rare pollutant, so
-                    # the message names both causes rather than asserting either.
-                    logger.warning(
+                    # Diagnostic only, at INFO: this era returned no files for the
+                    # whole requested country/pollutant set. Whether that is an
+                    # upstream outage or a genuine absence cannot be judged from a
+                    # single era — a sibling era (or the adjacent-era fallback) may
+                    # still hold the data — so `_api` owns the outage WARNING once
+                    # the whole sweep is in. Warning per era here would cry
+                    # "outage" on a download that actually succeeded.
+                    logger.info(
                         f"EEA download: era {dataset!r} returned no Parquet files "
-                        f"for countries {countries} / pollutants {polls}. A major "
-                        f"reporter returning zero files usually means the EEA "
-                        f"export is temporarily unavailable upstream; it can also "
-                        f"mean these countries/pollutants are genuinely absent "
-                        f"from this era."
+                        f"for countries {countries} / pollutants {polls}."
                     )
                 for parquet in parquets:
                     yield shape_frame(pd.read_parquet(parquet), dataset, code_to_name)

--- a/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
@@ -325,9 +325,9 @@ class EEA_AQ(AbstractDataSource):
         code_to_name = {
             self._catalog.get_pollutant(name).code: name for name in self.vars
         }
-        datasets = datasets_for_years(
-            self.time.start_date.year, self.time.end_date.year
-        )
+        start_year = self.time.start_date.year
+        end_year = self.time.end_date.year
+        datasets = datasets_for_years(start_year, end_year)
 
         # Lazy so a `limit=` stops the work where it costs: each dataset is a
         # separate bulk download of every matching Parquet, so a cap met by the
@@ -335,14 +335,17 @@ class EEA_AQ(AbstractDataSource):
         non_empty = self._sweep(datasets, client, countries, polls, code_to_name)
         if not non_empty:
             # The primary era(s) returned zero files. Retry the adjacent live
-            # era(s) not already swept (Verified <-> Unverified): a boundary year
-            # can be missing from its primary era yet present in the neighbour —
-            # a not-yet-promoted year still in the Unverified stream, or a
-            # transiently empty Verified export. This runs *only* on a
-            # fully-empty primary sweep, so the normal success path never
-            # double-downloads, and a recent-year request — already spanning both
-            # live eras — has no adjacent era left to try.
-            fallback = adjacent_eras(datasets)
+            # era(s) not already swept (Verified <-> Unverified) whose year span
+            # can plausibly cover the request: a boundary year can be missing
+            # from its primary era yet present in the neighbour (a not-yet-
+            # promoted year still in the Unverified stream). `adjacent_eras`
+            # gates on year overlap so a genuinely out-of-range request (e.g.
+            # 2015 against Unverified 2023+) never bulk-downloads an era it
+            # cannot be satisfied by. This runs *only* on a fully-empty primary
+            # sweep, so the normal success path never double-downloads, and a
+            # recent-year request — already spanning both live eras — has no
+            # adjacent era left to try.
+            fallback = adjacent_eras(datasets, start_year, end_year)
             if fallback:
                 logger.warning(
                     f"EEA download: primary era(s) {datasets} returned no files "

--- a/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
@@ -56,6 +56,7 @@ from earthlens.base import (
     to_datetime,
 )
 from earthlens.eea_aq._helpers import (
+    adjacent_eras,
     countries_in_bbox,
     datasets_for_years,
     download_request,
@@ -331,11 +332,26 @@ class EEA_AQ(AbstractDataSource):
         # Lazy so a `limit=` stops the work where it costs: each dataset is a
         # separate bulk download of every matching Parquet, so a cap met by the
         # Verified era means the Unverified one is never requested at all.
-        frames = self._take_limited(
-            self._iter_dataset_frames(datasets, client, countries, polls, code_to_name),
-            limit=self._limit,
-        )
-        non_empty = [frame for frame in frames if not frame.empty]
+        non_empty = self._sweep(datasets, client, countries, polls, code_to_name)
+        if not non_empty:
+            # The primary era(s) returned zero files. Retry the adjacent live
+            # era(s) not already swept (Verified <-> Unverified): a boundary year
+            # can be missing from its primary era yet present in the neighbour —
+            # a not-yet-promoted year still in the Unverified stream, or a
+            # transiently empty Verified export. This runs *only* on a
+            # fully-empty primary sweep, so the normal success path never
+            # double-downloads, and a recent-year request — already spanning both
+            # live eras — has no adjacent era left to try.
+            fallback = adjacent_eras(datasets)
+            if fallback:
+                logger.warning(
+                    f"EEA download: primary era(s) {datasets} returned no files "
+                    f"for countries {countries} / pollutants {polls}; retrying the "
+                    f"adjacent era(s) {fallback}."
+                )
+                non_empty = self._sweep(
+                    fallback, client, countries, polls, code_to_name
+                )
         if not non_empty:
             return empty_frame()
         combined = pd.concat(non_empty, ignore_index=True)
@@ -366,6 +382,35 @@ class EEA_AQ(AbstractDataSource):
                 f"empty part, not the upstream export."
             )
         return windowed
+
+    def _sweep(
+        self,
+        datasets: list[Any],
+        client: Any,
+        countries: list[str],
+        polls: list[str],
+        code_to_name: dict[int, str],
+    ) -> list[pd.DataFrame]:
+        """Download `datasets` era by era and return the non-empty shaped frames.
+
+        Args:
+            datasets: The eras to sweep, in priority order.
+            client: The airbase client to request through.
+            countries: Reporting-country codes the service serves.
+            polls: Pollutant codes to request.
+            code_to_name: Pollutant code (numeric) to catalog name, restricted
+                to the requested pollutants.
+
+        Returns:
+            list[pd.DataFrame]: One shaped frame per Parquet that held rows;
+                empty frames are dropped. A cap (`self._limit`) is honoured
+                lazily, so an era past the cap is never bulk-downloaded.
+        """
+        frames = self._take_limited(
+            self._iter_dataset_frames(datasets, client, countries, polls, code_to_name),
+            limit=self._limit,
+        )
+        return [frame for frame in frames if not frame.empty]
 
     def _iter_dataset_frames(
         self,

--- a/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/backend.py
@@ -388,17 +388,17 @@ class EEA_AQ(AbstractDataSource):
         windowed = combined[mask].reset_index(drop=True)
         if windowed.empty:
             # Files were downloaded and carried rows, but every row fell outside
-            # [start, end). This is a genuine no-data *window* — the era(s) hold
-            # data, just not for the requested dates — logged at INFO to keep it
-            # deliberately distinct from the WARNING an empty era raises in
-            # `_iter_dataset_frames`. That split is the whole point: a caller
-            # facing an empty frame can tell "the export returned no files"
-            # (possible upstream outage) from "the dates are simply empty".
+            # [start, end). Logged at INFO to keep it deliberately distinct from
+            # the aggregate outage WARNING (which fires only when *no* files came
+            # back): a caller facing an empty frame can tell "the export returned
+            # no files" (possible upstream outage) from "files came back, just
+            # not for these dates". The wording stays factual — it reports what
+            # was downloaded vs the window, without asserting a cause.
             logger.info(
                 f"EEA download: {len(combined)} observation(s) were downloaded "
-                f"but none fell within [{lower}, {upper}); the era(s) hold data "
-                f"for {countries} / {polls}, so the requested date window is the "
-                f"empty part, not the upstream export."
+                f"for {countries} / {polls} but none fell within [{lower}, "
+                f"{upper}); the swept era(s) returned data outside the requested "
+                f"window."
             )
         return windowed
 

--- a/libs/providers/atmosphere/tests/eea_aq/test_backend.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_backend.py
@@ -303,9 +303,11 @@ class TestEmptyResultSignals:
     def test_all_eras_empty_warns_once_about_upstream(self, tmp_path):
         """When every era returns zero files, one aggregate upstream WARNING fires."""
         client = _NoFilesClient()
-        warnings, sink = _capture("WARNING")
+        infos, isink = _capture("INFO")
+        warnings, wsink = _capture("WARNING")
         df = _backend(client, tmp_path).download(progress_bar=False)
-        logger.remove(sink)
+        logger.remove(wsink)
+        logger.remove(isink)
 
         assert df.empty and "station_id" in df.columns
         assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
@@ -314,8 +316,11 @@ class TestEmptyResultSignals:
         assert len(outage) == 1
         assert "upstream" in outage[0]
         assert "Verified" in outage[0] and "Unverified" in outage[0]
-        # The per-era emptiness is no longer a WARNING (it is diagnostic INFO).
+        # The per-era emptiness is downgraded to a diagnostic INFO (not a WARNING),
+        # and is positively emitted per era with the new wording.
         assert not any("returned no Parquet files" in m for m in warnings)
+        assert any("era 'Verified' returned no Parquet files" in m for m in infos)
+        assert any("era 'Unverified' returned no Parquet files" in m for m in infos)
 
     def test_out_of_window_download_logs_info_not_outage(self, tmp_path):
         """Files that all fall outside the window log an INFO, not the era WARNING."""
@@ -339,7 +344,7 @@ class TestAdjacentEraFallback:
     """When the primary era is empty, the adjacent live era is retried (#1046)."""
 
     def test_empty_primary_era_falls_back_to_adjacent(self, tmp_path):
-        """A 2013-2022 window whose Verified era is empty resolves via Unverified."""
+        """A June-2022 boundary-year request with an empty Verified era resolves via Unverified."""
         unverified = tmp_path / "u.parquet"
         _row_frame("2022-06-15T00:00").to_parquet(unverified)
         client = _SelectiveEraClient(Verified=None, Unverified=str(unverified))

--- a/libs/providers/atmosphere/tests/eea_aq/test_backend.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_backend.py
@@ -310,7 +310,7 @@ class TestEmptyResultSignals:
         assert df.empty and "station_id" in df.columns
         assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
         # A single aggregate outage WARNING, naming both eras, not one per era.
-        outage = [m for m in warnings if "no era returned any files" in m]
+        outage = [m for m in warnings if "no era returned any usable observations" in m]
         assert len(outage) == 1
         assert "upstream" in outage[0]
         assert "Verified" in outage[0] and "Unverified" in outage[0]
@@ -358,7 +358,7 @@ class TestAdjacentEraFallback:
         assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
         # The retry is an INFO, and a recovered download raises no outage WARNING.
         assert any("retrying the adjacent era(s)" in m for m in infos)
-        assert not any("no era returned any files" in m for m in warnings)
+        assert not any("no era returned any usable observations" in m for m in warnings)
 
     def test_no_fallback_when_both_live_eras_already_swept(self, tmp_path):
         """A 2023+ window already spans both live eras, so no fallback fires."""

--- a/libs/providers/atmosphere/tests/eea_aq/test_backend.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_backend.py
@@ -309,13 +309,15 @@ class TestEmptyResultSignals:
         logger.remove(wsink)
         logger.remove(isink)
 
-        assert df.empty and "station_id" in df.columns
+        assert df.empty
+        assert "station_id" in df.columns
         assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
         # A single aggregate outage WARNING, naming both eras, not one per era.
         outage = [m for m in warnings if "no era returned any usable observations" in m]
         assert len(outage) == 1
         assert "upstream" in outage[0]
-        assert "Verified" in outage[0] and "Unverified" in outage[0]
+        assert "Verified" in outage[0]
+        assert "Unverified" in outage[0]
         # The per-era emptiness is downgraded to a diagnostic INFO (not a WARNING),
         # and is positively emitted per era with the new wording.
         assert not any("returned no Parquet files" in m for m in warnings)
@@ -333,7 +335,8 @@ class TestEmptyResultSignals:
         )
         logger.remove(sink)
 
-        assert df.empty and "station_id" in df.columns
+        assert df.empty
+        assert "station_id" in df.columns
         assert any("none fell within" in m for m in messages)
         # Distinct from the empty-era path: this is not reported as missing files.
         assert not any("no Parquet files" in m for m in messages)
@@ -384,7 +387,8 @@ class TestAdjacentEraFallback:
             progress_bar=False
         )
 
-        assert df.empty and "station_id" in df.columns
+        assert df.empty
+        assert "station_id" in df.columns
         assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
 
     def test_out_of_range_request_does_not_fall_back(self, tmp_path):

--- a/libs/providers/atmosphere/tests/eea_aq/test_backend.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_backend.py
@@ -294,26 +294,28 @@ class TestApi:
 class TestEmptyResultSignals:
     """The two empty results are logged distinctly (see issue #1046).
 
-    An era that returns zero Parquet files (the shape of an upstream EEA
-    export outage) is a WARNING; a window that excludes every downloaded row
-    (the era holds data, the dates are simply empty) is an INFO, so a caller
-    facing an empty frame can tell the two apart.
+    A request where every era returns zero files (the shape of an upstream EEA
+    export outage) raises a single aggregate WARNING; a window that excludes
+    every downloaded row (the era holds data, the dates are simply empty) is an
+    INFO, so a caller facing an empty frame can tell the two apart.
     """
 
-    def test_empty_era_warns_per_era(self, tmp_path):
-        """An era serving zero files logs a WARNING naming the era and cause."""
+    def test_all_eras_empty_warns_once_about_upstream(self, tmp_path):
+        """When every era returns zero files, one aggregate upstream WARNING fires."""
         client = _NoFilesClient()
-        messages, sink = _capture("WARNING")
+        warnings, sink = _capture("WARNING")
         df = _backend(client, tmp_path).download(progress_bar=False)
         logger.remove(sink)
 
         assert df.empty and "station_id" in df.columns
-        # The default 2023 window sweeps both eras; each empty era warns.
         assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
-        no_file_warnings = [m for m in messages if "no Parquet files" in m]
-        assert len(no_file_warnings) == 2
-        assert any("Verified" in m for m in no_file_warnings)
-        assert all("upstream" in m for m in no_file_warnings)
+        # A single aggregate outage WARNING, naming both eras, not one per era.
+        outage = [m for m in warnings if "no era returned any files" in m]
+        assert len(outage) == 1
+        assert "upstream" in outage[0]
+        assert "Verified" in outage[0] and "Unverified" in outage[0]
+        # The per-era emptiness is no longer a WARNING (it is diagnostic INFO).
+        assert not any("returned no Parquet files" in m for m in warnings)
 
     def test_out_of_window_download_logs_info_not_outage(self, tmp_path):
         """Files that all fall outside the window log an INFO, not the era WARNING."""
@@ -341,18 +343,22 @@ class TestAdjacentEraFallback:
         unverified = tmp_path / "u.parquet"
         _row_frame("2022-06-15T00:00").to_parquet(unverified)
         client = _SelectiveEraClient(Verified=None, Unverified=str(unverified))
-        messages, sink = _capture("WARNING")
+        infos, isink = _capture("INFO")
+        warnings, wsink = _capture("WARNING")
         df = _backend(client, tmp_path, start="2022-06-01", end="2022-06-30").download(
             progress_bar=False
         )
-        logger.remove(sink)
+        logger.remove(isink)
+        logger.remove(wsink)
 
         assert len(df) == 1
         assert df.loc[0, "dataset"] == "Unverified"
         assert df.loc[0, "datetime_utc"].year == 2022
         # Verified swept first (empty), then Unverified as the adjacent fallback.
         assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
-        assert any("retrying the adjacent era(s)" in m for m in messages)
+        # The retry is an INFO, and a recovered download raises no outage WARNING.
+        assert any("retrying the adjacent era(s)" in m for m in infos)
+        assert not any("no era returned any files" in m for m in warnings)
 
     def test_no_fallback_when_both_live_eras_already_swept(self, tmp_path):
         """A 2023+ window already spans both live eras, so no fallback fires."""

--- a/libs/providers/atmosphere/tests/eea_aq/test_backend.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_backend.py
@@ -49,6 +49,26 @@ def _era_frame(verification: int) -> pd.DataFrame:
     )
 
 
+def _row_frame(start: str, verification: int = 1) -> pd.DataFrame:
+    """One MT pm25 row at ISO `start`, tagged with `verification`."""
+    starts = pd.to_datetime([start])
+    return pd.DataFrame(
+        {
+            "Samplingpoint": ["MT/SPO-1"],
+            "Pollutant": [6001],
+            "Start": starts,
+            # `End` is unused by `shape_frame`; keep it equal to `Start` to avoid
+            # timedelta arithmetic (the value is irrelevant to the reshape).
+            "End": starts,
+            "Value": ["5.0"],
+            "Unit": ["ug.m-3"],
+            "AggType": ["hour"],
+            "Validity": [1],
+            "Verification": [verification],
+        }
+    )
+
+
 class _EraRequest:
     """Copies a per-era fixture Parquet into the download dir."""
 
@@ -94,6 +114,33 @@ class _NoFilesClient:
     def request(self, source, *countries, poll=None, verbose=True):
         self.calls.append((source, countries, poll))
         return _NoFilesRequest()
+
+
+class _MaybeEraRequest:
+    """Copies a fixture Parquet, or writes nothing when the era has no files."""
+
+    def __init__(self, parquet: str | None) -> None:
+        self._parquet = parquet
+
+    def download(
+        self, dir: str, skip_existing: bool = True, raise_for_status: bool = True
+    ) -> None:
+        if self._parquet is not None:
+            shutil.copy(self._parquet, Path(dir) / "d.parquet")
+
+
+class _SelectiveEraClient:
+    """Serves a Parquet for some eras and zero files for others (by era name)."""
+
+    countries = frozenset({"MT"})
+
+    def __init__(self, **era_parquets: str | None) -> None:
+        self._map = era_parquets
+        self.calls: list[tuple[str, tuple[str, ...], object]] = []
+
+    def request(self, source, *countries, poll=None, verbose=True):
+        self.calls.append((source, countries, poll))
+        return _MaybeEraRequest(self._map.get(source))
 
 
 def _capture(level: str) -> tuple[list[str], int]:
@@ -283,6 +330,51 @@ class TestEmptyResultSignals:
         assert any("none fell within" in m for m in messages)
         # Distinct from the empty-era path: this is not reported as missing files.
         assert not any("no Parquet files" in m for m in messages)
+
+
+@pytest.mark.eea
+class TestAdjacentEraFallback:
+    """When the primary era is empty, the adjacent live era is retried (#1046)."""
+
+    def test_empty_primary_era_falls_back_to_adjacent(self, tmp_path):
+        """A 2013-2022 window whose Verified era is empty resolves via Unverified."""
+        unverified = tmp_path / "u.parquet"
+        _row_frame("2022-06-15T00:00").to_parquet(unverified)
+        client = _SelectiveEraClient(Verified=None, Unverified=str(unverified))
+        messages, sink = _capture("WARNING")
+        df = _backend(client, tmp_path, start="2022-06-01", end="2022-06-30").download(
+            progress_bar=False
+        )
+        logger.remove(sink)
+
+        assert len(df) == 1
+        assert df.loc[0, "dataset"] == "Unverified"
+        assert df.loc[0, "datetime_utc"].year == 2022
+        # Verified swept first (empty), then Unverified as the adjacent fallback.
+        assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
+        assert any("retrying the adjacent era(s)" in m for m in messages)
+
+    def test_no_fallback_when_both_live_eras_already_swept(self, tmp_path):
+        """A 2023+ window already spans both live eras, so no fallback fires."""
+        client = _NoFilesClient()  # both eras empty
+        messages, sink = _capture("WARNING")
+        df = _backend(client, tmp_path).download(progress_bar=False)  # default 2023
+        logger.remove(sink)
+
+        assert df.empty
+        # Exactly the two live eras, with no extra adjacent retry appended.
+        assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
+        assert not any("retrying the adjacent era(s)" in m for m in messages)
+
+    def test_fallback_era_also_empty_returns_schema_only(self, tmp_path):
+        """When both the primary and the adjacent era are empty, an empty frame."""
+        client = _SelectiveEraClient(Verified=None, Unverified=None)
+        df = _backend(client, tmp_path, start="2022-06-01", end="2022-06-30").download(
+            progress_bar=False
+        )
+
+        assert df.empty and "station_id" in df.columns
+        assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
 
 
 @pytest.mark.eea

--- a/libs/providers/atmosphere/tests/eea_aq/test_backend.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_backend.py
@@ -429,6 +429,36 @@ def test_missing_airbase_raises(tmp_path, monkeypatch):
 
 
 @pytest.mark.eea
+def test_airbase_client_builds_and_caches_real_client(tmp_path, monkeypatch):
+    """With no client injected, `_airbase_client` builds one via airbase, once."""
+    import airbase
+
+    built: list[object] = []
+
+    def _factory():
+        obj = object()
+        built.append(obj)
+        return obj
+
+    monkeypatch.setattr(airbase, "AirbaseClient", _factory)
+    backend = EEA_AQ(
+        start="2023-06-01",
+        end="2023-06-30",
+        variables=["pm25"],
+        lat_lim=[35.7, 36.1],
+        lon_lim=[14.1, 14.6],
+        country="MT",
+        path=str(tmp_path),
+    )
+    first = backend._airbase_client()
+    second = backend._airbase_client()
+
+    assert first is built[0], "should return the airbase-built client"
+    assert second is first, "should cache the client, not rebuild it"
+    assert len(built) == 1, f"client built {len(built)} times, expected once"
+
+
+@pytest.mark.eea
 class TestLimitStopsTheWork:
     """A `limit=` must stop the era downloads, not trim the concatenated frame.
 

--- a/libs/providers/atmosphere/tests/eea_aq/test_backend.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_backend.py
@@ -376,6 +376,19 @@ class TestAdjacentEraFallback:
         assert df.empty and "station_id" in df.columns
         assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
 
+    def test_out_of_range_request_does_not_fall_back(self, tmp_path):
+        """A 2015 empty-Verified request never bulk-downloads the Unverified era."""
+        unverified = tmp_path / "u.parquet"
+        _row_frame("2023-06-15T00:00").to_parquet(unverified)
+        client = _SelectiveEraClient(Verified=None, Unverified=str(unverified))
+        df = _backend(client, tmp_path, start="2015-06-01", end="2015-06-30").download(
+            progress_bar=False
+        )
+
+        assert df.empty
+        # Unverified (2023+) can never satisfy 2015, so it is never requested.
+        assert [call[0] for call in client.calls] == ["Verified"]
+
 
 @pytest.mark.eea
 class TestGuards:

--- a/libs/providers/atmosphere/tests/eea_aq/test_backend.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_backend.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from loguru import logger
 
 from earthlens.eea_aq import EEA_AQ
 
@@ -71,6 +72,35 @@ class _EraClient:
 
     def request(self, source, *countries, poll=None, verbose=True):
         return _EraRequest(self._verified if source == "Verified" else self._unverified)
+
+
+class _NoFilesRequest:
+    """An airbase request whose download writes no Parquet (an empty era)."""
+
+    def download(
+        self, dir: str, skip_existing: bool = True, raise_for_status: bool = True
+    ) -> None:
+        return None
+
+
+class _NoFilesClient:
+    """A recording client whose every era returns zero Parquet files."""
+
+    countries = frozenset({"MT"})
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[str, ...], object]] = []
+
+    def request(self, source, *countries, poll=None, verbose=True):
+        self.calls.append((source, countries, poll))
+        return _NoFilesRequest()
+
+
+def _capture(level: str) -> tuple[list[str], int]:
+    """Add a loguru sink collecting messages at `level`; return (messages, id)."""
+    messages: list[str] = []
+    sink = logger.add(lambda m: messages.append(m.record["message"]), level=level)
+    return messages, sink
 
 
 def _backend(client, tmp_path: Path, **overrides) -> EEA_AQ:
@@ -211,6 +241,48 @@ class TestApi:
 
         df = _backend(_EmptyClient(), tmp_path).download(progress_bar=False)
         assert df.empty
+
+
+@pytest.mark.eea
+class TestEmptyResultSignals:
+    """The two empty results are logged distinctly (see issue #1046).
+
+    An era that returns zero Parquet files (the shape of an upstream EEA
+    export outage) is a WARNING; a window that excludes every downloaded row
+    (the era holds data, the dates are simply empty) is an INFO, so a caller
+    facing an empty frame can tell the two apart.
+    """
+
+    def test_empty_era_warns_per_era(self, tmp_path):
+        """An era serving zero files logs a WARNING naming the era and cause."""
+        client = _NoFilesClient()
+        messages, sink = _capture("WARNING")
+        df = _backend(client, tmp_path).download(progress_bar=False)
+        logger.remove(sink)
+
+        assert df.empty and "station_id" in df.columns
+        # The default 2023 window sweeps both eras; each empty era warns.
+        assert [call[0] for call in client.calls] == ["Verified", "Unverified"]
+        no_file_warnings = [m for m in messages if "no Parquet files" in m]
+        assert len(no_file_warnings) == 2
+        assert any("Verified" in m for m in no_file_warnings)
+        assert all("upstream" in m for m in no_file_warnings)
+
+    def test_out_of_window_download_logs_info_not_outage(self, tmp_path):
+        """Files that all fall outside the window log an INFO, not the era WARNING."""
+        parquet = tmp_path / "june.parquet"
+        _era_frame(verification=1).to_parquet(parquet)  # a single 2023-06-15 row
+        client = _FakeAirbaseClient(parquet)
+        messages, sink = _capture("INFO")
+        df = _backend(client, tmp_path, start="2023-07-01", end="2023-07-31").download(
+            progress_bar=False
+        )
+        logger.remove(sink)
+
+        assert df.empty and "station_id" in df.columns
+        assert any("none fell within" in m for m in messages)
+        # Distinct from the empty-era path: this is not reported as missing files.
+        assert not any("no Parquet files" in m for m in messages)
 
 
 @pytest.mark.eea

--- a/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
@@ -85,23 +85,35 @@ class TestDatasetsForYears:
 
 @pytest.mark.eea
 class TestAdjacentEras:
-    """The empty-primary-era fallback target (Verified <-> Unverified)."""
+    """The empty-primary-era fallback target (Verified <-> Unverified), year-gated."""
 
-    def test_verified_only_falls_back_to_unverified(self):
-        """A Verified-only (2013-2022) sweep falls back to Unverified."""
-        assert adjacent_eras(["Verified"]) == ["Unverified"]
+    def test_boundary_year_falls_back_to_unverified(self):
+        """A Verified-only request at the promotion boundary falls back to Unverified."""
+        assert adjacent_eras(["Verified"], 2022, 2022) == ["Unverified"]
+
+    def test_out_of_range_year_does_not_fall_back(self):
+        """A Verified-only request years before the boundary has no useful neighbour."""
+        assert adjacent_eras(["Verified"], 2015, 2015) == []
+
+    def test_range_touching_boundary_falls_back(self):
+        """A range whose upper end reaches the boundary year falls back."""
+        assert adjacent_eras(["Verified"], 2020, 2022) == ["Unverified"]
 
     def test_both_live_eras_have_no_untried_neighbour(self):
         """A recent-year sweep already spans both live eras: nothing to try."""
-        assert adjacent_eras(["Verified", "Unverified"]) == []
+        assert adjacent_eras(["Verified", "Unverified"], 2024, 2024) == []
 
     def test_historical_only_has_no_live_neighbour(self):
         """Historical is a frozen archive with no adjacent live era."""
-        assert adjacent_eras(["Historical"]) == []
+        assert adjacent_eras(["Historical"], 2010, 2010) == []
 
-    def test_historical_plus_verified_falls_back_to_unverified(self):
-        """A straddling Historical+Verified sweep still tries Unverified."""
-        assert adjacent_eras(["Historical", "Verified"]) == ["Unverified"]
+    def test_historical_plus_verified_out_of_range_does_not_fall_back(self):
+        """A 2012-2013 straddling request cannot be served by Unverified 2023+."""
+        assert adjacent_eras(["Historical", "Verified"], 2012, 2013) == []
+
+    def test_reversed_years_normalised(self):
+        """Reversed year arguments are normalised before the overlap test."""
+        assert adjacent_eras(["Verified"], 2022, 2020) == ["Unverified"]
 
 
 @pytest.mark.eea

--- a/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from earthlens.eea_aq._helpers import (
+    adjacent_eras,
     countries_in_bbox,
     datasets_for_years,
     download_request,
@@ -80,6 +81,27 @@ class TestDatasetsForYears:
     def test_reversed_years_normalised(self):
         """A reversed year pair is normalised."""
         assert datasets_for_years(2024, 2021) == ["Verified", "Unverified"]
+
+
+@pytest.mark.eea
+class TestAdjacentEras:
+    """The empty-primary-era fallback target (Verified <-> Unverified)."""
+
+    def test_verified_only_falls_back_to_unverified(self):
+        """A Verified-only (2013-2022) sweep falls back to Unverified."""
+        assert adjacent_eras(["Verified"]) == ["Unverified"]
+
+    def test_both_live_eras_have_no_untried_neighbour(self):
+        """A recent-year sweep already spans both live eras: nothing to try."""
+        assert adjacent_eras(["Verified", "Unverified"]) == []
+
+    def test_historical_only_has_no_live_neighbour(self):
+        """Historical is a frozen archive with no adjacent live era."""
+        assert adjacent_eras(["Historical"]) == []
+
+    def test_historical_plus_verified_falls_back_to_unverified(self):
+        """A straddling Historical+Verified sweep still tries Unverified."""
+        assert adjacent_eras(["Historical", "Verified"]) == ["Unverified"]
 
 
 @pytest.mark.eea


### PR DESCRIPTION
# Description

The `eea_aq` backend returned the same near-silent, generic WARNING for an empty result regardless of *why* it
was empty — so an upstream EEA export outage was indistinguishable from a legitimately empty date window — and a
boundary-year request whose Verified era was temporarily empty silently yielded nothing even when the data was
still reachable in the adjacent live era. In Aug 2026 the live Verified/Unverified Parquet exports served zero
files platform-wide (issue #1046). This PR addresses the whole issue:

**1. Adjacent-era fallback (year-gated).** When a primary era sweep returns zero Parquet files, the backend
retries the adjacent live era (`Verified` ↔ `Unverified`) — but only when that neighbour's year span can
plausibly cover the request. A year straddling the promotion frontier can be missing from its primary era yet
still sit in the neighbour (a not-yet-promoted year lives in the `Unverified`/E2a stream before it lands in
`Verified`/E1a), so `adjacent_eras(datasets, start_year, end_year)` widens the neighbour's declared span by a
one-year promotion-lag margin (`_PROMOTION_LAG_YEARS`). Concretely: an empty-`Verified` request for the 2022
boundary year falls back to `Unverified` and recovers, while a 2015 (or any 2013–2021) request does **not** — it
never bulk-downloads the `Unverified` 2023+ era it could not be satisfied by (airbase has no server-side date
filter, so an ungated fallback would transfer a whole era in vain). The retry runs **only** on a fully-empty
primary sweep, so the success path never double-downloads; a recent-year (2023+) request already spans both live
eras (`adjacent_eras` returns `[]`); `Historical` has no live neighbour. A shared `_sweep` helper backs both the
primary and fallback passes, preserving the lazy `limit=` behaviour.

**2. Distinguishable empty signals.** An empty result is now attributable from the logs without over-claiming:
- **Per-era empty → INFO**, and the **fallback retry → INFO** — diagnostic, not alarming, so a sibling era that
  holds the data never triggers a false alarm.
- **Aggregate outage → a single WARNING**, raised once, only when the *whole* sweep (primary + fallback) returned
  no usable observations for the requested countries/pollutants — the shape of an upstream export outage, though
  it names a genuine absence as the alternative cause rather than asserting either.
- **Empty window → INFO** when rows *were* downloaded but all fell outside `[start, end)` — the benign genuine
  no-data case.

The backend cannot tell an outage from a genuine absence from a single response (both are "zero files"), so it
makes the emptiness visible and attributable rather than claiming a cause.

**3. Upstream re-verified.** As of 2026-08-17 the EEA export has recovered — DE Verified/Unverified 476/412
files, MT 10/10, Historical unchanged (179/3) — and EEA did **not** renumber datasets (ids 1/2/3 still
Unverified/Verified/Historical, matching the `airbase` enum and the catalog), so the era mapping is left as-is.

The `-999` / negative-`validity` sentinel half of the original report is tracked separately in #1047.
No new dependencies.

# Issues
- Closes #1046 — EEA live Verified/Unverified empty datasets silently yielded empty frames: adds a year-gated
  adjacent-era fallback, distinguishes the per-era/empty-window INFO from a single aggregate outage WARNING, and
  re-verifies the upstream export recovered with no dataset renumbering.

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

New offline unit tests in `tests/eea_aq/` drive the backend via fake `airbase` clients (no network) and assert
both the returned frame and the emitted log records (via the repo's loguru-sink capture pattern). The branch went
through two review rounds plus a SonarCloud sweep.

Reproduce:

```
uv sync --extra all --group dev
uv run pytest libs/providers/atmosphere/tests/eea_aq -m "not e2e"
```

Result: **69 passed, 1 deselected** (e2e). `ruff check`, `ruff format --check`, `mypy`, and `--doctest-modules`
(3 doctests) on the changed files are clean, and coverage of the changed modules (`backend.py`, `_helpers.py`) is
**100% line + branch**.

- [x] Adjacent-era fallback: `test_empty_primary_era_falls_back_to_adjacent` (2022 boundary recovers via
  Unverified), `test_out_of_range_request_does_not_fall_back` (2015 never requests Unverified),
  `test_no_fallback_when_both_live_eras_already_swept`, `test_fallback_era_also_empty_returns_schema_only`, plus
  `TestAdjacentEras` unit tests for the year-gating helper.
- [x] Empty-result signals: `test_all_eras_empty_warns_once_about_upstream` (single aggregate WARNING; per-era
  note is INFO) and `test_out_of_window_download_logs_info_not_outage` (out-of-window INFO, not the outage
  WARNING).

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
