### PR TITLE
refactor(base): AOI-sidecar cache into earthlens.base; windowed reads onto pyramids crop(bbox=)

### DIFF
--- a/docs/examples/jrc-flood/01_catalog_explorer.ipynb
+++ b/docs/examples/jrc-flood/01_catalog_explorer.ipynb
@@ -44,7 +44,15 @@
    "cell_type": "markdown",
    "id": "3",
    "metadata": {},
-   "source": "## How a small AOI stays cheap\n\nEach return period is one whole-Europe GeoTIFF (~23 GB uncompressed). The backend\nnever reads it whole: it opens the file lazily and reads only the AOI's pixel\nwindow over `/vsicurl` (HTTP range requests) via pyramids' `Dataset.crop(bbox=)`.\nBuilding the request — the per-return-period URL below — is offline; only\n`.download()` touches the network."
+   "source": [
+    "## How a small AOI stays cheap\n",
+    "\n",
+    "Each return period is one whole-Europe GeoTIFF (~23 GB uncompressed). The backend\n",
+    "never reads it whole: it opens the file lazily and reads only the AOI's pixel\n",
+    "window over `/vsicurl` (HTTP range requests) via pyramids' `Dataset.crop(bbox=)`.\n",
+    "Building the request — the per-return-period URL below — is offline; only\n",
+    "`.download()` touches the network."
+   ]
   },
   {
    "cell_type": "code",
@@ -52,7 +60,14 @@
    "id": "4",
    "metadata": {},
    "outputs": [],
-   "source": "from earthlens.jrc_flood._helpers import efhm_url\n\n# One whole-Europe ~23 GB GeoTIFF per return period; a small AOI reads only its\n# pixel window via pyramids' Dataset.crop(bbox=) over /vsicurl (a few hundred KB).\nfor rp in (100, 200, 500):\n    print(f\"RP{rp}:\", efhm_url(rp))"
+   "source": [
+    "from earthlens.jrc_flood._helpers import efhm_url\n",
+    "\n",
+    "# One whole-Europe ~23 GB GeoTIFF per return period; a small AOI reads only its\n",
+    "# pixel window via pyramids' Dataset.crop(bbox=) over /vsicurl (a few hundred KB).\n",
+    "for rp in (100, 200, 500):\n",
+    "    print(f\"RP{rp}:\", efhm_url(rp))"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/jrc-flood/01_catalog_explorer.ipynb
+++ b/docs/examples/jrc-flood/01_catalog_explorer.ipynb
@@ -44,13 +44,7 @@
    "cell_type": "markdown",
    "id": "3",
    "metadata": {},
-   "source": [
-    "## How a small AOI stays cheap\n",
-    "\n",
-    "Each return period is one whole-Europe GeoTIFF (~23 GB uncompressed). The backend\n",
-    "never reads it whole: it maps the AOI to a pixel window and reads only that window\n",
-    "over `/vsicurl`. `pixel_window` is the math behind it."
-   ]
+   "source": "## How a small AOI stays cheap\n\nEach return period is one whole-Europe GeoTIFF (~23 GB uncompressed). The backend\nnever reads it whole: it opens the file lazily and reads only the AOI's pixel\nwindow over `/vsicurl` (HTTP range requests) via pyramids' `Dataset.crop(bbox=)`.\nBuilding the request — the per-return-period URL below — is offline; only\n`.download()` touches the network."
   },
   {
    "cell_type": "code",
@@ -58,19 +52,7 @@
    "id": "4",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from earthlens.jrc_flood._helpers import efhm_url, pixel_window\n",
-    "\n",
-    "# The verified EFHM geotransform + raster size (EPSG:4326, ~3 arc-second).\n",
-    "gt = (-24.54208333, 0.0008333333333333334, 0.0, 71.13375, 0.0, -0.0008333333333333334)\n",
-    "columns, rows = 110162, 51992\n",
-    "\n",
-    "print(\"RP100 URL:\", efhm_url(100))\n",
-    "# A small Rhine-delta AOI -> a ~240 x 240 px window, not 110162 x 51992.\n",
-    "print(\"window:\", pixel_window(gt, (4.8, 51.8, 5.0, 52.0), columns, rows))\n",
-    "# An AOI outside the Europe / Mediterranean coverage -> None.\n",
-    "print(\"outside coverage:\", pixel_window(gt, (30.0, -5.0, 30.2, -4.8), columns, rows))"
-   ]
+   "source": "from earthlens.jrc_flood._helpers import efhm_url\n\n# One whole-Europe ~23 GB GeoTIFF per return period; a small AOI reads only its\n# pixel window via pyramids' Dataset.crop(bbox=) over /vsicurl (a few hundred KB).\nfor rp in (100, 200, 500):\n    print(f\"RP{rp}:\", efhm_url(rp))"
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/solar_wind_atlas/01_wind_quickstart.ipynb
+++ b/docs/examples/solar_wind_atlas/01_wind_quickstart.ipynb
@@ -89,7 +89,7 @@
     "## Why this is fast\n",
     "\n",
     "`download()` opens the remote COG over `/vsicurl/` and reads only the tiles\n",
-    "overlapping the bbox via pyramids `Dataset.read_part` — a few hundred KB, not the\n",
+    "overlapping the bbox via pyramids `Dataset.crop(bbox=)` — a few hundred KB, not the\n",
     "13.9 GB global file. The Global Solar Atlas layers (`ghi`, `dni`, …) instead\n",
     "download their full ~2.7 GB ZIP once and crop locally, since they are not served\n",
     "as range-accessible COGs.\n"

--- a/docs/reference/solar_wind_atlas/introduction.md
+++ b/docs/reference/solar_wind_atlas/introduction.md
@@ -28,7 +28,7 @@ Which transport a layer uses is set by how its atlas is hosted, not by a knob:
   Cloud-Optimized GeoTIFFs (COGs) on figshare, so the backend reads **only the
   bbox window** over a virtual `/vsicurl/` range read through the
   [pyramids](https://github.com/serapeum-org/pyramids) GIS backend
-  (`Dataset.read_part`). A small area transfers a few hundred KB, not the
+  (`Dataset.crop(bbox=)`). A small area transfers a few hundred KB, not the
   multi-GB global file.
 
 - **Global Solar Atlas layers are *downloaded once, then cropped locally*.**

--- a/libs/core/src/earthlens/base/__init__.py
+++ b/libs/core/src/earthlens/base/__init__.py
@@ -66,6 +66,7 @@ from earthlens.base.spatial import (
     mask_to_geometry,
     normalize_aoi,
     resolve_aoi,
+    widen_degenerate_bbox,
 )
 
 __all__ = [
@@ -116,6 +117,7 @@ __all__ = [
     "to_datetime",
     "warn_if_egress",
     "WHOLE_WINDOW",
+    "widen_degenerate_bbox",
     "window_labels",
     "write_sidecar",
     "yaml_files_for",

--- a/libs/core/src/earthlens/base/__init__.py
+++ b/libs/core/src/earthlens/base/__init__.py
@@ -27,6 +27,12 @@ from earthlens.base.abstractdatasource import (
     TemporalExtent,
 )
 from earthlens.base.auth import AbstractAuth, AuthenticationError
+from earthlens.base.cache import (
+    aoi_tag,
+    sidecar_is_fresh,
+    sidecar_path,
+    write_sidecar,
+)
 from earthlens.base.catalog_source import (
     catalog_cache_key,
     clear_all_catalog_caches,
@@ -66,6 +72,7 @@ __all__ = [
     "AbstractAuth",
     "AbstractCatalog",
     "AbstractDataSource",
+    "aoi_tag",
     "AuthenticationError",
     "CADENCE_ALIASES",
     "catalog_cache_key",
@@ -100,6 +107,8 @@ __all__ = [
     "S3Auth",
     "S3Credentials",
     "safe_filename",
+    "sidecar_is_fresh",
+    "sidecar_path",
     "SpatialExtent",
     "split_time",
     "TemporalExtent",
@@ -108,5 +117,6 @@ __all__ = [
     "warn_if_egress",
     "WHOLE_WINDOW",
     "window_labels",
+    "write_sidecar",
     "yaml_files_for",
 ]

--- a/libs/core/src/earthlens/base/__init__.py
+++ b/libs/core/src/earthlens/base/__init__.py
@@ -61,6 +61,7 @@ from earthlens.base.region import (
 from earthlens.base.s3 import S3Auth, S3Credentials
 from earthlens.base.spatial import (
     METRES_PER_DEGREE,
+    bbox_overlaps,
     crop_to_aoi,
     ensure_no_data,
     estimate_pixel_dims,
@@ -78,6 +79,7 @@ __all__ = [
     "AbstractDataSource",
     "aoi_tag",
     "AuthenticationError",
+    "bbox_overlaps",
     "CADENCE_ALIASES",
     "catalog_cache_key",
     "clear_all_catalog_caches",

--- a/libs/core/src/earthlens/base/__init__.py
+++ b/libs/core/src/earthlens/base/__init__.py
@@ -62,6 +62,7 @@ from earthlens.base.s3 import S3Auth, S3Credentials
 from earthlens.base.spatial import (
     METRES_PER_DEGREE,
     crop_to_aoi,
+    ensure_no_data,
     estimate_pixel_dims,
     mask_to_geometry,
     normalize_aoi,
@@ -83,6 +84,7 @@ __all__ = [
     "close_quietly",
     "crop_to_aoi",
     "date_windows",
+    "ensure_no_data",
     "estimate_pixel_dims",
     "FluxableLeaf",
     "HttpClient",

--- a/libs/core/src/earthlens/base/__init__.py
+++ b/libs/core/src/earthlens/base/__init__.py
@@ -69,6 +69,7 @@ from earthlens.base.spatial import (
     resolve_aoi,
     vsicurl_config,
     widen_degenerate_bbox,
+    windowed_bbox_crop,
 )
 
 __all__ = [
@@ -122,6 +123,7 @@ __all__ = [
     "warn_if_egress",
     "WHOLE_WINDOW",
     "widen_degenerate_bbox",
+    "windowed_bbox_crop",
     "window_labels",
     "write_sidecar",
     "yaml_files_for",

--- a/libs/core/src/earthlens/base/__init__.py
+++ b/libs/core/src/earthlens/base/__init__.py
@@ -67,6 +67,7 @@ from earthlens.base.spatial import (
     mask_to_geometry,
     normalize_aoi,
     resolve_aoi,
+    vsicurl_config,
     widen_degenerate_bbox,
 )
 
@@ -117,6 +118,7 @@ __all__ = [
     "TemporalExtent",
     "Timeout",
     "to_datetime",
+    "vsicurl_config",
     "warn_if_egress",
     "WHOLE_WINDOW",
     "widen_degenerate_bbox",

--- a/libs/core/src/earthlens/base/cache.py
+++ b/libs/core/src/earthlens/base/cache.py
@@ -1,0 +1,88 @@
+"""AOI-sidecar cache primitives for download-and-localise raster backends.
+
+A backend that writes one output file per request whose *filename does not
+encode the AOI* (e.g. `fabdem_V1-2.tif`, `efhm_RP100.tif`) cannot tell "does the
+cached file hold the AOI this request wants?" from a bare `Path.exists()` check:
+a previous AOI's raster would be returned for a new bounding box written to the
+same output path. These helpers record the AOI a cached file was produced for in
+a `<target>.aoi` sidecar and compare it on the next request, so the
+skip-if-exists fast path fires only for a genuine match.
+
+The tag is bbox-plus-polygon: a backend that supports a polygon `aoi=` can be
+handed two requests with the same bounding box but different polygon masks, so
+the polygon geometry (when present) is hashed into the tag to keep their cached
+crops distinct. Shared by the `fabdem` and `jrc_flood` backends (issue #972).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from earthlens.base.abstractdatasource import SpatialExtent
+
+#: Suffix appended to an output path to form its AOI sidecar (`<target>.aoi`).
+AOI_SIDECAR_SUFFIX = ".aoi"
+
+
+def aoi_tag(space: SpatialExtent) -> str:
+    """Return a stable cache key for a spatial extent (bbox plus any polygon).
+
+    The bounding box alone is not a sufficient key: a backend that supports a
+    polygon `aoi=` can receive two requests with the *same* bounding box but
+    different polygon masks, whose cropped outputs differ. When the extent
+    carries a polygon geometry it is hashed into the key so those requests get
+    distinct tags.
+
+    Args:
+        space: The request's spatial extent, exposing `west` / `south` /
+            `east` / `north` and an optional `geometry`.
+
+    Returns:
+        A `"west,south,east,north"` string, with `|<sha256>` appended when the
+        extent carries a polygon geometry.
+    """
+    tag = f"{space.west},{space.south},{space.east},{space.north}"
+    geometry = getattr(space, "geometry", None)
+    if geometry is not None:
+        # `space.geometry` is a geopandas GeoDataFrame (from the facade's
+        # `aoi=`), so serialise it to GeoJSON; fall back to a shapely `.wkt`.
+        if hasattr(geometry, "to_json"):
+            key = geometry.to_json()
+        else:
+            key = getattr(geometry, "wkt", str(geometry))
+        tag += "|" + hashlib.sha256(key.encode("utf-8")).hexdigest()
+    return tag
+
+
+def sidecar_path(target: Path) -> Path:
+    """Return the `<target>.aoi` sidecar path for an output file."""
+    return target.with_suffix(target.suffix + AOI_SIDECAR_SUFFIX)
+
+
+def sidecar_is_fresh(target: Path, tag: str) -> bool:
+    """Whether `target` exists and its sidecar records the AOI `tag`.
+
+    Args:
+        target: The candidate cached output file.
+        tag: The current request's AOI tag (from `aoi_tag`).
+
+    Returns:
+        `True` when both the output and its sidecar exist and the sidecar's
+        recorded tag matches `tag` — i.e. the cached file holds this exact AOI.
+        A `force` re-fetch is the caller's concern and is not checked here.
+    """
+    sidecar = sidecar_path(target)
+    return (
+        target.exists()
+        and sidecar.exists()
+        and sidecar.read_text(encoding="utf-8").strip() == tag
+    )
+
+
+def write_sidecar(target: Path, tag: str) -> None:
+    """Record the AOI `tag` that `target` was written for, in its sidecar."""
+    sidecar_path(target).write_text(tag, encoding="utf-8")

--- a/libs/core/src/earthlens/base/cache.py
+++ b/libs/core/src/earthlens/base/cache.py
@@ -131,6 +131,7 @@ def sidecar_is_fresh(target: Path, tag: str) -> bool:
             True
             >>> sidecar_is_fresh(target, "9,9,9,9")
             False
+            >>> import shutil; shutil.rmtree(target.parent)
 
             ```
         - A missing output (even with a sidecar present) is not fresh:
@@ -142,6 +143,7 @@ def sidecar_is_fresh(target: Path, tag: str) -> bool:
             >>> write_sidecar(target, "0,0,1,1")
             >>> sidecar_is_fresh(target, "0,0,1,1")
             False
+            >>> import shutil; shutil.rmtree(target.parent)
 
             ```
     """
@@ -170,6 +172,7 @@ def write_sidecar(target: Path, tag: str) -> None:
             >>> write_sidecar(target, "0,0,1,1")
             >>> sidecar_path(target).read_text(encoding="utf-8")
             '0,0,1,1'
+            >>> import shutil; shutil.rmtree(target.parent)
 
             ```
     """

--- a/libs/core/src/earthlens/base/cache.py
+++ b/libs/core/src/earthlens/base/cache.py
@@ -44,6 +44,32 @@ def aoi_tag(space: SpatialExtent) -> str:
     Returns:
         A `"west,south,east,north"` string, with `|<sha256>` appended when the
         extent carries a polygon geometry.
+
+    Examples:
+        - A geometry-less extent keys to its bare bbox:
+            ```python
+            >>> from types import SimpleNamespace
+            >>> from earthlens.base.cache import aoi_tag
+            >>> space = SimpleNamespace(
+            ...     west=0.4, south=50.4, east=0.6, north=50.6, geometry=None
+            ... )
+            >>> aoi_tag(space)
+            '0.4,50.4,0.6,50.6'
+
+            ```
+        - A polygon geometry appends a `|<sha256>` segment to the bbox:
+            ```python
+            >>> from types import SimpleNamespace
+            >>> from earthlens.base.cache import aoi_tag
+            >>> geom = SimpleNamespace(to_json=lambda: '{"type": "Polygon"}')
+            >>> space = SimpleNamespace(west=0, south=0, east=1, north=1, geometry=geom)
+            >>> tag = aoi_tag(space)
+            >>> tag.startswith("0,0,1,1|")
+            True
+            >>> len(tag.split("|")[1])
+            64
+
+            ```
     """
     tag = f"{space.west},{space.south},{space.east},{space.north}"
     geometry = getattr(space, "geometry", None)
@@ -59,7 +85,24 @@ def aoi_tag(space: SpatialExtent) -> str:
 
 
 def sidecar_path(target: Path) -> Path:
-    """Return the `<target>.aoi` sidecar path for an output file."""
+    """Return the `<target>.aoi` sidecar path for an output file.
+
+    Args:
+        target: The output file whose sidecar path to build.
+
+    Returns:
+        `target` with the `.aoi` suffix appended to its full name.
+
+    Examples:
+        - The sidecar sits beside the target with `.aoi` appended:
+            ```python
+            >>> from pathlib import Path
+            >>> from earthlens.base.cache import sidecar_path
+            >>> sidecar_path(Path("out/efhm_RP100.tif")).name
+            'efhm_RP100.tif.aoi'
+
+            ```
+    """
     return target.with_suffix(target.suffix + AOI_SIDECAR_SUFFIX)
 
 
@@ -74,6 +117,33 @@ def sidecar_is_fresh(target: Path, tag: str) -> bool:
         `True` when both the output and its sidecar exist and the sidecar's
         recorded tag matches `tag` — i.e. the cached file holds this exact AOI.
         A `force` re-fetch is the caller's concern and is not checked here.
+
+    Examples:
+        - A written sidecar is fresh for its own tag and stale for another:
+            ```python
+            >>> import tempfile
+            >>> from pathlib import Path
+            >>> from earthlens.base.cache import sidecar_is_fresh, write_sidecar
+            >>> target = Path(tempfile.mkdtemp()) / "out.tif"
+            >>> _ = target.write_bytes(b"raster")
+            >>> write_sidecar(target, "0,0,1,1")
+            >>> sidecar_is_fresh(target, "0,0,1,1")
+            True
+            >>> sidecar_is_fresh(target, "9,9,9,9")
+            False
+
+            ```
+        - A missing output (even with a sidecar present) is not fresh:
+            ```python
+            >>> import tempfile
+            >>> from pathlib import Path
+            >>> from earthlens.base.cache import sidecar_is_fresh, write_sidecar
+            >>> target = Path(tempfile.mkdtemp()) / "out.tif"
+            >>> write_sidecar(target, "0,0,1,1")
+            >>> sidecar_is_fresh(target, "0,0,1,1")
+            False
+
+            ```
     """
     sidecar = sidecar_path(target)
     return (
@@ -84,5 +154,23 @@ def sidecar_is_fresh(target: Path, tag: str) -> bool:
 
 
 def write_sidecar(target: Path, tag: str) -> None:
-    """Record the AOI `tag` that `target` was written for, in its sidecar."""
+    """Record the AOI `tag` that `target` was written for, in its sidecar.
+
+    Args:
+        target: The output file the sidecar sits beside.
+        tag: The AOI tag (from `aoi_tag`) to record.
+
+    Examples:
+        - The tag is written next to the target and reads back verbatim:
+            ```python
+            >>> import tempfile
+            >>> from pathlib import Path
+            >>> from earthlens.base.cache import sidecar_path, write_sidecar
+            >>> target = Path(tempfile.mkdtemp()) / "out.tif"
+            >>> write_sidecar(target, "0,0,1,1")
+            >>> sidecar_path(target).read_text(encoding="utf-8")
+            '0,0,1,1'
+
+            ```
+    """
     sidecar_path(target).write_text(tag, encoding="utf-8")

--- a/libs/core/src/earthlens/base/spatial.py
+++ b/libs/core/src/earthlens/base/spatial.py
@@ -507,6 +507,40 @@ def vsicurl_config() -> CloudConfig:
     )
 
 
+def windowed_bbox_crop(dataset: Any, bbox: Sequence[float], *, epsg: Any = 4326) -> Any:
+    """Windowed bbox crop that keeps an all-no-data AOI as an all-no-data crop.
+
+    `Dataset.crop(bbox=)` with the default `touch=True` takes pyramids' windowed
+    fast path — reading only the AOI's pixel window — but *raises* `crop produced
+    no valid pixels` when that window is entirely no-data. An in-coverage but
+    empty AOI (e.g. open sea, or an area with no modelled value) must still
+    produce a crop, matching the pre-refactor contract where the backend wrote an
+    all-no-data raster rather than aborting. So retry with `touch=False`, which
+    returns the all-no-data window instead of raising. The fallback reads more of
+    the source (a cutline warp) and is logged, but fires only for the rare empty
+    AOI; the common data-present AOI keeps the fast windowed read.
+
+    Args:
+        dataset: An opened `pyramids.Dataset` (anything exposing `crop`).
+        bbox: `(west, south, east, north)` in `epsg` (already widened if a point).
+        epsg: CRS of `bbox`. Defaults to `4326`.
+
+    Returns:
+        The cropped `Dataset` — the windowed read, or the all-no-data window when
+        the AOI holds no valid data.
+    """
+    try:
+        return dataset.crop(bbox=list(bbox), epsg=epsg)
+    except ValueError as exc:
+        if "no valid pixels" not in str(exc):
+            raise
+        logger.info(
+            "windowed crop AOI holds no valid data; keeping the all-no-data "
+            "window via the cutline path (reads more of the source)"
+        )
+        return dataset.crop(bbox=list(bbox), epsg=epsg, touch=False)
+
+
 def widen_degenerate_bbox(
     bbox: Sequence[float], pixel_width: float, pixel_height: float
 ) -> list[float]:
@@ -623,15 +657,17 @@ def crop_to_aoi(
     geometry = getattr(space, "geometry", None)
     if geometry is not None:
         return _crop_to_mask(dataset, geometry, touch=True)
-    # Widen a point / cell-edge bbox to one pixel so crop(bbox=) does not raise
-    # on the zero-width box (a point AOI still yields a 1x1 crop). The pixel size
-    # (`geo[1]`/`geo[5]`) is in the dataset's CRS units, so only widen when the
-    # bbox is in that same CRS — for a reprojecting crop (bbox `epsg` != the
-    # dataset's CRS) mixing the units would push the edge out by a wrong amount,
-    # so leave the bbox as-is. (A real `Dataset` always exposes `geotransform` /
-    # `epsg`; the getattr guards let a bare test double without them reach crop.)
+    # Widen a point / cell-edge bbox to one pixel so a zero-area box is not handed
+    # to `crop` (which would trim to nothing / error); a point AOI still yields a
+    # 1x1 crop. The pixel size (`geo[1]`/`geo[5]`) is in the dataset's CRS units,
+    # so only widen when the bbox is in that same CRS — `epsg is None` means "the
+    # dataset's own CRS" (pyramids' default), and an explicit `epsg` must match
+    # the dataset's. For a reprojecting crop (bbox `epsg` != the dataset's CRS)
+    # mixing the units would push the edge out by a wrong amount, so leave the
+    # bbox as-is. (A real `Dataset` exposes `geotransform` / `epsg`; the getattr
+    # guards let a bare test double without them reach crop.)
     geo = getattr(dataset, "geotransform", None)
-    if geo is not None and getattr(dataset, "epsg", None) == epsg:
+    if geo is not None and (epsg is None or getattr(dataset, "epsg", None) == epsg):
         bbox = widen_degenerate_bbox(bbox, geo[1], geo[5])
     return dataset.crop(bbox=list(bbox), epsg=epsg, touch=touch)
 

--- a/libs/core/src/earthlens/base/spatial.py
+++ b/libs/core/src/earthlens/base/spatial.py
@@ -14,7 +14,16 @@ from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from loguru import logger
+from pyramids.base.remote import CloudConfig
 from pyramids.feature import bbox as _pyramids_bbox
+
+#: `/vsicurl` HTTP tuning for a remote-raster read: suppress per-open sidecar
+#: probes (`GDAL_DISABLE_READDIR_ON_OPEN`, via `vsicurl_tuning`) and bound each
+#: range request with a retry / timeout budget. These are the knobs the raster
+#: backends used to set by hand; a plain `Dataset.read_file` installs none.
+_VSICURL_HTTP_MAX_RETRY = 3
+_VSICURL_HTTP_RETRY_DELAY = 2.0
+_VSICURL_HTTP_TIMEOUT = 30
 
 #: Approximate metres per degree of latitude at the equator. Retained as
 #: part of the public surface for callers doing their own rough
@@ -463,6 +472,39 @@ def normalize_aoi(
     """
     lat_lim, lon_lim, _geometry = resolve_aoi(aoi, buffer=buffer)
     return lat_lim, lon_lim
+
+
+def vsicurl_config() -> CloudConfig:
+    """Return a pyramids `CloudConfig` that tunes a remote `/vsicurl` read.
+
+    A plain `pyramids.dataset.Dataset.read_file(url)` installs no GDAL config, so
+    the readdir-suppression and retry / timeout knobs a backend needs on the
+    remote-raster hot path are not applied by default. Wrap the `read_file` (and
+    the `crop` that reads the window) in this context so `/vsicurl` opens skip the
+    per-open `.aux.xml` / `.ovr` sidecar probes against the host and bound each
+    range request — restoring the tuning the backends used to set by hand, now
+    scoped to the read rather than mutating the process environment.
+
+    Returns:
+        A `CloudConfig` context manager enabling `vsicurl_tuning` plus the retry /
+        retry-delay / timeout budget.
+
+    Examples:
+        - Use it around a remote read so the window fetch is tuned:
+            ```python
+            >>> from earthlens.base.spatial import vsicurl_config
+            >>> cfg = vsicurl_config()
+            >>> hasattr(cfg, "__enter__")
+            True
+
+            ```
+    """
+    return CloudConfig(
+        vsicurl_tuning=True,
+        http_max_retry=_VSICURL_HTTP_MAX_RETRY,
+        http_retry_delay=_VSICURL_HTTP_RETRY_DELAY,
+        http_timeout=_VSICURL_HTTP_TIMEOUT,
+    )
 
 
 def widen_degenerate_bbox(

--- a/libs/core/src/earthlens/base/spatial.py
+++ b/libs/core/src/earthlens/base/spatial.py
@@ -520,6 +520,13 @@ def widen_degenerate_bbox(
     1x1 window the old floor/ceil pixel math clamped to (`max(1, ...)`). A box
     already positive on both axes is returned unchanged.
 
+    One whole pixel (not a sub-pixel epsilon) is used deliberately: a sub-pixel
+    box would fall through the strict `west < east` fast-path check into the
+    cutline warp and yield no cells. This assumes the pixel size is not lost to
+    float rounding at the coordinate magnitude (`west + abs(pixel) > west`),
+    which holds for geographic (|lon| <= 180, pixel ~1e-3) and normal projected
+    grids.
+
     Args:
         bbox: `(west, south, east, north)` in the source CRS.
         pixel_width: The source's pixel width (`geotransform[1]`); the absolute
@@ -574,7 +581,7 @@ def ensure_no_data(dataset: Any, default: float) -> Any:
         The same `dataset`, with a no-data value guaranteed on its first band.
     """
     nodata = getattr(dataset, "no_data_value", None)
-    if not nodata or nodata[0] is None:
+    if not isinstance(nodata, (list, tuple)) or not nodata or nodata[0] is None:
         dataset.no_data_value = default
     return dataset
 
@@ -617,11 +624,14 @@ def crop_to_aoi(
     if geometry is not None:
         return _crop_to_mask(dataset, geometry, touch=True)
     # Widen a point / cell-edge bbox to one pixel so crop(bbox=) does not raise
-    # on the zero-width box (a point AOI still yields a 1x1 crop). A real
-    # `Dataset` always exposes `geotransform`; guard it so a bare test double
-    # without one still reaches the crop.
+    # on the zero-width box (a point AOI still yields a 1x1 crop). The pixel size
+    # (`geo[1]`/`geo[5]`) is in the dataset's CRS units, so only widen when the
+    # bbox is in that same CRS — for a reprojecting crop (bbox `epsg` != the
+    # dataset's CRS) mixing the units would push the edge out by a wrong amount,
+    # so leave the bbox as-is. (A real `Dataset` always exposes `geotransform` /
+    # `epsg`; the getattr guards let a bare test double without them reach crop.)
     geo = getattr(dataset, "geotransform", None)
-    if geo is not None:
+    if geo is not None and getattr(dataset, "epsg", None) == epsg:
         bbox = widen_degenerate_bbox(bbox, geo[1], geo[5])
     return dataset.crop(bbox=list(bbox), epsg=epsg, touch=touch)
 

--- a/libs/core/src/earthlens/base/spatial.py
+++ b/libs/core/src/earthlens/base/spatial.py
@@ -507,6 +507,36 @@ def vsicurl_config() -> CloudConfig:
     )
 
 
+def bbox_overlaps(dataset: Any, bbox: Sequence[float]) -> bool:
+    """Whether a bbox intersects a dataset's geographic extent.
+
+    A cheap geographic bounds test from the dataset's affine transform and pixel
+    dimensions, used to reject an AOI outside the source's coverage *before* a
+    windowed read — so an out-of-extent AOI fails fast with a clear error rather
+    than falling into pyramids' full-source cutline warp. The bbox is assumed to
+    be in the dataset's own CRS (the case for the raster backends here).
+
+    Args:
+        dataset: An opened `pyramids.Dataset` exposing `geotransform`, `columns`,
+            and `rows`.
+        bbox: `(west, south, east, north)` in the dataset's CRS.
+
+    Returns:
+        `True` when the bbox intersects the raster's extent.
+    """
+    origin_x, pixel_w, _, origin_y, _, pixel_h = dataset.geotransform
+    west_bound, east_bound = origin_x, origin_x + dataset.columns * pixel_w
+    # `pixel_h` is negative for a north-up grid, so the south edge is lower.
+    north_bound, south_bound = origin_y, origin_y + dataset.rows * pixel_h
+    west, south, east, north = bbox
+    return not (
+        east <= west_bound
+        or west >= east_bound
+        or north <= south_bound
+        or south >= north_bound
+    )
+
+
 def windowed_bbox_crop(dataset: Any, bbox: Sequence[float], *, epsg: Any = 4326) -> Any:
     """Windowed bbox crop that keeps an all-no-data AOI as an all-no-data crop.
 
@@ -515,14 +545,22 @@ def windowed_bbox_crop(dataset: Any, bbox: Sequence[float], *, epsg: Any = 4326)
     no valid pixels` when that window is entirely no-data. An in-coverage but
     empty AOI (e.g. open sea, or an area with no modelled value) must still
     produce a crop, matching the pre-refactor contract where the backend wrote an
-    all-no-data raster rather than aborting. So retry with `touch=False`, which
-    returns the all-no-data window instead of raising. The fallback reads more of
-    the source (a cutline warp) and is logged, but fires only for the rare empty
-    AOI; the common data-present AOI keeps the fast windowed read.
+    all-no-data raster rather than aborting. So retry with `touch=False`, whose
+    cutline warp crops the same window but returns the all-no-data result instead
+    of raising, and materialise it (a read into an in-memory dataset) so the
+    fallback's reads happen here — inside any tuning context and before the source
+    handle is closed — rather than lazily through a VRT afterwards.
+
+    Contract: the caller must guarantee `bbox` overlaps the source (e.g. via
+    `bbox_overlaps`). pyramids raises the same "no valid pixels" message for both
+    an all-no-data window (kept here) and a non-overlapping bbox (a full-source
+    read then error); pre-checking overlap ensures the only meaning that reaches
+    the fallback is all-no-data.
 
     Args:
         dataset: An opened `pyramids.Dataset` (anything exposing `crop`).
-        bbox: `(west, south, east, north)` in `epsg` (already widened if a point).
+        bbox: `(west, south, east, north)` in `epsg` (already widened if a point),
+            guaranteed to overlap the source.
         epsg: CRS of `bbox`. Defaults to `4326`.
 
     Returns:
@@ -532,13 +570,29 @@ def windowed_bbox_crop(dataset: Any, bbox: Sequence[float], *, epsg: Any = 4326)
     try:
         return dataset.crop(bbox=list(bbox), epsg=epsg)
     except ValueError as exc:
+        # The only ValueError carrying this phrase is pyramids'
+        # `_correct_wrap_cutline_error`; it means the window overlaps no valid
+        # data. Coupled to pyramids' wording — the `test_all_nodata_*` tests fail
+        # if a pyramids bump rewords it, flagging this string for update.
         if "no valid pixels" not in str(exc):
             raise
         logger.info(
             "windowed crop AOI holds no valid data; keeping the all-no-data "
-            "window via the cutline path (reads more of the source)"
+            "window via the slower cutline-warp crop of the same window"
         )
-        return dataset.crop(bbox=list(bbox), epsg=epsg, touch=False)
+        fallback = dataset.crop(bbox=list(bbox), epsg=epsg, touch=False)
+        # `touch=False` returns a lazy warp VRT that reads through to the source;
+        # materialise it now so those reads happen before the caller closes the
+        # source handle (and inside any active tuning context).
+        from pyramids.dataset import Dataset
+
+        no_data = fallback.no_data_value
+        return Dataset.create_from_array(
+            arr=fallback.read_array(),
+            geo=fallback.geotransform,
+            epsg=fallback.epsg,
+            no_data_value=no_data[0] if isinstance(no_data, (list, tuple)) else no_data,
+        )
 
 
 def widen_degenerate_bbox(

--- a/libs/core/src/earthlens/base/spatial.py
+++ b/libs/core/src/earthlens/base/spatial.py
@@ -465,6 +465,54 @@ def normalize_aoi(
     return lat_lim, lon_lim
 
 
+def widen_degenerate_bbox(
+    bbox: Sequence[float], pixel_width: float, pixel_height: float
+) -> list[float]:
+    """Widen a zero-width / zero-height AOI to one source pixel.
+
+    `pyramids.Dataset.crop(bbox=)` requires a strictly positive box
+    (`west < east and south < north`); a point or cell-edge-aligned AOI
+    (`min == max` on an axis, which the facade allows) would otherwise raise. A
+    collapsed edge is pushed out by exactly one source pixel so the crop's
+    windowed fast path resolves to the single cell containing the point — the
+    1x1 window the old floor/ceil pixel math clamped to (`max(1, ...)`). A box
+    already positive on both axes is returned unchanged.
+
+    Args:
+        bbox: `(west, south, east, north)` in the source CRS.
+        pixel_width: The source's pixel width (`geotransform[1]`); the absolute
+            value is used, so the sign does not matter.
+        pixel_height: The source's pixel height (`geotransform[5]`, negative for
+            a north-up grid); the absolute value is used.
+
+    Returns:
+        A `[west, south, east, north]` list, with any collapsed axis widened by
+        one pixel.
+
+    Examples:
+        - A point AOI is widened by one pixel on both axes:
+            ```python
+            >>> from earthlens.base.spatial import widen_degenerate_bbox
+            >>> widen_degenerate_bbox([5.0, -5.0, 5.0, -5.0], 1.0, -1.0)
+            [5.0, -5.0, 6.0, -4.0]
+
+            ```
+        - A positive box is left unchanged:
+            ```python
+            >>> from earthlens.base.spatial import widen_degenerate_bbox
+            >>> widen_degenerate_bbox([4.8, 51.8, 5.0, 52.0], 0.00083, -0.00083)
+            [4.8, 51.8, 5.0, 52.0]
+
+            ```
+    """
+    west, south, east, north = bbox
+    if east <= west:
+        east = west + abs(pixel_width)
+    if north <= south:
+        north = south + abs(pixel_height)
+    return [west, south, east, north]
+
+
 def crop_to_aoi(
     dataset: Any,
     space: Any,

--- a/libs/core/src/earthlens/base/spatial.py
+++ b/libs/core/src/earthlens/base/spatial.py
@@ -574,6 +574,13 @@ def crop_to_aoi(
     geometry = getattr(space, "geometry", None)
     if geometry is not None:
         return _crop_to_mask(dataset, geometry, touch=True)
+    # Widen a point / cell-edge bbox to one pixel so crop(bbox=) does not raise
+    # on the zero-width box (a point AOI still yields a 1x1 crop). A real
+    # `Dataset` always exposes `geotransform`; guard it so a bare test double
+    # without one still reaches the crop.
+    geo = getattr(dataset, "geotransform", None)
+    if geo is not None:
+        bbox = widen_degenerate_bbox(bbox, geo[1], geo[5])
     return dataset.crop(bbox=list(bbox), epsg=epsg, touch=touch)
 
 

--- a/libs/core/src/earthlens/base/spatial.py
+++ b/libs/core/src/earthlens/base/spatial.py
@@ -513,6 +513,30 @@ def widen_degenerate_bbox(
     return [west, south, east, north]
 
 
+def ensure_no_data(dataset: Any, default: float) -> Any:
+    """Stamp a fallback no-data value when a dataset declares none.
+
+    A windowed `crop(bbox=)` carries the source's own no-data through, but a
+    source that declares none leaves the output untagged — losing the flag that
+    exact polygon masking (`crop_to_aoi`) needs to trim outside-polygon cells.
+    When the dataset's first band has no no-data, set `default` and return the
+    dataset; this is a pure metadata tag (pixels are unchanged), restoring the
+    pre-crop behaviour where the backend stamped a catalog / default no-data.
+
+    Args:
+        dataset: A `pyramids.Dataset` (anything exposing a settable
+            `no_data_value` per-band tuple).
+        default: The no-data value to stamp when the dataset declares none.
+
+    Returns:
+        The same `dataset`, with a no-data value guaranteed on its first band.
+    """
+    nodata = getattr(dataset, "no_data_value", None)
+    if not nodata or nodata[0] is None:
+        dataset.no_data_value = default
+    return dataset
+
+
 def crop_to_aoi(
     dataset: Any,
     space: Any,

--- a/libs/core/tests/base/test_cache.py
+++ b/libs/core/tests/base/test_cache.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from earthlens.base.cache import (
+    AOI_SIDECAR_SUFFIX,
+    aoi_tag,
+    sidecar_is_fresh,
+    sidecar_path,
+    write_sidecar,
+)
+
+
+def _space(west, south, east, north, geometry=None):
+    """Return a minimal duck-typed spatial extent for the cache helpers."""
+    return SimpleNamespace(
+        west=west, south=south, east=east, north=north, geometry=geometry
+    )
+
+
+class TestAoiTag:
+    """`aoi_tag` keys a request by bbox, folding in any polygon geometry."""
+
+    def test_bbox_only(self):
+        """A geometry-less extent tags to its bare `w,s,e,n` bbox."""
+        assert aoi_tag(_space(0.4, 50.4, 0.6, 50.6)) == "0.4,50.4,0.6,50.6"
+
+    def test_polygon_appends_hash(self):
+        """A geometry with `to_json` appends a `|<sha256>` segment to the bbox."""
+        geom = SimpleNamespace(to_json=lambda: '{"type": "Polygon"}')
+        tag = aoi_tag(_space(0.4, 50.4, 0.6, 50.6, geometry=geom))
+        assert tag.startswith("0.4,50.4,0.6,50.6|")
+        assert len(tag.split("|")[1]) == 64
+
+    def test_same_bbox_different_polygon_differs(self):
+        """Two requests sharing a bbox but not a polygon get distinct tags."""
+        a = aoi_tag(_space(0, 0, 1, 1, geometry=SimpleNamespace(to_json=lambda: "A")))
+        b = aoi_tag(_space(0, 0, 1, 1, geometry=SimpleNamespace(to_json=lambda: "B")))
+        assert a != b
+
+    def test_geometry_wkt_fallback(self):
+        """A geometry without `to_json` falls back to its `.wkt`."""
+        geom = SimpleNamespace(wkt="POLYGON((0 0,1 0,1 1,0 0))")
+        assert "|" in aoi_tag(_space(0, 0, 1, 1, geometry=geom))
+
+
+class TestSidecar:
+    """The `<target>.aoi` sidecar records the AOI a cached file was written for."""
+
+    def test_sidecar_path_appends_suffix(self, tmp_path):
+        """The sidecar sits beside the target with the `.aoi` suffix appended."""
+        target = tmp_path / "fabdem_V1-2.tif"
+        assert sidecar_path(target) == tmp_path / (
+            "fabdem_V1-2.tif" + AOI_SIDECAR_SUFFIX
+        )
+
+    def test_write_then_fresh_round_trip(self, tmp_path):
+        """A written sidecar reads back as fresh for the same tag."""
+        target = tmp_path / "out.tif"
+        target.write_bytes(b"raster")
+        write_sidecar(target, "0,0,1,1")
+        assert sidecar_is_fresh(target, "0,0,1,1")
+
+    def test_stale_tag_is_not_fresh(self, tmp_path):
+        """A sidecar recording a different AOI is not fresh."""
+        target = tmp_path / "out.tif"
+        target.write_bytes(b"raster")
+        write_sidecar(target, "9,9,9.1,9.1")
+        assert not sidecar_is_fresh(target, "0,0,1,1")
+
+    def test_missing_output_is_not_fresh(self, tmp_path):
+        """A sidecar without its output file is not fresh."""
+        target = tmp_path / "out.tif"
+        write_sidecar(target, "0,0,1,1")
+        assert not sidecar_is_fresh(target, "0,0,1,1")
+
+    def test_missing_sidecar_is_not_fresh(self, tmp_path):
+        """An output file with no sidecar is not fresh."""
+        target = tmp_path / "out.tif"
+        target.write_bytes(b"raster")
+        assert not sidecar_is_fresh(target, "0,0,1,1")

--- a/libs/core/tests/base/test_cache.py
+++ b/libs/core/tests/base/test_cache.py
@@ -43,6 +43,29 @@ class TestAoiTag:
         geom = SimpleNamespace(wkt="POLYGON((0 0,1 0,1 1,0 0))")
         assert "|" in aoi_tag(_space(0, 0, 1, 1, geometry=geom))
 
+    def test_geometry_str_fallback(self):
+        """A geometry with neither `to_json` nor `wkt` falls back to `str()`."""
+
+        class _Geom:
+            def __str__(self) -> str:
+                return "geom-repr"
+
+        tag = aoi_tag(_space(0, 0, 1, 1, geometry=_Geom()))
+        assert tag.startswith("0,0,1,1|")
+        assert len(tag.split("|")[1]) == 64
+
+    def test_falsy_non_none_geometry_still_hashed(self):
+        """A geometry that is falsy but not None is still folded into the tag."""
+
+        class _EmptyGeom:
+            def __bool__(self) -> bool:
+                return False
+
+            def __str__(self) -> str:
+                return "empty"
+
+        assert "|" in aoi_tag(_space(0, 0, 1, 1, geometry=_EmptyGeom()))
+
 
 class TestSidecar:
     """The `<target>.aoi` sidecar records the AOI a cached file was written for."""

--- a/libs/core/tests/base/test_spatial.py
+++ b/libs/core/tests/base/test_spatial.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyramids.dataset import Dataset
+
+from earthlens.base.spatial import ensure_no_data, widen_degenerate_bbox
+
+
+def _dataset(no_data_value):
+    """Return a small in-memory 4326 Dataset with the given no-data value."""
+    arr = np.arange(9, dtype="float32").reshape(3, 3)
+    return Dataset.create_from_array(
+        arr,
+        top_left_corner=(0, 0),
+        cell_size=1.0,
+        epsg=4326,
+        no_data_value=no_data_value,
+    )
+
+
+class TestWidenDegenerateBbox:
+    """`widen_degenerate_bbox` pushes a collapsed edge out by one source pixel."""
+
+    def test_point_widened_on_both_axes(self):
+        """A point AOI is widened by one pixel on both axes."""
+        assert widen_degenerate_bbox([5.0, -5.0, 5.0, -5.0], 1.0, -1.0) == [
+            5.0,
+            -5.0,
+            6.0,
+            -4.0,
+        ]
+
+    def test_positive_box_unchanged(self):
+        """A box already positive on both axes is returned unchanged."""
+        assert widen_degenerate_bbox([4.8, 51.8, 5.0, 52.0], 0.1, -0.1) == [
+            4.8,
+            51.8,
+            5.0,
+            52.0,
+        ]
+
+    def test_only_collapsed_axis_widened(self):
+        """Only the zero-width axis is widened; the positive axis is left alone."""
+        assert widen_degenerate_bbox([5.0, 51.0, 5.0, 52.0], 2.0, -2.0) == [
+            5.0,
+            51.0,
+            7.0,
+            52.0,
+        ]
+
+    def test_pixel_size_sign_ignored(self):
+        """The absolute pixel size is used, so a positive pixel_height still widens."""
+        assert widen_degenerate_bbox([0.0, 0.0, 0.0, 0.0], -3.0, 3.0) == [
+            0.0,
+            0.0,
+            3.0,
+            3.0,
+        ]
+
+
+class TestEnsureNoData:
+    """`ensure_no_data` stamps a fallback only when the dataset declares none."""
+
+    def test_stamps_default_when_absent(self):
+        """A dataset with no no-data gets the default stamped (pixels unchanged)."""
+        ds = _dataset(no_data_value=None)
+        before = ds.read_array().tolist()
+        result = ensure_no_data(ds, -9999.0)
+        assert result.no_data_value[0] == -9999.0, result.no_data_value
+        assert result.read_array().tolist() == before, "pixels must be untouched"
+
+    def test_keeps_existing_no_data(self):
+        """A dataset that already declares a no-data keeps it (no override)."""
+        ds = _dataset(no_data_value=-32768.0)
+        assert ensure_no_data(ds, -9999.0).no_data_value[0] == -32768.0
+
+    def test_returns_same_object(self):
+        """The dataset is returned for chaining."""
+        ds = _dataset(no_data_value=-1.0)
+        assert ensure_no_data(ds, -9999.0) is ds
+
+
+pytestmark = pytest.mark.unit

--- a/libs/core/tests/base/test_spatial.py
+++ b/libs/core/tests/base/test_spatial.py
@@ -118,11 +118,12 @@ class TestWindowedBboxCrop:
         )
 
     def test_data_present_window_is_cropped(self):
-        """A window with valid data returns a non-empty crop."""
+        """A 3-deg box on a 1-deg grid reads exactly the 3x3 AOI window."""
         crop = windowed_bbox_crop(
             self._raster(all_nodata=False), [2.0, -6.0, 5.0, -3.0]
         )
-        assert crop.rows > 0 and crop.columns > 0
+        assert crop.rows == 3, crop.rows
+        assert crop.columns == 3, crop.columns
 
     def test_all_nodata_window_does_not_raise(self):
         """An entirely-no-data window returns an all-no-data crop, not a raise."""

--- a/libs/core/tests/base/test_spatial.py
+++ b/libs/core/tests/base/test_spatial.py
@@ -4,7 +4,12 @@ import numpy as np
 import pytest
 from pyramids.dataset import Dataset
 
-from earthlens.base.spatial import ensure_no_data, widen_degenerate_bbox
+from earthlens.base.spatial import (
+    ensure_no_data,
+    vsicurl_config,
+    widen_degenerate_bbox,
+    windowed_bbox_crop,
+)
 
 
 def _dataset(no_data_value):
@@ -79,6 +84,50 @@ class TestEnsureNoData:
         """The dataset is returned for chaining."""
         ds = _dataset(no_data_value=-1.0)
         assert ensure_no_data(ds, -9999.0) is ds
+
+
+class TestVsicurlConfig:
+    """`vsicurl_config` builds a CloudConfig carrying the /vsicurl tuning."""
+
+    def test_carries_tuning_and_retry_budget(self):
+        """The config enables vsicurl_tuning plus the retry / timeout budget."""
+        cfg = vsicurl_config()
+        assert cfg.vsicurl_tuning is True, "readdir/HTTP2 fast-read tuning enabled"
+        assert cfg.http_max_retry == 3, cfg.http_max_retry
+        assert cfg.http_retry_delay == 2.0, cfg.http_retry_delay
+        assert cfg.http_timeout == 30, cfg.http_timeout
+
+    def test_is_a_context_manager(self):
+        """It is usable as a `with` block around a read."""
+        assert hasattr(vsicurl_config(), "__enter__")
+        assert hasattr(vsicurl_config(), "__exit__")
+
+
+class TestWindowedBboxCrop:
+    """`windowed_bbox_crop` reads the window, keeping an all-no-data AOI."""
+
+    def _raster(self, all_nodata: bool):
+        """A 10x10 4326 raster; optionally entirely no-data."""
+        arr = (
+            np.full((10, 10), -9999.0, "float32")
+            if all_nodata
+            else np.arange(100, dtype="float32").reshape(10, 10)
+        )
+        return Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=1.0, epsg=4326, no_data_value=-9999.0
+        )
+
+    def test_data_present_window_is_cropped(self):
+        """A window with valid data returns a non-empty crop."""
+        crop = windowed_bbox_crop(
+            self._raster(all_nodata=False), [2.0, -6.0, 5.0, -3.0]
+        )
+        assert crop.rows > 0 and crop.columns > 0
+
+    def test_all_nodata_window_does_not_raise(self):
+        """An entirely-no-data window returns an all-no-data crop, not a raise."""
+        crop = windowed_bbox_crop(self._raster(all_nodata=True), [2.0, -6.0, 5.0, -3.0])
+        assert bool((crop.read_array() == -9999.0).all()), "all-no-data crop returned"
 
 
 pytestmark = pytest.mark.unit

--- a/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
@@ -32,6 +32,7 @@ from earthlens.base import (
     ensure_no_data,
     vsicurl_config,
     widen_degenerate_bbox,
+    windowed_bbox_crop,
 )
 from earthlens.base.http import HttpClient
 
@@ -93,8 +94,10 @@ def read_part_to_geotiff(
     one pixel (`widen_degenerate_bbox`) so the strict `west < east` fast path
     still fires. The source grid, CRS and no-data value are carried onto the crop
     (with a `-9999` fallback stamped when the source declares none), so
-    genuinely-empty cells stay flagged. The read is wrapped in `vsicurl_config()`
-    for the `/vsicurl` readdir-suppression + retry/timeout tuning.
+    genuinely-empty cells stay flagged; an AOI that is entirely no-data still
+    yields an all-no-data crop rather than raising. The read is wrapped in
+    `vsicurl_config()` for the `/vsicurl` readdir-suppression + retry/timeout
+    tuning.
 
     Args:
         path: A `/vsicurl/<url>` (remote COG) or `/vsizip/<zip>/<member.tif>`
@@ -115,10 +118,11 @@ def read_part_to_geotiff(
         dataset = Dataset.read_file(path)
         try:
             # A point / cell-edge AOI is widened to one source pixel so crop(bbox=)
-            # yields a 1x1 window instead of raising on the zero-width box.
+            # yields a 1x1 window instead of raising on the zero-width box; an
+            # all-no-data AOI keeps an all-no-data window rather than raising.
             geo = dataset.geotransform
-            window = dataset.crop(
-                bbox=widen_degenerate_bbox(bbox, geo[1], geo[5]), epsg=epsg
+            window = windowed_bbox_crop(
+                dataset, widen_degenerate_bbox(bbox, geo[1], geo[5]), epsg=epsg
             )
         finally:
             # Drop the /vsicurl handle — an open remote dataset can hang the

--- a/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
@@ -28,6 +28,7 @@ from urllib.parse import urlsplit
 import requests  # noqa: F401  # runtime seam so tests can monkeypatch this module's `requests`
 
 from earthlens.base import (
+    bbox_overlaps,
     close_quietly,
     ensure_no_data,
     vsicurl_config,
@@ -117,6 +118,14 @@ def read_part_to_geotiff(
     with vsicurl_config():
         dataset = Dataset.read_file(path)
         try:
+            # Reject an AOI outside the source's extent before the read, so an
+            # out-of-coverage request fails fast rather than triggering a full
+            # remote read (windowed_bbox_crop's contract requires overlap).
+            if not bbox_overlaps(dataset, bbox):
+                raise ValueError(
+                    f"the AOI {bbox} is outside the source raster's coverage; "
+                    "nothing to read."
+                )
             # A point / cell-edge AOI is widened to one source pixel so crop(bbox=)
             # yields a 1x1 window instead of raising on the zero-width box; an
             # all-no-data AOI keeps an all-no-data window rather than raising.

--- a/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
@@ -6,8 +6,11 @@ range-accessible Cloud-Optimized GeoTIFFs on figshare, read **windowed** over
 Atlas layers are DEFLATE-compressed ZIP archives with no random access, so they
 are downloaded once into a cache and read **windowed from the local ZIP member**
 (`download_cache_crop`). Both paths funnel through `read_part_to_geotiff`, which
-uses `pyramids.dataset.Dataset.read_part` — the cloud-native partial read — and
-never `Dataset.crop` (which materialises the whole global raster).
+delegates to `pyramids.dataset.Dataset.crop(bbox=)` — its windowed fast path
+reads only the AOI's pixel window straight from the source (over `/vsicurl/` a
+few hundred KB rather than the whole multi-GB raster) and never materialises the
+whole global grid. `pyramids` applies the `/vsicurl` HTTP tuning (readdir/retry/
+timeout, extensionless-URL handling) itself, so no GDAL env is set here.
 
 All raster I/O goes through `pyramids`; the stdlib `zipfile` is used only to
 name the GeoTIFF member inside a downloaded ZIP, never to read pixels.
@@ -15,8 +18,6 @@ name the GeoTIFF member inside a downloaded ZIP, never to read pixels.
 
 from __future__ import annotations
 
-import math
-import os
 import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -24,37 +25,14 @@ from urllib.parse import urlsplit
 
 import requests  # noqa: F401  # runtime seam so tests can monkeypatch this module's `requests`
 
+from earthlens.base import close_quietly
 from earthlens.base.http import HttpClient
 
 if TYPE_CHECKING:
     from earthlens.base import SpatialExtent
 
-#: GDAL `/vsicurl` HTTP settings applied (via `setdefault`) before the first
-#: remote read. `GDAL_DISABLE_READDIR_ON_OPEN` stops GDAL listing the "directory"
-#: of a remote object; the retry knobs ride out the figshare presigned-URL
-#: refresh. `CPL_VSIL_CURL_ALLOWED_EXTENSIONS` is deliberately **not** set — it
-#: whitelists extensions, and the figshare download URL is extension-less, so
-#: setting it would make GDAL reject the URL (pinned in the A1b gate).
-_GDAL_HTTP_ENV: dict[str, str] = {
-    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
-    "GDAL_HTTP_TIMEOUT": "30",
-    "GDAL_HTTP_MAX_RETRY": "3",
-    "GDAL_HTTP_RETRY_DELAY": "2",
-}
-
 #: Stream chunk size (bytes) for the Global Solar Atlas ZIP download.
 _DOWNLOAD_CHUNK = 1 << 20
-
-
-def configure_gdal_http() -> None:
-    """Apply the `/vsicurl` HTTP environment defaults (idempotent).
-
-    Sets each key in `_GDAL_HTTP_ENV` only when absent, so a caller that has
-    already tuned GDAL is left untouched. Called once at the top of every
-    windowed read.
-    """
-    for key, value in _GDAL_HTTP_ENV.items():
-        os.environ.setdefault(key, value)
 
 
 def vsicurl(url: str) -> str:
@@ -91,37 +69,18 @@ def bbox_from_extent(space: SpatialExtent) -> list[float]:
     return [space.west, space.south, space.east, space.north]
 
 
-def _source_no_data(dataset: object) -> object:
-    """Return the source raster's first-band no-data value, or `-9999` default.
-
-    `pyramids` exposes `no_data_value` as a per-band tuple (e.g. `(-9999.0,)` or
-    `(None,)`). The windowed crop carries the source value through to the written
-    GeoTIFF so genuinely-empty cells stay flagged; a missing value falls back to
-    the pyramids default.
-
-    Args:
-        dataset: An opened `pyramids.Dataset`.
-
-    Returns:
-        The first-band no-data value when the source declares one, else `-9999`.
-    """
-    nodata = getattr(dataset, "no_data_value", None)
-    if isinstance(nodata, (list, tuple)) and nodata and nodata[0] is not None:
-        return nodata[0]
-    return -9999
-
-
 def read_part_to_geotiff(
     path: str, bbox: list[float], out_path: Path, *, epsg: int = 4326
 ) -> Path:
     """Read just the `bbox` window from a raster and write it as a GeoTIFF.
 
-    The windowed primitive is `pyramids.dataset.Dataset.read_part`, which fetches
-    only the AOI's byte ranges (for a COG over `/vsicurl/`, a few hundred KB
-    rather than the whole multi-GB file). `Dataset.crop` is **not** used: it
-    reads the entire band into memory, which for a global 250 m COG is tens of
-    GiB. The returned pixels are wrapped back into a georeferenced GeoTIFF using
-    the source grid snapped to the bbox.
+    Delegates the windowed read to `pyramids.dataset.Dataset.crop(bbox=)`, whose
+    fast path resolves the bbox to a pixel window and reads **only** that window
+    straight from the source: for a COG over `/vsicurl/` a few hundred KB rather
+    than the whole multi-GB file, and for a `/vsizip/` member only that member's
+    window. The source grid, CRS and no-data value are carried onto the crop, so
+    genuinely-empty cells stay flagged. `pyramids` applies the `/vsicurl` HTTP
+    tuning (readdir/retry/timeout, extensionless-URL handling) itself.
 
     Args:
         path: A `/vsicurl/<url>` (remote COG) or `/vsizip/<zip>/<member.tif>`
@@ -135,47 +94,18 @@ def read_part_to_geotiff(
     """
     from pyramids.dataset import Dataset
 
-    configure_gdal_http()
     west, south, east, north = bbox
     dataset = Dataset.read_file(path)
     try:
-        origin_x, pixel_w, _, origin_y, _, pixel_h = dataset.geotransform
-        col0 = math.floor((west - origin_x) / pixel_w)
-        col1 = math.ceil((east - origin_x) / pixel_w)
-        row0 = math.floor((north - origin_y) / pixel_h)
-        row1 = math.ceil((south - origin_y) / pixel_h)
-        # A point / sub-pixel bbox (e.g. lat_min == lat_max landing on a cell
-        # edge) snaps to a zero-width window; read at least one pixel so the
-        # request still yields a 1x1 cell instead of failing.
-        ncols = max(1, col1 - col0)
-        nrows = max(1, row1 - row0)
-        array = dataset.read_part(
-            (west, south, east, north),
-            dst_width=ncols,
-            dst_height=nrows,
-            bbox_crs=epsg,
-        )
-        if getattr(array, "ndim", 2) == 3 and array.shape[0] == 1:
-            array = array[0]
-        geo = (
-            origin_x + col0 * pixel_w,
-            pixel_w,
-            0.0,
-            origin_y + row0 * pixel_h,
-            0.0,
-            pixel_h,
-        )
-        window = Dataset.create_from_array(
-            arr=array,
-            geo=geo,
-            epsg=dataset.epsg,
-            no_data_value=_source_no_data(dataset),
-        )
-        window.to_file(str(out_path))
+        window = dataset.crop(bbox=[west, south, east, north], epsg=epsg)
     finally:
         # Drop the /vsicurl handle — an open remote dataset can hang the
         # interpreter at exit on GDAL's curl-handle cleanup (A1b).
-        dataset = None
+        close_quietly(dataset)
+    try:
+        window.to_file(str(out_path))
+    finally:
+        close_quietly(window)
     return out_path
 
 

--- a/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
@@ -6,11 +6,12 @@ range-accessible Cloud-Optimized GeoTIFFs on figshare, read **windowed** over
 Atlas layers are DEFLATE-compressed ZIP archives with no random access, so they
 are downloaded once into a cache and read **windowed from the local ZIP member**
 (`download_cache_crop`). Both paths funnel through `read_part_to_geotiff`, which
-delegates to `pyramids.dataset.Dataset.crop(bbox=)` — its windowed fast path
-reads only the AOI's pixel window straight from the source (over `/vsicurl/` a
-few hundred KB rather than the whole multi-GB raster) and never materialises the
-whole global grid. `pyramids` applies the `/vsicurl` HTTP tuning (readdir/retry/
-timeout, extensionless-URL handling) itself, so no GDAL env is set here.
+delegates to `pyramids.dataset.Dataset.crop(bbox=)`. For an axis-aligned box in
+the source CRS its windowed fast path reads only the AOI's pixel window straight
+from the source (over `/vsicurl/` a few hundred KB rather than the whole multi-GB
+raster); an ineligible box (reprojecting or a rotated grid) falls back to a
+cutline warp instead. `pyramids` applies the `/vsicurl` HTTP tuning (readdir/
+retry/timeout, extensionless-URL handling) itself, so no GDAL env is set here.
 
 All raster I/O goes through `pyramids`; the stdlib `zipfile` is used only to
 name the GeoTIFF member inside a downloaded ZIP, never to read pixels.
@@ -77,11 +78,15 @@ def read_part_to_geotiff(
 ) -> Path:
     """Read just the `bbox` window from a raster and write it as a GeoTIFF.
 
-    Delegates the windowed read to `pyramids.dataset.Dataset.crop(bbox=)`, whose
-    fast path resolves the bbox to a pixel window and reads **only** that window
-    straight from the source: for a COG over `/vsicurl/` a few hundred KB rather
-    than the whole multi-GB file, and for a `/vsizip/` member only that member's
-    window. The source grid, CRS and no-data value are carried onto the crop, so
+    Delegates the windowed read to `pyramids.dataset.Dataset.crop(bbox=)`. For an
+    axis-aligned box in the source CRS (the case here — EPSG:4326 AOI against a
+    4326 source) its fast path resolves the bbox to a pixel window and reads
+    **only** that window straight from the source: for a COG over `/vsicurl/` a
+    few hundred KB rather than the whole multi-GB file, and for a `/vsizip/`
+    member only that member's window. A point / cell-edge AOI is first widened to
+    one pixel (`widen_degenerate_bbox`) so the strict `west < east` fast path
+    still fires. The source grid, CRS and no-data value are carried onto the crop
+    (with a `-9999` fallback stamped when the source declares none), so
     genuinely-empty cells stay flagged. `pyramids` applies the `/vsicurl` HTTP
     tuning (readdir/retry/timeout, extensionless-URL handling) itself.
 

--- a/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
@@ -25,8 +25,11 @@ from urllib.parse import urlsplit
 
 import requests  # noqa: F401  # runtime seam so tests can monkeypatch this module's `requests`
 
-from earthlens.base import close_quietly, widen_degenerate_bbox
+from earthlens.base import close_quietly, ensure_no_data, widen_degenerate_bbox
 from earthlens.base.http import HttpClient
+
+#: No-data value stamped on a windowed crop when the source declares none.
+_DEFAULT_NO_DATA = -9999.0
 
 if TYPE_CHECKING:
     from earthlens.base import SpatialExtent
@@ -106,6 +109,9 @@ def read_part_to_geotiff(
         # Drop the /vsicurl handle — an open remote dataset can hang the
         # interpreter at exit on GDAL's curl-handle cleanup (A1b).
         close_quietly(dataset)
+    # crop carries the source's own no-data through; fall back to the default so
+    # genuinely-empty cells stay flagged when the source declares none.
+    window = ensure_no_data(window, _DEFAULT_NO_DATA)
     try:
         window.to_file(str(out_path))
     finally:

--- a/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
@@ -10,8 +10,9 @@ delegates to `pyramids.dataset.Dataset.crop(bbox=)`. For an axis-aligned box in
 the source CRS its windowed fast path reads only the AOI's pixel window straight
 from the source (over `/vsicurl/` a few hundred KB rather than the whole multi-GB
 raster); an ineligible box (reprojecting or a rotated grid) falls back to a
-cutline warp instead. `pyramids` applies the `/vsicurl` HTTP tuning (readdir/
-retry/timeout, extensionless-URL handling) itself, so no GDAL env is set here.
+cutline warp instead. The read is wrapped in `vsicurl_config()` for the
+`/vsicurl` readdir-suppression + retry/timeout tuning (pyramids handles opening
+the extensionless figshare URL itself).
 
 All raster I/O goes through `pyramids`; the stdlib `zipfile` is used only to
 name the GeoTIFF member inside a downloaded ZIP, never to read pixels.
@@ -26,7 +27,12 @@ from urllib.parse import urlsplit
 
 import requests  # noqa: F401  # runtime seam so tests can monkeypatch this module's `requests`
 
-from earthlens.base import close_quietly, ensure_no_data, widen_degenerate_bbox
+from earthlens.base import (
+    close_quietly,
+    ensure_no_data,
+    vsicurl_config,
+    widen_degenerate_bbox,
+)
 from earthlens.base.http import HttpClient
 
 #: No-data value stamped on a windowed crop when the source declares none.
@@ -87,8 +93,8 @@ def read_part_to_geotiff(
     one pixel (`widen_degenerate_bbox`) so the strict `west < east` fast path
     still fires. The source grid, CRS and no-data value are carried onto the crop
     (with a `-9999` fallback stamped when the source declares none), so
-    genuinely-empty cells stay flagged. `pyramids` applies the `/vsicurl` HTTP
-    tuning (readdir/retry/timeout, extensionless-URL handling) itself.
+    genuinely-empty cells stay flagged. The read is wrapped in `vsicurl_config()`
+    for the `/vsicurl` readdir-suppression + retry/timeout tuning.
 
     Args:
         path: A `/vsicurl/<url>` (remote COG) or `/vsizip/<zip>/<member.tif>`
@@ -102,18 +108,22 @@ def read_part_to_geotiff(
     """
     from pyramids.dataset import Dataset
 
-    dataset = Dataset.read_file(path)
-    try:
-        # A point / cell-edge AOI is widened to one source pixel so crop(bbox=)
-        # yields a 1x1 window instead of raising on the zero-width box.
-        geo = dataset.geotransform
-        window = dataset.crop(
-            bbox=widen_degenerate_bbox(bbox, geo[1], geo[5]), epsg=epsg
-        )
-    finally:
-        # Drop the /vsicurl handle — an open remote dataset can hang the
-        # interpreter at exit on GDAL's curl-handle cleanup (A1b).
-        close_quietly(dataset)
+    # Tune the /vsicurl read (readdir-suppression + retry/timeout) for the
+    # duration of the open + windowed crop; a plain read_file installs none. It
+    # is harmless for a local `/vsizip/` member (the Global Solar Atlas path).
+    with vsicurl_config():
+        dataset = Dataset.read_file(path)
+        try:
+            # A point / cell-edge AOI is widened to one source pixel so crop(bbox=)
+            # yields a 1x1 window instead of raising on the zero-width box.
+            geo = dataset.geotransform
+            window = dataset.crop(
+                bbox=widen_degenerate_bbox(bbox, geo[1], geo[5]), epsg=epsg
+            )
+        finally:
+            # Drop the /vsicurl handle — an open remote dataset can hang the
+            # interpreter at exit on GDAL's curl-handle cleanup (A1b).
+            close_quietly(dataset)
     # crop carries the source's own no-data through; fall back to the default so
     # genuinely-empty cells stay flagged when the source declares none.
     window = ensure_no_data(window, _DEFAULT_NO_DATA)

--- a/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/solar_wind_atlas/_helpers.py
@@ -25,7 +25,7 @@ from urllib.parse import urlsplit
 
 import requests  # noqa: F401  # runtime seam so tests can monkeypatch this module's `requests`
 
-from earthlens.base import close_quietly
+from earthlens.base import close_quietly, widen_degenerate_bbox
 from earthlens.base.http import HttpClient
 
 if TYPE_CHECKING:
@@ -94,10 +94,14 @@ def read_part_to_geotiff(
     """
     from pyramids.dataset import Dataset
 
-    west, south, east, north = bbox
     dataset = Dataset.read_file(path)
     try:
-        window = dataset.crop(bbox=[west, south, east, north], epsg=epsg)
+        # A point / cell-edge AOI is widened to one source pixel so crop(bbox=)
+        # yields a 1x1 window instead of raising on the zero-width box.
+        geo = dataset.geotransform
+        window = dataset.crop(
+            bbox=widen_degenerate_bbox(bbox, geo[1], geo[5]), epsg=epsg
+        )
     finally:
         # Drop the /vsicurl handle — an open remote dataset can hang the
         # interpreter at exit on GDAL's curl-handle cleanup (A1b).

--- a/libs/providers/atmosphere/tests/solar_wind_atlas/conftest.py
+++ b/libs/providers/atmosphere/tests/solar_wind_atlas/conftest.py
@@ -9,7 +9,6 @@ import zipfile
 from collections.abc import Iterator
 from pathlib import Path
 
-import numpy as np
 import pytest
 
 from earthlens.solar_wind_atlas import _helpers
@@ -24,7 +23,7 @@ def zip_bytes(member: str = "World_GHI.tif") -> bytes:
 
 
 class FakeWindow:
-    """Stand-in for a created pyramids `Dataset`, recording the written path."""
+    """Stand-in for a cropped pyramids `Dataset`, recording the written path."""
 
     def __init__(self, recorder: dict) -> None:
         self._recorder = recorder
@@ -36,7 +35,13 @@ class FakeWindow:
 
 
 class FakeDataset:
-    """Stand-in for `pyramids.dataset.Dataset` capturing read_part / create."""
+    """Stand-in for `pyramids.dataset.Dataset` capturing the windowed crop.
+
+    The real windowed read + geo/no-data carry-through now lives in
+    `Dataset.crop(bbox=)` (pyramids), so the fake only records the crop request
+    and the write — the window math and no-data preservation are pyramids' own
+    tested concern, not the helper's.
+    """
 
     recorder: dict = {}
     #: A plausible global geotransform (origin, 0.0025 deg pixel, negative dy).
@@ -44,9 +49,6 @@ class FakeDataset:
     epsg = 4326
     #: Per-band no-data tuple, mirroring pyramids' `Dataset.no_data_value`.
     no_data_value = (-32768.0,)
-    #: When True, `read_part` returns a single-band `(1, H, W)` array so the
-    #: helper's squeeze branch is exercised.
-    emit_3d = False
 
     @classmethod
     def read_file(cls, path: str) -> FakeDataset:
@@ -54,48 +56,23 @@ class FakeDataset:
         cls.recorder.setdefault("opened", []).append(path)
         return cls()
 
-    def read_part(
+    def crop(
         self,
-        bbox: tuple[float, float, float, float],
+        mask: object = None,
+        touch: bool = True,
         *,
-        dst_width: int,
-        dst_height: int,
-        bbox_crs: int = 4326,
-    ) -> np.ndarray:
-        """Record the window request and return a zero array of that size."""
-        type(self).recorder.setdefault("read_part", []).append(
-            {
-                "bbox": bbox,
-                "dst_width": dst_width,
-                "dst_height": dst_height,
-                "bbox_crs": bbox_crs,
-            }
-        )
-        if type(self).emit_3d:
-            return np.zeros((1, dst_height, dst_width), dtype="float32")
-        return np.zeros((dst_height, dst_width), dtype="float32")
-
-    @classmethod
-    def create_from_array(
-        cls, *, arr: np.ndarray, geo: tuple, epsg: int, no_data_value: object = -9999
+        bbox: list[float] | tuple[float, float, float, float] | None = None,
+        epsg: object = None,
     ) -> FakeWindow:
-        """Record the geo-wrap (incl. no-data) and return a writable fake window."""
-        cls.recorder.setdefault("create", []).append(
-            {
-                "shape": arr.shape,
-                "geo": geo,
-                "epsg": epsg,
-                "no_data_value": no_data_value,
-            }
-        )
-        return FakeWindow(cls.recorder)
+        """Record the windowed bbox crop and return a writable fake window."""
+        type(self).recorder.setdefault("crop", []).append({"bbox": bbox, "epsg": epsg})
+        return FakeWindow(type(self).recorder)
 
 
 @pytest.fixture
 def fake_pyramids(monkeypatch: pytest.MonkeyPatch) -> type[FakeDataset]:
     """Inject a fake `pyramids.dataset` module so no real GDAL is touched."""
     FakeDataset.recorder = {}
-    FakeDataset.emit_3d = False
     module = types.ModuleType("pyramids.dataset")
     module.Dataset = FakeDataset
     monkeypatch.setitem(sys.modules, "pyramids.dataset", module)

--- a/libs/providers/atmosphere/tests/solar_wind_atlas/conftest.py
+++ b/libs/providers/atmosphere/tests/solar_wind_atlas/conftest.py
@@ -44,8 +44,11 @@ class FakeDataset:
     """
 
     recorder: dict = {}
-    #: A plausible global geotransform (origin, 0.0025 deg pixel, negative dy).
+    #: A plausible global geotransform (origin, 0.0025 deg pixel, negative dy)
+    #: with matching dimensions, so `bbox_overlaps` sees a global extent.
     geotransform = (-180.0, 0.0025, 0.0, 80.0, 0.0, -0.0025)
+    columns = 144000
+    rows = 64000
     epsg = 4326
     #: Per-band no-data tuple, mirroring pyramids' `Dataset.no_data_value`.
     no_data_value = (-32768.0,)

--- a/libs/providers/atmosphere/tests/solar_wind_atlas/test_backend.py
+++ b/libs/providers/atmosphere/tests/solar_wind_atlas/test_backend.py
@@ -34,7 +34,7 @@ def test_wind_variable_reads_windowed_vsicurl(
     opened = fake_pyramids.recorder["opened"]
     assert len(opened) == 1
     assert opened[0] == "/vsicurl/https://ndownloader.figshare.com/files/17247017"
-    assert fake_pyramids.recorder["read_part"][0]["dst_width"] == 200
+    assert "crop" in fake_pyramids.recorder
 
 
 def test_solar_variable_downloads_then_crops(

--- a/libs/providers/atmosphere/tests/solar_wind_atlas/test_backend.py
+++ b/libs/providers/atmosphere/tests/solar_wind_atlas/test_backend.py
@@ -34,7 +34,9 @@ def test_wind_variable_reads_windowed_vsicurl(
     opened = fake_pyramids.recorder["opened"]
     assert len(opened) == 1
     assert opened[0] == "/vsicurl/https://ndownloader.figshare.com/files/17247017"
-    assert "crop" in fake_pyramids.recorder
+    crop = fake_pyramids.recorder["crop"][0]
+    assert crop["bbox"] == [12.0, 55.0, 12.5, 55.5], crop["bbox"]
+    assert crop["epsg"] == 4326, crop["epsg"]
 
 
 def test_solar_variable_downloads_then_crops(

--- a/libs/providers/atmosphere/tests/solar_wind_atlas/test_helpers.py
+++ b/libs/providers/atmosphere/tests/solar_wind_atlas/test_helpers.py
@@ -45,14 +45,20 @@ def test_window_crop_opens_vsicurl_and_crops(
     assert fake_pyramids.recorder["written"] == str(out)
 
 
-def test_window_crop_degenerate_bbox_still_crops(
+def test_window_crop_degenerate_bbox_widened_before_crop(
     fake_pyramids: type[FakeDataset], tmp_path: Path
 ) -> None:
-    """A zero-extent point bbox is forwarded to crop (pyramids clamps the window)."""
+    """A zero-extent point bbox is widened to one source pixel before crop.
+
+    crop(bbox=) requires a strictly positive box, so a point AOI must be
+    widened first; assert the collapsed edges are pushed out.
+    """
     _helpers.window_crop(
         "https://x/w.tif", [12.0, 55.0, 12.0, 55.0], tmp_path / "p.tif"
     )
-    assert fake_pyramids.recorder["crop"][0]["bbox"] == [12.0, 55.0, 12.0, 55.0]
+    bbox = fake_pyramids.recorder["crop"][0]["bbox"]
+    assert bbox[2] > bbox[0], f"west edge not widened: {bbox}"
+    assert bbox[3] > bbox[1], f"south edge not widened: {bbox}"
     assert fake_pyramids.recorder["written"] == str(tmp_path / "p.tif")
 
 

--- a/libs/providers/atmosphere/tests/solar_wind_atlas/test_helpers.py
+++ b/libs/providers/atmosphere/tests/solar_wind_atlas/test_helpers.py
@@ -111,9 +111,18 @@ def test_download_zip_streams_once_then_caches(
     assert fake_get.calls == 1
 
 
-def _write_geotiff(path: Path, *, no_data_value: float | None) -> None:
-    """Write a 20x20 0.1-deg EPSG:4326 GeoTIFF for real windowed-crop tests."""
-    arr = np.arange(400, dtype="float32").reshape(20, 20)
+def _write_geotiff(
+    path: Path, *, no_data_value: float | None, fill: float | None = None
+) -> None:
+    """Write a 20x20 0.1-deg EPSG:4326 GeoTIFF for real windowed-crop tests.
+
+    `fill` writes a constant raster (use the no-data value for an all-no-data
+    source); otherwise a ramp of distinct values.
+    """
+    if fill is None:
+        arr = np.arange(400, dtype="float32").reshape(20, 20)
+    else:
+        arr = np.full((20, 20), fill, dtype="float32")
     Dataset.create_from_array(
         arr,
         top_left_corner=(0.0, 0.0),
@@ -150,6 +159,15 @@ class TestReadPartToGeotiffReal:
         assert 1 <= result.columns <= 2, (
             f"columns should clamp small, got {result.columns}"
         )
+
+    def test_all_nodata_aoi_writes_crop_not_raise(self, tmp_path: Path) -> None:
+        """An all-no-data AOI writes an all-no-data crop instead of raising."""
+        src = tmp_path / "src.tif"
+        _write_geotiff(src, no_data_value=-9999.0, fill=-9999.0)
+        out = tmp_path / "empty.tif"
+        _helpers.read_part_to_geotiff(str(src), [0.2, -0.6, 0.6, -0.2], out)
+        result = Dataset.read_file(str(out))
+        assert bool((result.read_array() == -9999.0).all()), "written all-no-data"
 
 
 def test_download_cache_crop_downloads_then_windows(

--- a/libs/providers/atmosphere/tests/solar_wind_atlas/test_helpers.py
+++ b/libs/providers/atmosphere/tests/solar_wind_atlas/test_helpers.py
@@ -6,7 +6,9 @@ import io
 import zipfile
 from pathlib import Path
 
+import numpy as np
 import pytest
+from pyramids.dataset import Dataset
 
 from earthlens.base import SpatialExtent
 from earthlens.solar_wind_atlas import _helpers
@@ -107,6 +109,44 @@ def test_download_zip_streams_once_then_caches(
     second = _helpers.download_zip(url, tmp_path)
     assert first == second == tmp_path / "World_GHI.zip"
     assert fake_get.calls == 1
+
+
+def _write_geotiff(path: Path, *, no_data_value: float | None) -> None:
+    """Write a 20x20 0.1-deg EPSG:4326 GeoTIFF for real windowed-crop tests."""
+    arr = np.arange(400, dtype="float32").reshape(20, 20)
+    Dataset.create_from_array(
+        arr,
+        top_left_corner=(0.0, 0.0),
+        cell_size=0.1,
+        epsg=4326,
+        no_data_value=no_data_value,
+    ).to_file(str(path))
+
+
+class TestReadPartToGeotiffReal:
+    """`read_part_to_geotiff` against a real (local) pyramids raster."""
+
+    def test_windowed_crop_carries_source_no_data(self, tmp_path: Path) -> None:
+        """A normal window writes a subset carrying the source's own no-data."""
+        src = tmp_path / "src.tif"
+        _write_geotiff(src, no_data_value=-32768.0)
+        out = tmp_path / "out.tif"
+        _helpers.read_part_to_geotiff(str(src), [0.2, -0.6, 0.6, -0.2], out)
+        result = Dataset.read_file(str(out))
+        assert result.rows > 0 and result.columns > 0, "a non-empty window is written"
+        assert result.rows < 20 and result.columns < 20, "only the AOI window read"
+        assert result.no_data_value[0] == -32768.0, "source no-data carried through"
+
+    def test_degenerate_point_yields_small_crop_not_raise(self, tmp_path: Path) -> None:
+        """A point AOI produces a small crop instead of raising (review H1)."""
+        src = tmp_path / "src.tif"
+        _write_geotiff(src, no_data_value=-9999.0)
+        out = tmp_path / "point.tif"
+        _helpers.read_part_to_geotiff(str(src), [0.35, -0.35, 0.35, -0.35], out)
+        result = Dataset.read_file(str(out))
+        assert 1 <= result.rows <= 2 and 1 <= result.columns <= 2, (
+            f"degenerate AOI should clamp small, got {result.rows}x{result.columns}"
+        )
 
 
 def test_download_cache_crop_downloads_then_windows(

--- a/libs/providers/atmosphere/tests/solar_wind_atlas/test_helpers.py
+++ b/libs/providers/atmosphere/tests/solar_wind_atlas/test_helpers.py
@@ -27,10 +27,10 @@ def test_bbox_from_extent_returns_wsen() -> None:
     assert _helpers.bbox_from_extent(space) == [12.0, 55.0, 12.5, 55.5]
 
 
-def test_window_crop_opens_vsicurl_and_reads_part(
+def test_window_crop_opens_vsicurl_and_crops(
     fake_pyramids: type[FakeDataset], tmp_path: Path
 ) -> None:
-    """window_crop opens the /vsicurl path and extracts via read_part, not crop."""
+    """window_crop opens the /vsicurl path and windowed-crops it to the bbox."""
     out = tmp_path / "wind_100m.tif"
     result = _helpers.window_crop(
         "https://ndownloader.figshare.com/files/17247017",
@@ -39,54 +39,21 @@ def test_window_crop_opens_vsicurl_and_reads_part(
     )
     assert result == out
     assert fake_pyramids.recorder["opened"][0].startswith("/vsicurl/https://")
-    assert fake_pyramids.recorder["read_part"][0]["bbox"] == (12.0, 55.0, 12.5, 55.5)
+    crop = fake_pyramids.recorder["crop"][0]
+    assert crop["bbox"] == [12.0, 55.0, 12.5, 55.5]
+    assert crop["epsg"] == 4326
     assert fake_pyramids.recorder["written"] == str(out)
-    assert "create" in fake_pyramids.recorder
 
 
-def test_window_crop_window_size_matches_native_grid(
+def test_window_crop_degenerate_bbox_still_crops(
     fake_pyramids: type[FakeDataset], tmp_path: Path
 ) -> None:
-    """A 0.5 deg bbox at the 0.0025 deg native grid reads a ~200x200 window."""
-    _helpers.window_crop(
-        "https://x/w.tif", [12.0, 55.0, 12.5, 55.5], tmp_path / "w.tif"
-    )
-    part = fake_pyramids.recorder["read_part"][0]
-    assert part["dst_width"] == 200
-    assert part["dst_height"] == 200
-
-
-def test_window_crop_clamps_degenerate_bbox_to_one_pixel(
-    fake_pyramids: type[FakeDataset], tmp_path: Path
-) -> None:
-    """A zero-extent point bbox still reads a 1x1 window instead of failing."""
+    """A zero-extent point bbox is forwarded to crop (pyramids clamps the window)."""
     _helpers.window_crop(
         "https://x/w.tif", [12.0, 55.0, 12.0, 55.0], tmp_path / "p.tif"
     )
-    part = fake_pyramids.recorder["read_part"][0]
-    assert part["dst_width"] == 1
-    assert part["dst_height"] == 1
-
-
-def test_window_crop_squeezes_single_band_3d(
-    fake_pyramids: type[FakeDataset], tmp_path: Path
-) -> None:
-    """A (1, H, W) read_part result is squeezed to (H, W) before writing."""
-    fake_pyramids.emit_3d = True
-    _helpers.window_crop(
-        "https://x/w.tif", [12.0, 55.0, 12.5, 55.5], tmp_path / "w.tif"
-    )
-    assert fake_pyramids.recorder["create"][0]["shape"] == (200, 200)
-
-
-def test_window_crop_propagates_source_no_data(
-    fake_pyramids: type[FakeDataset], tmp_path: Path
-) -> None:
-    """The written GeoTIFF carries the source raster's no-data value, not -9999."""
-    _helpers.window_crop(
-        "https://x/w.tif", [12.0, 55.0, 12.5, 55.5], tmp_path / "w.tif"
-    )
-    assert fake_pyramids.recorder["create"][0]["no_data_value"] == -32768.0
+    assert fake_pyramids.recorder["crop"][0]["bbox"] == [12.0, 55.0, 12.0, 55.0]
+    assert fake_pyramids.recorder["written"] == str(tmp_path / "p.tif")
 
 
 def test_download_zip_cleans_partial_on_failure(

--- a/libs/providers/atmosphere/tests/solar_wind_atlas/test_helpers.py
+++ b/libs/providers/atmosphere/tests/solar_wind_atlas/test_helpers.py
@@ -133,8 +133,10 @@ class TestReadPartToGeotiffReal:
         out = tmp_path / "out.tif"
         _helpers.read_part_to_geotiff(str(src), [0.2, -0.6, 0.6, -0.2], out)
         result = Dataset.read_file(str(out))
-        assert result.rows > 0 and result.columns > 0, "a non-empty window is written"
-        assert result.rows < 20 and result.columns < 20, "only the AOI window read"
+        assert result.rows > 0, "a non-empty window is written"
+        assert result.columns > 0, "a non-empty window is written"
+        assert result.rows < 20, "only the AOI window read"
+        assert result.columns < 20, "only the AOI window read"
         assert result.no_data_value[0] == -32768.0, "source no-data carried through"
 
     def test_degenerate_point_yields_small_crop_not_raise(self, tmp_path: Path) -> None:
@@ -144,8 +146,9 @@ class TestReadPartToGeotiffReal:
         out = tmp_path / "point.tif"
         _helpers.read_part_to_geotiff(str(src), [0.35, -0.35, 0.35, -0.35], out)
         result = Dataset.read_file(str(out))
-        assert 1 <= result.rows <= 2 and 1 <= result.columns <= 2, (
-            f"degenerate AOI should clamp small, got {result.rows}x{result.columns}"
+        assert 1 <= result.rows <= 2, f"rows should clamp small, got {result.rows}"
+        assert 1 <= result.columns <= 2, (
+            f"columns should clamp small, got {result.columns}"
         )
 
 

--- a/libs/providers/hazards/src/earthlens/jrc_flood/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/jrc_flood/_helpers.py
@@ -1,33 +1,18 @@
-"""URL builder + pixel-window math for the JRC European flood-hazard backend.
+"""URL builder for the JRC European flood-hazard backend.
 
 The JRC serves the European Flood Hazard Map (EFHM) over a deterministic,
 anonymous HTTPS directory (verified live 2026-08-09): one whole-Europe GeoTIFF
 per return period at `{BASE_URL}/Europe_RP{rp}_filled_depth.tif`. Each file is a
-single-band EPSG:4326 Float32 grid at ~0.000833° (~90 m; documented 100 m),
-covering Europe and the Mediterranean Basin — 110162×51992 px (~23 GB
-uncompressed), so it is **never** read whole. Instead the backend opens it
-lazily over GDAL's `/vsicurl` (HTTP range requests) and reads only the AOI's
-pixel window; `pixel_window` turns a geographic bbox into that window.
+single-band EPSG:4326 Float32 grid at ~0.000833 deg (~90 m; documented 100 m),
+covering Europe and the Mediterranean Basin — 110162x51992 px (~23 GB
+uncompressed), so it is **never** read whole. The backend opens it lazily over
+`pyramids.dataset.Dataset.crop(bbox=)`, whose windowed fast path reads only the
+AOI's pixel window over GDAL's `/vsicurl` (HTTP range requests). This module only
+builds the per-return-period URL; the windowed read + crop live in the backend
+via pyramids (which applies the `/vsicurl` HTTP tuning itself).
 """
 
 from __future__ import annotations
-
-import math
-import os
-
-#: GDAL `/vsicurl` HTTP defaults applied (via `setdefault`) before a remote read.
-#: `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR` stops the per-open sidecar probes
-#: (`.aux.xml` / `.ovr`) against the JRC host; the retry/timeout knobs bound each
-#: range request. `CPL_VSIL_CURL_ALLOWED_EXTENSIONS` is deliberately **not** set:
-#: it is a process-global whitelist, so pinning it to `.tif` here would break
-#: another backend's extension-less `/vsicurl` reads in the same process (e.g.
-#: solar_wind_atlas' figshare URLs) — the exact reason that backend omits it too.
-_GDAL_HTTP_ENV: dict[str, str] = {
-    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
-    "GDAL_HTTP_TIMEOUT": "30",
-    "GDAL_HTTP_MAX_RETRY": "3",
-    "GDAL_HTTP_RETRY_DELAY": "2",
-}
 
 #: Root of the JRC CEMS-EFAS flood-hazard directory (anonymous HTTPS, no auth).
 BASE_URL: str = (
@@ -36,38 +21,6 @@ BASE_URL: str = (
 
 #: `strftime`-free file-name template; `{rp}` is the integer return period.
 FILENAME_TEMPLATE: str = "Europe_RP{rp}_filled_depth.tif"
-
-
-def configure_gdal_http() -> None:
-    """Apply the `/vsicurl` HTTP environment defaults (idempotent).
-
-    Sets each key in `_GDAL_HTTP_ENV` only when absent, so a caller that has
-    already tuned GDAL is left untouched. Called once before every windowed read
-    to avoid per-open sidecar-probe requests against the JRC host.
-    """
-    for key, value in _GDAL_HTTP_ENV.items():
-        os.environ.setdefault(key, value)
-
-
-def source_no_data(dataset: object, *, default: float = -9999.0) -> float:
-    """Return an opened raster's first-band no-data value, or `default`.
-
-    `pyramids` exposes `no_data_value` as a per-band tuple (e.g. `(-9999.0,)` or
-    `(None,)`); the windowed crop carries the source value through so genuinely
-    empty cells stay flagged, falling back to `default` when the source declares
-    none.
-
-    Args:
-        dataset: An opened `pyramids.Dataset`.
-        default: The value to use when the source declares no no-data.
-
-    Returns:
-        float: The first-band no-data value, or `default`.
-    """
-    nodata = getattr(dataset, "no_data_value", None)
-    if isinstance(nodata, (list, tuple)) and nodata and nodata[0] is not None:
-        return float(nodata[0])
-    return default
 
 
 def efhm_url(
@@ -93,90 +46,3 @@ def efhm_url(
             ```
     """
     return f"{base_url}/{template.format(rp=rp)}"
-
-
-def pixel_window(
-    geotransform: tuple[float, float, float, float, float, float],
-    bbox: tuple[float, float, float, float],
-    columns: int,
-    rows: int,
-) -> tuple[int, int, int, int] | None:
-    """Convert a geographic bbox to a clamped `(col_off, row_off, cols, rows)` window.
-
-    Uses the affine `geotransform` (`ox, px, 0, oy, 0, py`; `py` is negative for
-    a north-up raster) to map the bbox corners to pixel indices, then clamps the
-    window to the raster's `columns` × `rows` extent. Returns `None` when the
-    bbox does not overlap the raster (an AOI outside the EFHM's Europe /
-    Mediterranean coverage).
-
-    Args:
-        geotransform: The GDAL affine transform `(ox, px, 0, oy, 0, py)`.
-        bbox: `(west, south, east, north)` in the raster's CRS (EPSG:4326).
-        columns: Raster width in pixels.
-        rows: Raster height in pixels.
-
-    Returns:
-        tuple[int, int, int, int] | None: The `(col_off, row_off, cols, rows)`
-            window, or `None` when the bbox is entirely outside the raster.
-
-    Examples:
-        - A small AOI maps to a small window:
-            ```python
-            >>> from earthlens.jrc_flood._helpers import pixel_window
-            >>> gt = (-24.54208333, 0.0008333333333333334, 0.0,
-            ...       71.13375, 0.0, -0.0008333333333333334)
-            >>> pixel_window(gt, (4.8, 51.8, 5.0, 52.0), 110162, 51992)
-            (35210, 22960, 241, 241)
-
-            ```
-        - An AOI south of the coverage returns `None`:
-            ```python
-            >>> from earthlens.jrc_flood._helpers import pixel_window
-            >>> gt = (-24.54208333, 0.0008333333333333334, 0.0,
-            ...       71.13375, 0.0, -0.0008333333333333334)
-            >>> pixel_window(gt, (4.8, -5.0, 5.0, -4.8), 110162, 51992) is None
-            True
-
-            ```
-    """
-    west, south, east, north = bbox
-    ox, px, _, oy, _, py = geotransform
-    col_start = math.floor((west - ox) / px)
-    col_stop = math.ceil((east - ox) / px)
-    # `py` is negative, so the northern edge maps to the smaller row index.
-    row_start = math.floor((north - oy) / py)
-    row_stop = math.ceil((south - oy) / py)
-    # No overlap with the raster's pixel extent at all -> genuinely outside the
-    # coverage.
-    if col_stop <= 0 or col_start >= columns or row_stop <= 0 or row_start >= rows:
-        return None
-    col_off = max(0, col_start)
-    row_off = max(0, row_start)
-    # A bbox edge that lands exactly on a pixel boundary (or a point AOI) inside
-    # the coverage collapses to a zero-width window; read at least one pixel so it
-    # yields a 1x1 cell rather than being mistaken for out-of-coverage.
-    cols = max(1, min(columns, col_stop) - col_off)
-    rows_out = max(1, min(rows, row_stop) - row_off)
-    # Keep the window inside the raster when the offset sits on the last pixel.
-    col_off = min(col_off, columns - cols)
-    row_off = min(row_off, rows - rows_out)
-    return (col_off, row_off, cols, rows_out)
-
-
-def window_origin(
-    geotransform: tuple[float, float, float, float, float, float],
-    col_off: int,
-    row_off: int,
-) -> tuple[float, float, float, float, float, float]:
-    """Return the geotransform of a window, shifted to its top-left pixel.
-
-    Args:
-        geotransform: The source affine transform `(ox, px, 0, oy, 0, py)`.
-        col_off: The window's left pixel column.
-        row_off: The window's top pixel row.
-
-    Returns:
-        tuple: The window's affine transform (same pixel sizes, shifted origin).
-    """
-    ox, px, rot1, oy, rot2, py = geotransform
-    return (ox + col_off * px, px, rot1, oy + row_off * py, rot2, py)

--- a/libs/providers/hazards/src/earthlens/jrc_flood/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/jrc_flood/_helpers.py
@@ -10,8 +10,8 @@ uncompressed), so it is **never** read whole. The backend opens it lazily over
 AOI's pixel window over GDAL's `/vsicurl` (HTTP range requests) for an
 axis-aligned box in the source CRS — the case here (an EPSG:4326 AOI against the
 4326 EFHM). This module only builds the per-return-period URL; the windowed read
-+ crop live in the backend via pyramids (which applies the `/vsicurl` HTTP tuning
-itself).
++ crop live in the backend, which wraps them in `vsicurl_config()` for the
+`/vsicurl` readdir-suppression + retry/timeout tuning.
 """
 
 from __future__ import annotations

--- a/libs/providers/hazards/src/earthlens/jrc_flood/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/jrc_flood/_helpers.py
@@ -7,9 +7,11 @@ single-band EPSG:4326 Float32 grid at ~0.000833 deg (~90 m; documented 100 m),
 covering Europe and the Mediterranean Basin — 110162x51992 px (~23 GB
 uncompressed), so it is **never** read whole. The backend opens it lazily over
 `pyramids.dataset.Dataset.crop(bbox=)`, whose windowed fast path reads only the
-AOI's pixel window over GDAL's `/vsicurl` (HTTP range requests). This module only
-builds the per-return-period URL; the windowed read + crop live in the backend
-via pyramids (which applies the `/vsicurl` HTTP tuning itself).
+AOI's pixel window over GDAL's `/vsicurl` (HTTP range requests) for an
+axis-aligned box in the source CRS — the case here (an EPSG:4326 AOI against the
+4326 EFHM). This module only builds the per-return-period URL; the windowed read
++ crop live in the backend via pyramids (which applies the `/vsicurl` HTTP tuning
+itself).
 """
 
 from __future__ import annotations

--- a/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
+++ b/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
@@ -36,7 +36,7 @@ from earthlens.base import (
     sidecar_is_fresh,
     write_sidecar,
 )
-from earthlens.base.spatial import crop_to_aoi
+from earthlens.base.spatial import crop_to_aoi, widen_degenerate_bbox
 from earthlens.jrc_flood._helpers import efhm_url
 from earthlens.jrc_flood.catalog import Catalog, Dataset
 
@@ -380,9 +380,14 @@ class JRCFlood(AbstractDataSource):
             logger.info(
                 f"JRCFlood RP{rp}: windowed /vsicurl crop of {self._bbox} from {url}"
             )
+            # A point / cell-edge AOI (min == max on an axis) is widened to one
+            # source pixel so crop(bbox=)'s fast path yields a 1x1 window rather
+            # than raising on the zero-width box.
+            geo = source.geotransform
+            bbox = widen_degenerate_bbox(self._bbox, geo[1], geo[5])
             # The windowed fast path reads only the AOI pixel window from the
             # ~23 GB source; nodata / CRS / grid are carried onto the crop.
-            windowed = source.crop(bbox=list(self._bbox), epsg=4326)
+            windowed = source.crop(bbox=bbox, epsg=4326)
         finally:
             close_quietly(source)
 

--- a/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
+++ b/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
@@ -31,6 +31,9 @@ from earthlens.base import (
     OutputKind,
     RemoteProduct,
     TemporalExtent,
+    aoi_tag,
+    sidecar_is_fresh,
+    write_sidecar,
 )
 from earthlens.base.spatial import crop_to_aoi
 from earthlens.jrc_flood._helpers import (
@@ -234,37 +237,14 @@ class JRCFlood(AbstractDataSource):
         """The AOI as `(west, south, east, north)` in degrees."""
         return (self.space.west, self.space.south, self.space.east, self.space.north)
 
-    @property
-    def _aoi_tag(self) -> str:
-        """A stable cache key for this AOI (bbox plus any polygon geometry).
-
-        The bbox alone is not enough: with `SUPPORTS_POLYGON_AOI`, two requests
-        can share a bounding box but carry different polygon masks, so the
-        polygon geometry is folded in to keep their cached crops distinct.
-        """
-        import hashlib
-
-        tag = (
-            f"{self.space.west},{self.space.south},{self.space.east},{self.space.north}"
-        )
-        geometry = getattr(self.space, "geometry", None)
-        if geometry is not None:
-            # `space.geometry` is a geopandas GeoDataFrame (from the facade's
-            # `aoi=`), so serialise it to GeoJSON; fall back to a shapely `.wkt`.
-            if hasattr(geometry, "to_json"):
-                key = geometry.to_json()
-            else:
-                key = getattr(geometry, "wkt", str(geometry))
-            tag += "|" + hashlib.sha256(key.encode("utf-8")).hexdigest()
-        return tag
-
     def _is_cached(self, target: Path) -> bool:
         """Whether `target` already holds this exact AOI (AOI-aware skip).
 
         The output filename encodes the return period but not the AOI, so a bare
         exists-check would return a previous AOI's raster for a new bbox in the
-        same `path`. A `<target>.aoi` sidecar records the bbox the file was
-        written for; the skip only fires when it matches and `force` is off.
+        same `path`. The `<target>.aoi` sidecar records the AOI the file was
+        written for (`earthlens.base.cache`); the skip only fires when it matches
+        and `force` is off.
 
         Args:
             target: The candidate output GeoTIFF path.
@@ -272,18 +252,8 @@ class JRCFlood(AbstractDataSource):
         Returns:
             bool: `True` when a matching cached output exists and may be reused.
         """
-        sidecar = target.with_suffix(target.suffix + ".aoi")
-        return (
-            not getattr(self, "_force", False)
-            and target.exists()
-            and sidecar.exists()
-            and sidecar.read_text(encoding="utf-8").strip() == self._aoi_tag
-        )
-
-    def _write_aoi_sidecar(self, target: Path) -> None:
-        """Record the AOI `target` was written for, next to it."""
-        target.with_suffix(target.suffix + ".aoi").write_text(
-            self._aoi_tag, encoding="utf-8"
+        return not getattr(self, "_force", False) and sidecar_is_fresh(
+            target, aoi_tag(self.space)
         )
 
     def download(
@@ -427,5 +397,5 @@ class JRCFlood(AbstractDataSource):
             raise
         finally:
             close_quietly(window_ds)
-        self._write_aoi_sidecar(target)
+        write_sidecar(target, aoi_tag(self.space))
         return target

--- a/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
+++ b/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
@@ -345,10 +345,12 @@ class JRCFlood(AbstractDataSource):
         Opens the whole-Europe GeoTIFF lazily and windowed-crops it to the AOI
         with `pyramids.Dataset.crop(bbox=)`, whose fast path reads **only** the
         AOI's pixel window over `/vsicurl` (HTTP range requests — pyramids tunes
-        the readdir/retry/timeout knobs itself) and carries the source grid, CRS
-        and no-data through. `crop_to_aoi` then trims the all-touched window to
-        the exact bbox — or to the exact polygon when the request carried an
-        `aoi=` polygon.
+        the readdir/retry/timeout knobs itself) for an axis-aligned box in the
+        source CRS, carrying the source grid, CRS and no-data through (with the
+        catalog no-data stamped when the source declares none). A point AOI is
+        widened to one pixel so the strict fast path still fires. `crop_to_aoi`
+        then trims the all-touched window to the exact bbox — or to the exact
+        polygon when the request carried an `aoi=` polygon.
 
         Args:
             product: The `RemoteProduct` whose `metadata` carries `rp` + `url`.

--- a/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
+++ b/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
@@ -23,6 +23,7 @@ no `LicenseWarning`. The raster read happens through `pyramids` (a windowed
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from loguru import logger
 
@@ -36,13 +37,7 @@ from earthlens.base import (
     write_sidecar,
 )
 from earthlens.base.spatial import crop_to_aoi
-from earthlens.jrc_flood._helpers import (
-    configure_gdal_http,
-    efhm_url,
-    pixel_window,
-    source_no_data,
-    window_origin,
-)
+from earthlens.jrc_flood._helpers import efhm_url
 from earthlens.jrc_flood.catalog import Catalog, Dataset
 
 
@@ -237,6 +232,33 @@ class JRCFlood(AbstractDataSource):
         """The AOI as `(west, south, east, north)` in degrees."""
         return (self.space.west, self.space.south, self.space.east, self.space.north)
 
+    def _bbox_overlaps(self, source: Any) -> bool:
+        """Whether the AOI overlaps the source raster's geographic extent.
+
+        A cheap geographic bounds test (from the source's affine transform and
+        pixel dimensions) so an AOI outside the EFHM's Europe / Mediterranean
+        coverage is reported with a clear error before the windowed crop, rather
+        than surfacing as an empty or opaque crop result.
+
+        Args:
+            source: An opened `pyramids.Dataset` exposing `geotransform`,
+                `columns`, and `rows`.
+
+        Returns:
+            bool: `True` when the AOI bbox intersects the raster's extent.
+        """
+        origin_x, pixel_w, _, origin_y, _, pixel_h = source.geotransform
+        west_bound, east_bound = origin_x, origin_x + source.columns * pixel_w
+        # `pixel_h` is negative for a north-up grid, so the south edge is lower.
+        north_bound, south_bound = origin_y, origin_y + source.rows * pixel_h
+        west, south, east, north = self._bbox
+        return not (
+            east <= west_bound
+            or west >= east_bound
+            or north <= south_bound
+            or south >= north_bound
+        )
+
     def _is_cached(self, target: Path) -> bool:
         """Whether `target` already holds this exact AOI (AOI-aware skip).
 
@@ -320,12 +342,13 @@ class JRCFlood(AbstractDataSource):
     def _fetch_one(self, product: RemoteProduct) -> Path:
         """Read the AOI window of one return-period GeoTIFF and write the crop.
 
-        Opens the whole-Europe GeoTIFF lazily over `/vsicurl` (HTTP range
-        requests, tuned via `configure_gdal_http`), maps the AOI bbox to a pixel
-        window, reads **only** that window with `pyramids`, rebuilds a small
-        `Dataset` from the window (with the shifted geotransform and the source's
-        own no-data value), applies the polygon mask when the request carried an
-        `aoi=` polygon, and writes the GeoTIFF.
+        Opens the whole-Europe GeoTIFF lazily and windowed-crops it to the AOI
+        with `pyramids.Dataset.crop(bbox=)`, whose fast path reads **only** the
+        AOI's pixel window over `/vsicurl` (HTTP range requests — pyramids tunes
+        the readdir/retry/timeout knobs itself) and carries the source grid, CRS
+        and no-data through. `crop_to_aoi` then trims the all-touched window to
+        the exact bbox — or to the exact polygon when the request carried an
+        `aoi=` polygon.
 
         Args:
             product: The `RemoteProduct` whose `metadata` carries `rp` + `url`.
@@ -347,40 +370,27 @@ class JRCFlood(AbstractDataSource):
             logger.info(f"JRCFlood: {target.name} already holds this AOI; skipping.")
             return target
 
-        configure_gdal_http()
         source = PyramidsDataset.read_file(url)
         try:
-            geo = source.geotransform
-            window = pixel_window(geo, self._bbox, source.columns, source.rows)
-            if window is None:
+            if not self._bbox_overlaps(source):
                 raise ValueError(
                     f"the AOI {self._bbox} is outside the EFHM's Europe / "
                     f"Mediterranean coverage; no RP{rp} data to write."
                 )
-            col_off, row_off, cols, rows = window
             logger.info(
-                f"JRCFlood RP{rp}: reading window {cols}x{rows} px at "
-                f"({col_off}, {row_off}) from {url}"
+                f"JRCFlood RP{rp}: windowed /vsicurl crop of {self._bbox} from {url}"
             )
-            array = source.read_array(window=[col_off, row_off, cols, rows])
-            window_geo = window_origin(geo, col_off, row_off)
-            # Carry the source's own no-data through rather than assuming the
-            # catalog value; fall back to the catalog nodata if it declares none.
-            nodata = source_no_data(source, default=self._dataset.nodata)
+            # The windowed fast path reads only the AOI pixel window from the
+            # ~23 GB source; nodata / CRS / grid are carried onto the crop.
+            windowed = source.crop(bbox=list(self._bbox), epsg=4326)
         finally:
             close_quietly(source)
 
-        window_ds = PyramidsDataset.create_from_array(
-            array,
-            geo=window_geo,
-            epsg=4326,
-            no_data_value=nodata,
-        )
-        # The floor/ceil pixel window covers the bbox with up to one extra pixel
-        # per edge; crop to the exact bbox (matching FABDEM) — or to the exact
-        # polygon when the request carried an `aoi=` polygon.
+        # crop(bbox=) keeps every pixel the box overlaps (all-touched, up to one
+        # extra pixel per edge); trim to the exact bbox (matching FABDEM) — or to
+        # the exact polygon when the request carried an `aoi=` polygon.
         cropped = crop_to_aoi(
-            window_ds,
+            windowed,
             self.space,
             bbox=[self.space.west, self.space.south, self.space.east, self.space.north],
             touch=False,
@@ -396,6 +406,6 @@ class JRCFlood(AbstractDataSource):
             staged.unlink(missing_ok=True)
             raise
         finally:
-            close_quietly(window_ds)
+            close_quietly(windowed)
         write_sidecar(target, aoi_tag(self.space))
         return target

--- a/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
+++ b/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
@@ -36,7 +36,12 @@ from earthlens.base import (
     sidecar_is_fresh,
     write_sidecar,
 )
-from earthlens.base.spatial import crop_to_aoi, ensure_no_data, widen_degenerate_bbox
+from earthlens.base.spatial import (
+    crop_to_aoi,
+    ensure_no_data,
+    vsicurl_config,
+    widen_degenerate_bbox,
+)
 from earthlens.jrc_flood._helpers import efhm_url
 from earthlens.jrc_flood.catalog import Catalog, Dataset
 
@@ -344,9 +349,10 @@ class JRCFlood(AbstractDataSource):
 
         Opens the whole-Europe GeoTIFF lazily and windowed-crops it to the AOI
         with `pyramids.Dataset.crop(bbox=)`, whose fast path reads **only** the
-        AOI's pixel window over `/vsicurl` (HTTP range requests — pyramids tunes
-        the readdir/retry/timeout knobs itself) for an axis-aligned box in the
-        source CRS, carrying the source grid, CRS and no-data through (with the
+        AOI's pixel window over `/vsicurl` (HTTP range requests, tuned via
+        `vsicurl_config()` — readdir-suppression + retry/timeout) for an
+        axis-aligned box in the source CRS, carrying the source grid, CRS and
+        no-data through (with the
         catalog no-data stamped when the source declares none). A point AOI is
         widened to one pixel so the strict fast path still fires. `crop_to_aoi`
         then trims the all-touched window to the exact bbox — or to the exact
@@ -372,26 +378,30 @@ class JRCFlood(AbstractDataSource):
             logger.info(f"JRCFlood: {target.name} already holds this AOI; skipping.")
             return target
 
-        source = PyramidsDataset.read_file(url)
-        try:
-            if not self._bbox_overlaps(source):
-                raise ValueError(
-                    f"the AOI {self._bbox} is outside the EFHM's Europe / "
-                    f"Mediterranean coverage; no RP{rp} data to write."
+        # Tune the /vsicurl read (readdir-suppression + retry/timeout) for the
+        # duration of the open + windowed crop; a plain read_file installs none.
+        with vsicurl_config():
+            source = PyramidsDataset.read_file(url)
+            try:
+                if not self._bbox_overlaps(source):
+                    raise ValueError(
+                        f"the AOI {self._bbox} is outside the EFHM's Europe / "
+                        f"Mediterranean coverage; no RP{rp} data to write."
+                    )
+                logger.info(
+                    f"JRCFlood RP{rp}: windowed /vsicurl crop of {self._bbox} "
+                    f"from {url}"
                 )
-            logger.info(
-                f"JRCFlood RP{rp}: windowed /vsicurl crop of {self._bbox} from {url}"
-            )
-            # A point / cell-edge AOI (min == max on an axis) is widened to one
-            # source pixel so crop(bbox=)'s fast path yields a 1x1 window rather
-            # than raising on the zero-width box.
-            geo = source.geotransform
-            bbox = widen_degenerate_bbox(self._bbox, geo[1], geo[5])
-            # The windowed fast path reads only the AOI pixel window from the
-            # ~23 GB source; nodata / CRS / grid are carried onto the crop.
-            windowed = source.crop(bbox=bbox, epsg=4326)
-        finally:
-            close_quietly(source)
+                # A point / cell-edge AOI (min == max on an axis) is widened to
+                # one source pixel so crop(bbox=)'s fast path yields a 1x1 window
+                # rather than raising on the zero-width box.
+                geo = source.geotransform
+                bbox = widen_degenerate_bbox(self._bbox, geo[1], geo[5])
+                # The windowed fast path reads only the AOI pixel window from the
+                # ~23 GB source; nodata / CRS / grid are carried onto the crop.
+                windowed = source.crop(bbox=bbox, epsg=4326)
+            finally:
+                close_quietly(source)
 
         # crop carries the source's own no-data through; when the source declares
         # none, fall back to the catalog value so the output stays flagged and a

--- a/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
+++ b/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
@@ -36,7 +36,7 @@ from earthlens.base import (
     sidecar_is_fresh,
     write_sidecar,
 )
-from earthlens.base.spatial import crop_to_aoi, widen_degenerate_bbox
+from earthlens.base.spatial import crop_to_aoi, ensure_no_data, widen_degenerate_bbox
 from earthlens.jrc_flood._helpers import efhm_url
 from earthlens.jrc_flood.catalog import Catalog, Dataset
 
@@ -390,6 +390,11 @@ class JRCFlood(AbstractDataSource):
             windowed = source.crop(bbox=bbox, epsg=4326)
         finally:
             close_quietly(source)
+
+        # crop carries the source's own no-data through; when the source declares
+        # none, fall back to the catalog value so the output stays flagged and a
+        # polygon `aoi=` can trim exactly (matching the pre-crop behaviour).
+        windowed = ensure_no_data(windowed, self._dataset.nodata)
 
         # crop(bbox=) keeps every pixel the box overlaps (all-touched, up to one
         # extra pixel per edge); trim to the exact bbox (matching FABDEM) — or to

--- a/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
+++ b/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
@@ -41,6 +41,7 @@ from earthlens.base.spatial import (
     ensure_no_data,
     vsicurl_config,
     widen_degenerate_bbox,
+    windowed_bbox_crop,
 )
 from earthlens.jrc_flood._helpers import efhm_url
 from earthlens.jrc_flood.catalog import Catalog, Dataset
@@ -356,7 +357,9 @@ class JRCFlood(AbstractDataSource):
         catalog no-data stamped when the source declares none). A point AOI is
         widened to one pixel so the strict fast path still fires. `crop_to_aoi`
         then trims the all-touched window to the exact bbox — or to the exact
-        polygon when the request carried an `aoi=` polygon.
+        polygon when the request carried an `aoi=` polygon. An in-coverage AOI
+        that is entirely no-data (e.g. open sea) still writes an all-no-data
+        raster rather than raising.
 
         Args:
             product: The `RemoteProduct` whose `metadata` carries `rp` + `url`.
@@ -365,7 +368,8 @@ class JRCFlood(AbstractDataSource):
             pathlib.Path: The written GeoTIFF at `<path>/efhm_RP{rp}.tif`.
 
         Raises:
-            ValueError: If the AOI does not overlap the EFHM coverage.
+            ValueError: If the AOI does not overlap the EFHM coverage (an
+                in-coverage AOI is written even when it holds no valid data).
         """
         from pyramids.dataset import Dataset as PyramidsDataset
 
@@ -398,35 +402,42 @@ class JRCFlood(AbstractDataSource):
                 geo = source.geotransform
                 bbox = widen_degenerate_bbox(self._bbox, geo[1], geo[5])
                 # The windowed fast path reads only the AOI pixel window from the
-                # ~23 GB source; nodata / CRS / grid are carried onto the crop.
-                windowed = source.crop(bbox=bbox, epsg=4326)
+                # ~23 GB source; nodata / CRS / grid are carried onto the crop. An
+                # in-coverage but all-no-data AOI keeps an all-no-data window
+                # rather than raising.
+                windowed = windowed_bbox_crop(source, bbox, epsg=4326)
             finally:
                 close_quietly(source)
 
-        # crop carries the source's own no-data through; when the source declares
-        # none, fall back to the catalog value so the output stays flagged and a
-        # polygon `aoi=` can trim exactly (matching the pre-crop behaviour).
-        windowed = ensure_no_data(windowed, self._dataset.nodata)
-
-        # crop(bbox=) keeps every pixel the box overlaps (all-touched, up to one
-        # extra pixel per edge); trim to the exact bbox (matching FABDEM) — or to
-        # the exact polygon when the request carried an `aoi=` polygon.
-        cropped = crop_to_aoi(
-            windowed,
-            self.space,
-            bbox=[self.space.west, self.space.south, self.space.east, self.space.north],
-            touch=False,
-        )
-
-        staged = target.with_name(f"{target.stem}.part{target.suffix}")
         try:
-            cropped.to_file(str(staged))
-            close_quietly(cropped)
-            staged.replace(target)
-        except BaseException:
-            close_quietly(cropped)
-            staged.unlink(missing_ok=True)
-            raise
+            # crop carries the source's own no-data through; when the source
+            # declares none, fall back to the catalog value so the output stays
+            # flagged and a polygon `aoi=` can trim exactly (matching the pre-crop
+            # behaviour).
+            windowed = ensure_no_data(windowed, self._dataset.nodata)
+            # crop(bbox=) keeps every pixel the box overlaps (all-touched, up to
+            # one extra pixel per edge); trim to the exact bbox (matching FABDEM)
+            # — or to the exact polygon when the request carried an `aoi=` polygon.
+            cropped = crop_to_aoi(
+                windowed,
+                self.space,
+                bbox=[
+                    self.space.west,
+                    self.space.south,
+                    self.space.east,
+                    self.space.north,
+                ],
+                touch=False,
+            )
+            staged = target.with_name(f"{target.stem}.part{target.suffix}")
+            try:
+                cropped.to_file(str(staged))
+                close_quietly(cropped)
+                staged.replace(target)
+            except BaseException:
+                close_quietly(cropped)
+                staged.unlink(missing_ok=True)
+                raise
         finally:
             close_quietly(windowed)
         write_sidecar(target, aoi_tag(self.space))

--- a/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
+++ b/libs/providers/hazards/src/earthlens/jrc_flood/backend.py
@@ -37,6 +37,7 @@ from earthlens.base import (
     write_sidecar,
 )
 from earthlens.base.spatial import (
+    bbox_overlaps,
     crop_to_aoi,
     ensure_no_data,
     vsicurl_config,
@@ -241,10 +242,10 @@ class JRCFlood(AbstractDataSource):
     def _bbox_overlaps(self, source: Any) -> bool:
         """Whether the AOI overlaps the source raster's geographic extent.
 
-        A cheap geographic bounds test (from the source's affine transform and
-        pixel dimensions) so an AOI outside the EFHM's Europe / Mediterranean
-        coverage is reported with a clear error before the windowed crop, rather
-        than surfacing as an empty or opaque crop result.
+        Delegates to `earthlens.base.spatial.bbox_overlaps` so an AOI outside the
+        EFHM's Europe / Mediterranean coverage is reported with a clear error
+        before the windowed crop, rather than surfacing as an empty or opaque
+        crop result.
 
         Args:
             source: An opened `pyramids.Dataset` exposing `geotransform`,
@@ -253,17 +254,7 @@ class JRCFlood(AbstractDataSource):
         Returns:
             bool: `True` when the AOI bbox intersects the raster's extent.
         """
-        origin_x, pixel_w, _, origin_y, _, pixel_h = source.geotransform
-        west_bound, east_bound = origin_x, origin_x + source.columns * pixel_w
-        # `pixel_h` is negative for a north-up grid, so the south edge is lower.
-        north_bound, south_bound = origin_y, origin_y + source.rows * pixel_h
-        west, south, east, north = self._bbox
-        return not (
-            east <= west_bound
-            or west >= east_bound
-            or north <= south_bound
-            or south >= north_bound
-        )
+        return bbox_overlaps(source, self._bbox)
 
     def _is_cached(self, target: Path) -> bool:
         """Whether `target` already holds this exact AOI (AOI-aware skip).

--- a/libs/providers/hazards/tests/jrc_flood/test_backend.py
+++ b/libs/providers/hazards/tests/jrc_flood/test_backend.py
@@ -16,28 +16,8 @@ pytestmark = pytest.mark.jrc_flood
 _GT = (-24.54208333, 0.0008333333333333334, 0.0, 71.13375, 0.0, -0.0008333333333333334)
 
 
-class _FakeSource:
-    """Stand-in for a lazily-opened pyramids Dataset over the EFHM."""
-
-    def __init__(self, geo, columns: int, rows: int, no_data_value=(-9999.0,)):
-        self.geotransform = geo
-        self.columns = columns
-        self.rows = rows
-        self.no_data_value = no_data_value
-        self.reads: list[list[int]] = []
-
-    def read_array(self, window: list[int]) -> np.ndarray:
-        """Record the window and return a zero array of its shape."""
-        self.reads.append(window)
-        _, _, cols, rows = window
-        return np.zeros((rows, cols), dtype="float32")
-
-    def close(self) -> None:
-        """No-op."""
-
-
 class _FakeCropped:
-    """Stand-in for the rebuilt window Dataset that writes a stub GeoTIFF."""
+    """Stand-in for the cropped window Dataset that writes a stub GeoTIFF."""
 
     def __init__(self, recorder: dict):
         self._recorder = recorder
@@ -51,26 +31,39 @@ class _FakeCropped:
         """No-op."""
 
 
+class _FakeSource:
+    """Stand-in for a lazily-opened pyramids Dataset over the EFHM."""
+
+    def __init__(
+        self, geo, columns: int, rows: int, no_data_value=(-9999.0,), recorder=None
+    ):
+        self.geotransform = geo
+        self.columns = columns
+        self.rows = rows
+        self.no_data_value = no_data_value
+        self.crops: list = []
+        self._recorder = recorder if recorder is not None else {}
+
+    def crop(self, mask=None, touch=True, *, bbox=None, epsg=None) -> _FakeCropped:
+        """Record the windowed bbox crop and return a writable fake window."""
+        self.crops.append(bbox)
+        return _FakeCropped(self._recorder)
+
+    def close(self) -> None:
+        """No-op."""
+
+
 @pytest.fixture
 def fake_pyramids(monkeypatch: pytest.MonkeyPatch) -> dict:
-    """Patch pyramids Dataset (read_file + create_from_array) + mask_to_geometry."""
-    recorder: dict = {"source": _FakeSource(_GT, 110162, 51992)}
+    """Patch pyramids Dataset (read_file + windowed crop) + crop_to_aoi."""
+    recorder: dict = {}
+    recorder["source"] = _FakeSource(_GT, 110162, 51992, recorder=recorder)
 
     class _FakeDataset:
         @classmethod
         def read_file(cls, path: str) -> _FakeSource:
             recorder["read_path"] = path
             return recorder["source"]
-
-        @classmethod
-        def create_from_array(cls, array, *, geo, epsg, no_data_value) -> _FakeCropped:
-            recorder["create"] = {
-                "shape": array.shape,
-                "geo": geo,
-                "epsg": epsg,
-                "nodata": no_data_value,
-            }
-            return _FakeCropped(recorder)
 
     import pyramids.dataset as pyr_dataset
 
@@ -175,15 +168,14 @@ class TestFetch:
     """Tests for the windowed read / write path."""
 
     def test_writes_one_geotiff_per_rp(self, tmp_path: Path, fake_pyramids: dict):
-        """A download reads the AOI window and writes one GeoTIFF."""
-        # #2: the source's own nodata (not the catalog default) is carried through.
-        fake_pyramids["source"].no_data_value = (-8888.0,)
+        """A download windowed-crops the AOI and writes one GeoTIFF."""
         out = _make(tmp_path, return_periods=[100]).download()
         assert out == [tmp_path / "efhm_RP100.tif"]
         assert out[0].exists()
-        assert fake_pyramids["source"].reads == [[35210, 22960, 241, 241]]
-        assert fake_pyramids["create"]["nodata"] == -8888.0
-        # #3: an AOI sidecar is written next to the output.
+        # The AOI bbox is forwarded to the windowed crop (nodata / grid carry
+        # through is pyramids' own concern now, covered by its tests).
+        assert fake_pyramids["source"].crops == [[4.8, 51.8, 5.0, 52.0]]
+        # An AOI sidecar is written next to the output.
         assert (tmp_path / "efhm_RP100.tif.aoi").exists()
 
     def test_outside_coverage_raises(self, tmp_path: Path, fake_pyramids: dict):
@@ -198,17 +190,17 @@ class TestFetch:
     def test_idempotent_skip_same_aoi(self, tmp_path: Path, fake_pyramids: dict):
         """A re-request for the same AOI skips the windowed read (sidecar match)."""
         _make(tmp_path, return_periods=[100]).download()
-        fake_pyramids["source"].reads.clear()
+        fake_pyramids["source"].crops.clear()
         out = _make(tmp_path, return_periods=[100]).download()
         assert out == [tmp_path / "efhm_RP100.tif"]
-        assert fake_pyramids["source"].reads == []
+        assert fake_pyramids["source"].crops == []
 
     def test_different_aoi_not_skipped(self, tmp_path: Path, fake_pyramids: dict):
         """A same-path request for a different AOI re-reads (no stale return)."""
         (tmp_path / "efhm_RP100.tif").write_bytes(b"stale")
         (tmp_path / "efhm_RP100.tif.aoi").write_text("9,9,9.1,9.1", encoding="utf-8")
         _make(tmp_path, return_periods=[100]).download()
-        assert fake_pyramids["source"].reads, "a different AOI must re-read the window"
+        assert fake_pyramids["source"].crops, "a different AOI must re-read the window"
 
     def test_write_failure_cleans_up(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -222,14 +214,14 @@ class TestFetch:
             def close(self) -> None:
                 pass
 
+        class _RaisingSource(_FakeSource):
+            def crop(self, mask=None, touch=True, *, bbox=None, epsg=None) -> _Raising:
+                return _Raising()
+
         class _FakeDataset:
             @classmethod
-            def read_file(cls, path: str) -> _FakeSource:
-                return _FakeSource(_GT, 110162, 51992)
-
-            @classmethod
-            def create_from_array(cls, array, *, geo, epsg, no_data_value) -> _Raising:
-                return _Raising()
+            def read_file(cls, path: str) -> _RaisingSource:
+                return _RaisingSource(_GT, 110162, 51992)
 
         import pyramids.dataset as pyr_dataset
 

--- a/libs/providers/hazards/tests/jrc_flood/test_backend.py
+++ b/libs/providers/hazards/tests/jrc_flood/test_backend.py
@@ -269,7 +269,8 @@ class TestFetchReal:
         ).download()
         assert out == [tmp_path / "efhm_RP100.tif"]
         result = Dataset.read_file(str(out[0]))
-        assert result.rows < 200 and result.columns < 200, "only the AOI window read"
+        assert result.rows < 200, "only the AOI window read"
+        assert result.columns < 200, "only the AOI window read"
         assert result.no_data_value[0] is not None, "output carries a no-data value"
 
     def test_point_aoi_succeeds(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/libs/providers/hazards/tests/jrc_flood/test_backend.py
+++ b/libs/providers/hazards/tests/jrc_flood/test_backend.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from pyramids.dataset import Dataset
 
 from earthlens.jrc_flood import backend as backend_module
 from earthlens.jrc_flood.backend import JRCFlood
@@ -232,3 +233,54 @@ class TestFetch:
             backend.download()
         assert not (tmp_path / "efhm_RP100.part.tif").exists()
         assert not (tmp_path / "efhm_RP100.tif").exists()
+
+
+def _write_efhm_geotiff(path: Path) -> None:
+    """Write an EFHM-like 4326 GeoTIFF covering lon 4..6, lat 51..53."""
+    arr = np.arange(200 * 200, dtype="float32").reshape(200, 200)
+    Dataset.create_from_array(
+        arr,
+        top_left_corner=(4.0, 53.0),
+        cell_size=0.01,
+        epsg=4326,
+        no_data_value=-9999.0,
+    ).to_file(str(path))
+
+
+class TestFetchReal:
+    """`_fetch_one` against a real (local) pyramids raster — no fakes.
+
+    Pins the delegated crop(bbox=) contract (windowed read + real two-crop trim +
+    no-data) that the faked-`crop` tests cannot exercise.
+    """
+
+    def test_windowed_crop_writes_subset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A normal AOI writes one small cropped GeoTIFF carrying a no-data value."""
+        src = tmp_path / "efhm.tif"
+        _write_efhm_geotiff(src)
+        monkeypatch.setattr(backend_module, "efhm_url", lambda rp, **kw: str(src))
+        out = JRCFlood(
+            lat_lim=[51.8, 52.0],
+            lon_lim=[4.8, 5.0],
+            return_periods=[100],
+            path=tmp_path,
+        ).download()
+        assert out == [tmp_path / "efhm_RP100.tif"]
+        result = Dataset.read_file(str(out[0]))
+        assert result.rows < 200 and result.columns < 200, "only the AOI window read"
+        assert result.no_data_value[0] is not None, "output carries a no-data value"
+
+    def test_point_aoi_succeeds(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """A degenerate point AOI writes a small crop instead of raising (review H1)."""
+        src = tmp_path / "efhm.tif"
+        _write_efhm_geotiff(src)
+        monkeypatch.setattr(backend_module, "efhm_url", lambda rp, **kw: str(src))
+        out = JRCFlood(
+            lat_lim=[51.9, 51.9],
+            lon_lim=[4.9, 4.9],
+            return_periods=[100],
+            path=tmp_path,
+        ).download()
+        assert out[0].exists(), "a point AOI still writes a crop"

--- a/libs/providers/hazards/tests/jrc_flood/test_backend.py
+++ b/libs/providers/hazards/tests/jrc_flood/test_backend.py
@@ -133,6 +133,7 @@ class TestReturnPeriods:
 
     def test_aoi_tag_includes_polygon(self, tmp_path: Path):
         """The cache key folds in the real `aoi=` polygon (a GeoDataFrame)."""
+        from earthlens.base.cache import aoi_tag
         from earthlens.earthlens import EarthLens
 
         aoi = {
@@ -141,16 +142,20 @@ class TestReturnPeriods:
                 [[4.8, 51.8], [5.0, 51.8], [5.0, 52.0], [4.8, 52.0], [4.8, 51.8]]
             ],
         }
-        bbox_only = EarthLens(
-            data_source="jrc-flood",
-            lat_lim=[51.8, 52.0],
-            lon_lim=[4.8, 5.0],
-            return_periods=[100],
-            path=tmp_path,
-        ).datasource._aoi_tag
-        with_polygon = EarthLens(
-            data_source="jrc-flood", aoi=aoi, return_periods=[100], path=tmp_path
-        ).datasource._aoi_tag
+        bbox_only = aoi_tag(
+            EarthLens(
+                data_source="jrc-flood",
+                lat_lim=[51.8, 52.0],
+                lon_lim=[4.8, 5.0],
+                return_periods=[100],
+                path=tmp_path,
+            ).datasource.space
+        )
+        with_polygon = aoi_tag(
+            EarthLens(
+                data_source="jrc-flood", aoi=aoi, return_periods=[100], path=tmp_path
+            ).datasource.space
+        )
         assert with_polygon != bbox_only
         assert "|" in with_polygon
 

--- a/libs/providers/hazards/tests/jrc_flood/test_backend.py
+++ b/libs/providers/hazards/tests/jrc_flood/test_backend.py
@@ -235,15 +235,24 @@ class TestFetch:
         assert not (tmp_path / "efhm_RP100.tif").exists()
 
 
-def _write_efhm_geotiff(path: Path) -> None:
-    """Write an EFHM-like 4326 GeoTIFF covering lon 4..6, lat 51..53."""
-    arr = np.arange(200 * 200, dtype="float32").reshape(200, 200)
+def _write_efhm_geotiff(
+    path: Path, *, no_data_value: float = -9999.0, fill: float | None = None
+) -> None:
+    """Write an EFHM-like 4326 GeoTIFF covering lon 4..6, lat 51..53.
+
+    `fill` writes a constant raster (use the no-data value for an all-no-data
+    source); otherwise a ramp of distinct values.
+    """
+    if fill is None:
+        arr = np.arange(200 * 200, dtype="float32").reshape(200, 200)
+    else:
+        arr = np.full((200, 200), fill, dtype="float32")
     Dataset.create_from_array(
         arr,
         top_left_corner=(4.0, 53.0),
         cell_size=0.01,
         epsg=4326,
-        no_data_value=-9999.0,
+        no_data_value=no_data_value,
     ).to_file(str(path))
 
 
@@ -257,9 +266,11 @@ class TestFetchReal:
     def test_windowed_crop_writes_subset(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
-        """A normal AOI writes one small cropped GeoTIFF carrying a no-data value."""
+        """A normal AOI writes a small crop carrying the source's own no-data."""
         src = tmp_path / "efhm.tif"
-        _write_efhm_geotiff(src)
+        # A distinctive source no-data (not the catalog -9999 fallback) so the
+        # assertion fails if source-carry-through breaks and the fallback stamps.
+        _write_efhm_geotiff(src, no_data_value=-8888.0)
         monkeypatch.setattr(backend_module, "efhm_url", lambda rp, **kw: str(src))
         out = JRCFlood(
             lat_lim=[51.8, 52.0],
@@ -271,7 +282,24 @@ class TestFetchReal:
         result = Dataset.read_file(str(out[0]))
         assert result.rows < 200, "only the AOI window read"
         assert result.columns < 200, "only the AOI window read"
-        assert result.no_data_value[0] is not None, "output carries a no-data value"
+        assert result.no_data_value[0] == -8888.0, "source no-data carried through"
+
+    def test_all_nodata_aoi_writes_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """An in-coverage but all-no-data AOI writes a raster instead of raising."""
+        src = tmp_path / "efhm.tif"
+        _write_efhm_geotiff(src, no_data_value=-9999.0, fill=-9999.0)
+        monkeypatch.setattr(backend_module, "efhm_url", lambda rp, **kw: str(src))
+        out = JRCFlood(
+            lat_lim=[51.8, 52.0],
+            lon_lim=[4.8, 5.0],
+            return_periods=[100],
+            path=tmp_path,
+        ).download()
+        assert out[0].exists(), "an all-no-data AOI still writes a file"
+        result = Dataset.read_file(str(out[0]))
+        assert bool((result.read_array() == -9999.0).all()), "written all-no-data"
 
     def test_point_aoi_succeeds(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """A degenerate point AOI writes a small crop instead of raising (review H1)."""

--- a/libs/providers/hazards/tests/jrc_flood/test_helpers.py
+++ b/libs/providers/hazards/tests/jrc_flood/test_helpers.py
@@ -1,4 +1,4 @@
-"""Unit tests for the JRC-flood URL + pixel-window helpers (no network)."""
+"""Unit tests for the JRC-flood URL helper (no network)."""
 
 from __future__ import annotations
 
@@ -7,11 +7,6 @@ import pytest
 from earthlens.jrc_flood import _helpers as h
 
 pytestmark = pytest.mark.jrc_flood
-
-#: The verified EFHM geotransform (EPSG:4326, ~3 arc-second) + raster size.
-_GT = (-24.54208333, 0.0008333333333333334, 0.0, 71.13375, 0.0, -0.0008333333333333334)
-_COLUMNS = 110162
-_ROWS = 51992
 
 
 class TestEfhmUrl:
@@ -29,96 +24,3 @@ class TestEfhmUrl:
         assert h.efhm_url(50, base_url="http://x", template="rp{rp}.tif") == (
             "http://x/rp50.tif"
         )
-
-
-class TestPixelWindow:
-    """Tests for pixel_window."""
-
-    def test_small_aoi_window(self):
-        """A small AOI maps to a small clamped window."""
-        assert h.pixel_window(_GT, (4.8, 51.8, 5.0, 52.0), _COLUMNS, _ROWS) == (
-            35210,
-            22960,
-            241,
-            241,
-        )
-
-    def test_outside_coverage_returns_none(self):
-        """An AOI south of the coverage returns None."""
-        assert h.pixel_window(_GT, (4.8, -5.0, 5.0, -4.8), _COLUMNS, _ROWS) is None
-
-    def test_west_of_coverage_returns_none(self):
-        """An AOI west of the raster origin returns None."""
-        assert h.pixel_window(_GT, (-40.0, 40.0, -39.0, 41.0), _COLUMNS, _ROWS) is None
-
-    def test_point_inside_yields_one_pixel(self):
-        """A point / boundary-aligned AOI inside the raster yields a 1x1 window."""
-        gt = (0.0, 1.0, 0.0, 10.0, 0.0, -1.0)
-        assert h.pixel_window(gt, (5.0, 5.0, 5.0, 5.0), 10, 10) == (5, 5, 1, 1)
-
-    def test_point_outside_returns_none(self):
-        """A point AOI beyond the raster extent is still None (outside)."""
-        gt = (0.0, 1.0, 0.0, 10.0, 0.0, -1.0)
-        assert h.pixel_window(gt, (50.0, 5.0, 50.0, 5.0), 10, 10) is None
-
-    def test_clamps_to_raster_extent(self):
-        """A window overflowing the north-west corner clamps to the raster."""
-        window = h.pixel_window(_GT, (-30.0, 68.0, -20.0, 75.0), _COLUMNS, _ROWS)
-        assert window is not None
-        col_off, row_off, cols, rows = window
-        assert col_off == 0
-        assert row_off == 0
-        assert 0 < cols <= _COLUMNS
-        assert 0 < rows <= _ROWS
-
-
-class TestConfigureGdalHttp:
-    """Tests for configure_gdal_http."""
-
-    def test_sets_vsicurl_defaults(self, monkeypatch: pytest.MonkeyPatch):
-        """The idempotent tuning sets the readdir + extension defaults."""
-        monkeypatch.delenv("GDAL_DISABLE_READDIR_ON_OPEN", raising=False)
-        h.configure_gdal_http()
-        import os
-
-        assert os.environ["GDAL_DISABLE_READDIR_ON_OPEN"] == "EMPTY_DIR"
-
-    def test_does_not_override_existing(self, monkeypatch: pytest.MonkeyPatch):
-        """An already-set value is left untouched (setdefault semantics)."""
-        monkeypatch.setenv("GDAL_HTTP_TIMEOUT", "99")
-        h.configure_gdal_http()
-        import os
-
-        assert os.environ["GDAL_HTTP_TIMEOUT"] == "99"
-
-
-class TestSourceNoData:
-    """Tests for source_no_data."""
-
-    def test_reads_first_band_value(self):
-        """A declared per-band no-data tuple yields its first value."""
-
-        class _DS:
-            no_data_value = (-8888.0,)
-
-        assert h.source_no_data(_DS()) == -8888.0
-
-    def test_falls_back_when_absent(self):
-        """A missing / None no-data falls back to the default."""
-
-        class _DS:
-            no_data_value = (None,)
-
-        assert h.source_no_data(_DS(), default=-1.0) == -1.0
-
-
-class TestWindowOrigin:
-    """Tests for window_origin."""
-
-    def test_shifts_origin_keeps_pixel_size(self):
-        """window_origin shifts the origin by the offset, keeping pixel sizes."""
-        geo = h.window_origin(_GT, 35210, 22960)
-        assert geo[1] == _GT[1]
-        assert geo[5] == _GT[5]
-        assert geo[0] == pytest.approx(_GT[0] + 35210 * _GT[1])
-        assert geo[3] == pytest.approx(_GT[3] + 22960 * _GT[5])

--- a/libs/providers/land/src/earthlens/fabdem/backend.py
+++ b/libs/providers/land/src/earthlens/fabdem/backend.py
@@ -33,7 +33,10 @@ from earthlens.base import (
     OutputKind,
     RemoteProduct,
     TemporalExtent,
+    aoi_tag,
     close_quietly,
+    sidecar_is_fresh,
+    write_sidecar,
 )
 from earthlens.base.spatial import crop_to_aoi
 from earthlens.biodiversity import warn_license
@@ -176,38 +179,14 @@ class FABDEM(AbstractDataSource):
         """The deterministic output GeoTIFF path for this request."""
         return Path(self.path) / f"fabdem_{self._dataset.version}.tif"
 
-    @property
-    def _aoi_tag(self) -> str:
-        """A stable cache key for this AOI (bbox plus any polygon geometry).
-
-        The bbox alone is not enough: with `SUPPORTS_POLYGON_AOI`, two requests
-        can share a bounding box but carry different polygon masks, so the
-        polygon geometry is folded in to keep their cached crops distinct.
-        """
-        import hashlib
-
-        tag = (
-            f"{self.space.west},{self.space.south},{self.space.east},{self.space.north}"
-        )
-        geometry = getattr(self.space, "geometry", None)
-        if geometry is not None:
-            # `space.geometry` is a geopandas GeoDataFrame (from the facade's
-            # `aoi=`), so serialise it to GeoJSON; fall back to a shapely `.wkt`.
-            if hasattr(geometry, "to_json"):
-                key = geometry.to_json()
-            else:
-                key = getattr(geometry, "wkt", str(geometry))
-            tag += "|" + hashlib.sha256(key.encode("utf-8")).hexdigest()
-        return tag
-
     def _is_cached(self, target: Path) -> bool:
         """Whether `target` already holds this exact AOI (AOI-aware skip).
 
-        The output filename does not encode the AOI, so a bare
-        exists-check would return a previous AOI's raster for a new bbox in the
-        same `path`. A `<target>.aoi` sidecar records the bbox the file was
-        written for; the skip only fires when it matches the current request and
-        `force` is off.
+        The output filename does not encode the AOI, so a bare exists-check
+        would return a previous AOI's raster for a new bbox in the same `path`.
+        The `<target>.aoi` sidecar records the AOI the file was written for
+        (`earthlens.base.cache`); the skip only fires when it matches the current
+        request and `force` is off.
 
         Args:
             target: The candidate output GeoTIFF path.
@@ -215,19 +194,7 @@ class FABDEM(AbstractDataSource):
         Returns:
             bool: `True` when a matching cached output exists and may be reused.
         """
-        sidecar = target.with_suffix(target.suffix + ".aoi")
-        return (
-            not self._force
-            and target.exists()
-            and sidecar.exists()
-            and sidecar.read_text(encoding="utf-8").strip() == self._aoi_tag
-        )
-
-    def _write_aoi_sidecar(self, target: Path) -> None:
-        """Record the AOI `target` was written for, next to it."""
-        target.with_suffix(target.suffix + ".aoi").write_text(
-            self._aoi_tag, encoding="utf-8"
-        )
+        return not self._force and sidecar_is_fresh(target, aoi_tag(self.space))
 
     def download(
         self,
@@ -420,5 +387,5 @@ class FABDEM(AbstractDataSource):
                 merged.unlink(missing_ok=True)
             except OSError:
                 pass
-        self._write_aoi_sidecar(target)
+        write_sidecar(target, aoi_tag(self.space))
         return target

--- a/libs/providers/land/tests/fabdem/test_backend.py
+++ b/libs/providers/land/tests/fabdem/test_backend.py
@@ -251,6 +251,7 @@ class TestDownload:
 
     def test_aoi_tag_includes_polygon(self, tmp_path: Path):
         """The cache key folds in the real `aoi=` polygon (a GeoDataFrame)."""
+        from earthlens.base.cache import aoi_tag
         from earthlens.earthlens import EarthLens
 
         aoi = {
@@ -259,15 +260,17 @@ class TestDownload:
                 [[0.4, 50.4], [0.6, 50.4], [0.6, 50.6], [0.4, 50.6], [0.4, 50.4]]
             ],
         }
-        bbox_only = EarthLens(
-            data_source="fabdem",
-            lat_lim=[50.4, 50.6],
-            lon_lim=[0.4, 0.6],
-            path=tmp_path,
-        ).datasource._aoi_tag
-        with_polygon = EarthLens(
-            data_source="fabdem", aoi=aoi, path=tmp_path
-        ).datasource._aoi_tag
+        bbox_only = aoi_tag(
+            EarthLens(
+                data_source="fabdem",
+                lat_lim=[50.4, 50.6],
+                lon_lim=[0.4, 0.6],
+                path=tmp_path,
+            ).datasource.space
+        )
+        with_polygon = aoi_tag(
+            EarthLens(data_source="fabdem", aoi=aoi, path=tmp_path).datasource.space
+        )
         assert with_polygon != bbox_only
         assert "|" in with_polygon
 


### PR DESCRIPTION
# Description

Removes the two families of duplicated raster-over-HTTP logic that `fabdem`,
`jrc_flood`, and `solar_wind_atlas` each hand-rolled, sending each half to its
correct home, then hardens the new shared surface across review.

**AOI-sidecar cache → `earthlens.base.cache` (new).** `fabdem` and `jrc_flood`
carried an identical AOI-aware skip: an `_aoi_tag` (bbox + hashed polygon
geometry), a `<target>.aoi` sidecar recording the AOI a cached output was written
for, and a freshness check. That provider-agnostic download orchestration now
lives once in `earthlens.base.cache` (`aoi_tag` / `sidecar_path` /
`sidecar_is_fresh` / `write_sidecar`); both backends import it and their copies
are deleted. The tag string is byte-identical, so existing `.aoi` sidecars stay
valid across the upgrade.

**`/vsicurl` windowed read → `pyramids.Dataset.crop(bbox=)`.** `jrc_flood` and
`solar_wind_atlas` each hand-rolled the windowed read (GDAL `/vsicurl` env tuning,
a nodata resolver, and geo→pixel window math via `pixel_window` / `window_origin`
or `read_part` + rebuild). pyramids 0.53's `Dataset.crop(bbox=)` windowed fast
path (serapeum-org/pyramids#957, PR #966) reads only the AOI pixel window straight
from the source over `/vsicurl`, rebuilds the geotransform, and preserves CRS +
nodata — a windowed-read GIS primitive that belongs in pyramids (per the porting
policy), not in `earthlens.base`, which is why the original single-consolidation
plan was split.

Consuming that primitive safely needed a small shared layer in
`earthlens.base.spatial`, added and hardened over review:

- `vsicurl_config()` — a pyramids `CloudConfig` that restores the `/vsicurl`
  readdir-suppression + retry/timeout tuning. A plain `Dataset.read_file(url)`
  installs **no** GDAL config, so the reads are wrapped in this context (pyramids
  does not apply the tuning on its own).
- `widen_degenerate_bbox()` — widens a point / cell-edge AOI to one source pixel
  so `crop(bbox=)`'s strict `west < east` fast path yields a 1x1 window instead of
  raising.
- `windowed_bbox_crop()` — runs the fast windowed crop, falling back to a
  `touch=False` cutline crop (materialised in-context) so an in-coverage but
  all-no-data AOI still writes an all-no-data raster instead of aborting.
- `ensure_no_data()` — stamps the catalog / default no-data when the source
  declares none (restores the pre-crop provenance for exact polygon masking).
- `bbox_overlaps()` — a cheap geographic pre-check that rejects an out-of-extent
  AOI before the read, so an off-coverage request fails fast rather than
  triggering a full remote read. Used by both backends.

Backend wiring: `jrc_flood._fetch_one` windowed-crops via `windowed_bbox_crop`
(with the `_bbox_overlaps` coverage guard) and `_helpers` shrinks to `efhm_url`;
`solar_wind_atlas.read_part_to_geotiff` delegates to the same helpers for both the
`/vsicurl` and `/vsizip` paths, with `window_crop` / `download_cache_crop`
unchanged.

Net effect: three backends stop re-implementing GIS primitives, and future
raster-over-HTTP backends get a tested `earthlens.base` layer plus pyramids'
windowed crop to build on. Depends on `pyramids-gis >= 0.53.0` (already the pinned
floor).

# Issues

- Closes #972 — promote the shared `/vsicurl` read + AOI-sidecar cache primitives out of the backends

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(Behaviour-preserving refactor. The one intentional change: a bbox-only crop now
uses pyramids' all-touched window convention — up to one pixel wider per edge for
a sub-pixel-aligned box — with the exact bbox still trimmed by
`crop_to_aoi(touch=False)`. An in-coverage all-no-data AOI still writes an
all-no-data raster, as before.)

# How Has This Been Tested?

- [x] New unit tests for `earthlens.base.cache` (tag with/without polygon; sidecar freshness / round-trip) and `earthlens.base.spatial` (`widen_degenerate_bbox`, `ensure_no_data`, `vsicurl_config`, `windowed_bbox_crop`, `bbox_overlaps`).
- [x] Real-pyramids tests for both backends: windowed subset, source no-data carry-through / fallback, point AOI, and an in-coverage all-no-data AOI.
- [x] Full non-e2e suite green (`pytest -m "not e2e"` → 9209 passed).
- [x] Live e2e re-confirmed: JRC EFHM RP100 `/vsicurl` crop and the figshare Global Wind Atlas COG both return correct windows.
- [x] `ruff check` + `ruff format` (pinned 0.15.22) and `uv run mypy` clean; SonarCloud gate OK (0 open issues).

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
