### PR TITLE
test(e2e): skip USGS empty-result and EMODnet WCS service failures

### DIFF
--- a/libs/providers/land/src/earthlens/bathymetry/__init__.py
+++ b/libs/providers/land/src/earthlens/bathymetry/__init__.py
@@ -14,7 +14,8 @@ backend and the :class:`~earthlens.bathymetry.catalog.Catalog` of DEM rows.
 
 from __future__ import annotations
 
+from earthlens.bathymetry._helpers import WcsServiceUnavailableError
 from earthlens.bathymetry.backend import Bathymetry
 from earthlens.bathymetry.catalog import Catalog, Dataset
 
-__all__ = ["Bathymetry", "Catalog", "Dataset"]
+__all__ = ["Bathymetry", "Catalog", "Dataset", "WcsServiceUnavailableError"]

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -139,6 +139,11 @@ class WcsServiceUnavailableError(RuntimeError):
 def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
     """Yield `exc` then each linked `__cause__` / `__context__`, cycle-safe.
 
+    Honours `__suppress_context__`, so a deliberate `raise … from None` hides the
+    implicit context (matching stdlib `traceback`): an explicit `__cause__` wins,
+    otherwise the `__context__` is followed only when the author did not suppress
+    it.
+
     Args:
         exc: The exception to walk.
 
@@ -150,7 +155,12 @@ def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
     while current is not None and id(current) not in seen:
         seen.add(id(current))
         yield current
-        current = current.__cause__ or current.__context__
+        if current.__cause__ is not None:
+            current = current.__cause__
+        elif current.__suppress_context__:
+            current = None
+        else:
+            current = current.__context__
 
 
 def _http_status(exc: BaseException) -> int | None:

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -237,19 +237,37 @@ def is_wcs_service_failure(exc: BaseException) -> bool:
             ```
     """
     for link in _exception_chain(exc):
-        status = _http_status(link)
-        if status is not None:
-            return status in _TRANSIENT_STATUS or 500 <= status <= 599
-        if isinstance(link, _TRANSPORT_EXC):
-            return True
-        if isinstance(link, OSError) and link.errno in _NETWORK_ERRNOS:
-            return True
-        message = str(link).lower()
-        if any(signature in message for signature in _SERVICE_SIGNATURES):
-            return True
-        if _STATUS_IN_TEXT_RE.search(message):
-            return True
+        verdict = _link_verdict(link)
+        if verdict is not None:
+            return verdict
     return False
+
+
+def _link_verdict(link: BaseException) -> bool | None:
+    """Classify one exception-chain link as service / request / undecided.
+
+    Args:
+        link: One exception from the cause/context chain.
+
+    Returns:
+        `True` when the link marks a service/transport failure, `False` when it
+        is an authoritative request answer (a definite non-transient HTTP
+        status), or `None` when this link alone does not decide it (defer to the
+        rest of the chain).
+    """
+    status = _http_status(link)
+    if status is not None:
+        return status in _TRANSIENT_STATUS or 500 <= status <= 599
+    if isinstance(link, _TRANSPORT_EXC):
+        return True
+    if isinstance(link, OSError) and link.errno in _NETWORK_ERRNOS:
+        return True
+    message = str(link).lower()
+    if any(signature in message for signature in _SERVICE_SIGNATURES):
+        return True
+    if _STATUS_IN_TEXT_RE.search(message):
+        return True
+    return None
 
 
 def resolution_degrees(native_resolution: str) -> float | None:

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -1,10 +1,13 @@
 """Pure, stateless helpers for the bathymetry backend.
 
-No SDK and no network: these build the ERDDAP `griddap` subset URL the
-backend GETs, so they are unit-testable in isolation. The exact URL shape
-(`…/griddap/<id>.nc?<var>[(lat_lo):1:(lat_hi)][(lon_lo):1:(lon_hi)]`, no
-time axis — the DEMs are static) was pinned live in the A1 gate; see
-`planning/bathymetry/captures/bathymetry-sdk-facts.md`.
+No SDK and no network — every helper here is unit-testable in isolation. Two
+groups: the ERDDAP `griddap` subset-URL builders the backend GETs (the exact
+shape `…/griddap/<id>.nc?<var>[(lat_lo):1:(lat_hi)][(lon_lo):1:(lon_hi)]`, no
+time axis — the DEMs are static — was pinned live in the A1 gate; see
+`planning/bathymetry/captures/bathymetry-sdk-facts.md`), and the WCS
+service-failure classification the backend uses to tell a transient upstream
+outage from a real request error: `WcsServiceUnavailableError` and
+`is_wcs_service_failure`.
 """
 
 from __future__ import annotations

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -10,9 +10,14 @@ time axis — the DEMs are static) was pinned live in the A1 gate; see
 from __future__ import annotations
 
 import re
+import urllib.error
 from typing import TYPE_CHECKING
 
+import requests
+
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from earthlens.base import SpatialExtent
 
 #: Default sampling stride for a griddap axis range (`1` = full resolution).
@@ -20,6 +25,121 @@ _DEFAULT_STEP = 1
 
 #: Parses a `"<value> arc-(second|minute)"` native-resolution label.
 _RESOLUTION_RE = re.compile(r"\s*([\d.]+)\s*arc-(second|minute)", re.IGNORECASE)
+
+#: Exception types that always mean the transport, not the request, failed.
+_TRANSPORT_EXC: tuple[type[BaseException], ...] = (
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+    ConnectionError,
+    TimeoutError,
+    urllib.error.URLError,
+)
+
+#: Lower-cased substrings in a WCS/GDAL failure that mark the OGC service — not
+#: the request — as the problem: a degraded server answering `GetCapabilities`
+#: with an HTML error page (`non-XML body`), a 5xx / gateway error, or a dropped
+#: connection. A genuine request error (a coverage id that does not exist, an
+#: empty subset intersection) carries none of these, so it stays a `ValueError`.
+_SERVICE_SIGNATURES: tuple[str, ...] = (
+    "non-xml",
+    "non xml",
+    "getcapabilities",
+    "empty reply from server",
+    "bad gateway",
+    "gateway time",
+    "service unavailable",
+    "temporarily unavailable",
+    "max retries",
+    "connection reset",
+    "connection aborted",
+    "remote end closed",
+    "read timed out",
+    "failed to establish",
+    "name resolution",
+    "name or service not known",
+)
+
+#: Matches a transient HTTP status (`408` / `429` / `5xx`) only in an HTTP
+#: context — `NNN Server Error` or `HTTP … NNN` — so a stray number in a request
+#: message (a pixel count, a coordinate) never trips it.
+_SERVICE_STATUS_RE = re.compile(
+    r"\b(?:408|429|50[0-9])\s+server error\b|http\D{0,20}(?:408|429|50[0-9])\b", re.I
+)
+
+
+class WcsServiceUnavailableError(RuntimeError):
+    """A WCS coverage read failed because the OGC service was unavailable.
+
+    Raised by the bathymetry backend's WCS path when `pyramids.Dataset.from_wcs`
+    fails for a **transport / service** reason — the endpoint dropped the
+    connection, returned a 5xx / gateway error, or answered `GetCapabilities`
+    with a non-XML error page — rather than a request error (a bad bbox or an
+    unknown coverage id, which stay a `ValueError`). It is a distinct type so a
+    caller — notably a live `e2e` test — can skip on a flaky upstream instead of
+    failing, the way the OSM backend's `OhsomeUnavailableError` does.
+    """
+
+
+def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
+    """Yield `exc` then each linked `__cause__` / `__context__`, cycle-safe.
+
+    Args:
+        exc: The exception to walk.
+
+    Yields:
+        Each exception in the chain, most recent first.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def is_wcs_service_failure(exc: BaseException) -> bool:
+    """Return whether `exc` marks the WCS service (not the request) as at fault.
+
+    Walks the exception's cause/context chain and reports `True` when any link is
+    a transport error (`requests` connection/timeout, `urllib` URL error) or its
+    message carries a service signature — a 5xx / `408` / `429` status, a
+    `non-XML body` `GetCapabilities` answer, an `Empty reply from server`, a
+    dropped connection, or a DNS failure. Returns `False` for a request error (an
+    unknown coverage, an empty subset intersection), so a genuine bug stays a
+    hard failure rather than being masked as "service down".
+
+    Args:
+        exc: The exception `pyramids.Dataset.from_wcs` raised.
+
+    Returns:
+        `True` when the failure looks like an unavailable / degraded service.
+
+    Examples:
+        - A non-XML `GetCapabilities` body is a service failure:
+            ```python
+            >>> from earthlens.bathymetry._helpers import is_wcs_service_failure
+            >>> is_wcs_service_failure(
+            ...     RuntimeError("WCS GetCapabilities returned a non-XML body")
+            ... )
+            True
+
+            ```
+        - An unknown coverage id is a request error, not a service failure:
+            ```python
+            >>> is_wcs_service_failure(RuntimeError("Could not find coverage 'x'"))
+            False
+
+            ```
+    """
+    for link in _exception_chain(exc):
+        if isinstance(link, _TRANSPORT_EXC):
+            return True
+        message = str(link).lower()
+        if any(signature in message for signature in _SERVICE_SIGNATURES):
+            return True
+        if _SERVICE_STATUS_RE.search(message):
+            return True
+    return False
 
 
 def resolution_degrees(native_resolution: str) -> float | None:

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -100,14 +100,17 @@ _SERVICE_SIGNATURES: tuple[str, ...] = (
     "no route to host",
 )
 
-#: Matches a transient status (`408` / `429` / any `5xx`) only where it is a real
-#: HTTP-status token: at the start of the message, adjacent to a status keyword
-#: (`status` / `code` / `http` / `returned` / `response`), or as `NNN … Error`.
-#: The keyword gap forbids letters/digits, so a status embedded in a URL
-#: (`http://host:500/wcs`, `/tiles/429/`) or a stray pixel count never trips it.
+#: Matches a transient status (`408` / `429` / any `5xx`) in text only where it is
+#: unambiguously an HTTP-status token: adjacent to a status keyword
+#: (`status` / `code` / `http` / `http/1.1`), or in the `NNN … Error` form. It
+#: deliberately does NOT match a bare leading integer or a keyword like
+#: `returned`, so a request / size message (`512 x 512 grid`, `500 records
+#: returned`, `coverage returned 512 rows`) is never mistaken for a status. A
+#: bare status in free text without such a token (a raw CDN `522 …` string) is
+#: instead recognised structurally by `_http_status` when the exception carries a
+#: `.response`; the text path is only a fallback for wrapped GDAL / CURL strings.
 _STATUS_IN_TEXT_RE = re.compile(
-    r"^\s*(?:408|429|5\d\d)\b"
-    r"|(?:\bstatus\b|\bcode\b|\bhttp\b|\breturned\b|\bresponse\b)"
+    r"(?:\bhttp\b|\bhttp/\d(?:\.\d)?\b|\bstatus\b|\bcode\b)"
     r"[^0-9A-Za-z]{0,4}(?:408|429|5\d\d)\b"
     r"|\b(?:408|429|5\d\d)\s+(?:server|client|internal server) error\b",
     re.I,

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -239,7 +239,10 @@ def is_wcs_service_failure(exc: Exception) -> bool:
             ```
     """
     for link in _exception_chain(exc):
-        verdict = _link_verdict(link)
+        # `link` is intentionally the generic `Exception` type: a service-failure
+        # classifier must inspect any chained exception, so no more-specific type
+        # fits. The trailing NOSONAR suppresses SonarCloud S112 on this line.
+        verdict = _link_verdict(link)  # NOSONAR
         if verdict is not None:
             return verdict
     return False

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -41,7 +41,7 @@ _TRANSIENT_STATUS: frozenset[int] = frozenset({408, 425, 429})
 #: `socket.gaierror` covers DNS resolution; the bare-`OSError` network errnos
 #: below cover unreachable-host / no-route cases that are not `ConnectionError`
 #: subclasses.
-_TRANSPORT_EXC: tuple[type[BaseException], ...] = (
+_TRANSPORT_EXC: tuple[type[Exception], ...] = (
     requests.exceptions.ConnectionError,
     requests.exceptions.Timeout,
     ConnectionError,
@@ -142,13 +142,14 @@ class WcsServiceUnavailableError(RuntimeError):
     """
 
 
-def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
+def _exception_chain(exc: Exception) -> Iterator[Exception]:
     """Yield `exc` then each linked `__cause__` / `__context__`, cycle-safe.
 
     Honours `__suppress_context__`, so a deliberate `raise … from None` hides the
     implicit context (matching stdlib `traceback`): an explicit `__cause__` wins,
     otherwise the `__context__` is followed only when the author did not suppress
-    it.
+    it. The walk stops at any non-`Exception` link (a `KeyboardInterrupt` /
+    `SystemExit` in the chain is never a service or request signal).
 
     Args:
         exc: The exception to walk.
@@ -157,19 +158,20 @@ def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
         Each exception in the chain, most recent first.
     """
     seen: set[int] = set()
-    current: BaseException | None = exc
+    current: Exception | None = exc
     while current is not None and id(current) not in seen:
         seen.add(id(current))
         yield current
         if current.__cause__ is not None:
-            current = current.__cause__
+            following: BaseException | None = current.__cause__
         elif current.__suppress_context__:
-            current = None
+            following = None
         else:
-            current = current.__context__
+            following = current.__context__
+        current = following if isinstance(following, Exception) else None
 
 
-def _http_status(exc: BaseException) -> int | None:
+def _http_status(exc: Exception) -> int | None:
     """Return the HTTP status `exc` carries, from its type or a `response`.
 
     Reads the two SDK shapes directly — `urllib.error.HTTPError.code` and
@@ -189,7 +191,7 @@ def _http_status(exc: BaseException) -> int | None:
     return code if isinstance(code, int) else None
 
 
-def is_wcs_service_failure(exc: BaseException) -> bool:
+def is_wcs_service_failure(exc: Exception) -> bool:
     """Return whether `exc` marks the WCS service (not the request) as at fault.
 
     Walks the exception's cause/context chain and reports `True` when a link is a
@@ -243,7 +245,7 @@ def is_wcs_service_failure(exc: BaseException) -> bool:
     return False
 
 
-def _link_verdict(link: BaseException) -> bool | None:
+def _link_verdict(link: Exception) -> bool | None:
     """Classify one exception-chain link as service / request / undecided.
 
     Args:

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -77,6 +77,18 @@ class WcsServiceUnavailableError(RuntimeError):
     unknown coverage id, which stay a `ValueError`). It is a distinct type so a
     caller — notably a live `e2e` test — can skip on a flaky upstream instead of
     failing, the way the OSM backend's `OhsomeUnavailableError` does.
+
+    Examples:
+        - It is a `RuntimeError`, so a broad transport-failure `except` catches it:
+            ```python
+            >>> from earthlens.bathymetry import WcsServiceUnavailableError
+            >>> try:
+            ...     raise WcsServiceUnavailableError("the WCS service is unavailable")
+            ... except RuntimeError as exc:
+            ...     print(exc)
+            the WCS service is unavailable
+
+            ```
     """
 
 
@@ -124,8 +136,17 @@ def is_wcs_service_failure(exc: BaseException) -> bool:
             True
 
             ```
+        - A dropped connection is a service failure, whatever its message:
+            ```python
+            >>> import requests
+            >>> from earthlens.bathymetry._helpers import is_wcs_service_failure
+            >>> is_wcs_service_failure(requests.exceptions.ConnectionError("boom"))
+            True
+
+            ```
         - An unknown coverage id is a request error, not a service failure:
             ```python
+            >>> from earthlens.bathymetry._helpers import is_wcs_service_failure
             >>> is_wcs_service_failure(RuntimeError("Could not find coverage 'x'"))
             False
 

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -240,8 +240,8 @@ def is_wcs_service_failure(exc: Exception) -> bool:
     """
     for link in _exception_chain(exc):
         # `link` is intentionally the generic `Exception` type: a service-failure
-        # classifier must inspect any chained exception, so no more-specific type
-        # fits. The trailing NOSONAR suppresses SonarCloud S112 on this line.
+        # classifier must inspect any chained exception, and there is no
+        # more-specific type that fits.
         verdict = _link_verdict(link)  # NOSONAR
         if verdict is not None:
             return verdict

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -9,7 +9,9 @@ time axis — the DEMs are static) was pinned live in the A1 gate; see
 
 from __future__ import annotations
 
+import errno
 import re
+import socket
 import urllib.error
 from typing import TYPE_CHECKING
 
@@ -26,13 +28,43 @@ _DEFAULT_STEP = 1
 #: Parses a `"<value> arc-(second|minute)"` native-resolution label.
 _RESOLUTION_RE = re.compile(r"\s*([\d.]+)\s*arc-(second|minute)", re.IGNORECASE)
 
+#: HTTP statuses (besides the whole 5xx range, handled separately) that mean the
+#: service — not the request — is at fault: request timeout, too-early, and
+#: rate-limit. `400` / `403` / `404` are deliberately excluded: they are real
+#: answers to the request and must stay a `ValueError`.
+_TRANSIENT_STATUS: frozenset[int] = frozenset({408, 425, 429})
+
 #: Exception types that always mean the transport, not the request, failed.
+#: `socket.gaierror` covers DNS resolution; the bare-`OSError` network errnos
+#: below cover unreachable-host / no-route cases that are not `ConnectionError`
+#: subclasses.
 _TRANSPORT_EXC: tuple[type[BaseException], ...] = (
     requests.exceptions.ConnectionError,
     requests.exceptions.Timeout,
     ConnectionError,
     TimeoutError,
     urllib.error.URLError,
+    socket.gaierror,
+)
+
+#: `OSError.errno` values that mark a network-path failure (not a bad request).
+_NETWORK_ERRNOS: frozenset[int] = frozenset(
+    e
+    for e in (
+        getattr(errno, name, None)
+        for name in (
+            "ENETUNREACH",
+            "EHOSTUNREACH",
+            "ECONNREFUSED",
+            "ECONNRESET",
+            "ECONNABORTED",
+            "ETIMEDOUT",
+            "ENETDOWN",
+            "EHOSTDOWN",
+            "ENETRESET",
+        )
+    )
+    if e is not None
 )
 
 #: Lower-cased substrings in a WCS/GDAL failure that mark the OGC service — not
@@ -40,30 +72,42 @@ _TRANSPORT_EXC: tuple[type[BaseException], ...] = (
 #: with an HTML error page (`non-XML body`), a 5xx / gateway error, or a dropped
 #: connection. A genuine request error (a coverage id that does not exist, an
 #: empty subset intersection) carries none of these, so it stays a `ValueError`.
+#: Note: `getcapabilities` alone is intentionally absent — servers name it when
+#: reporting an unknown coverage too, so the `non-xml` signature (plus the status
+#: checks) catches the real bad-body case without masking a request error.
 _SERVICE_SIGNATURES: tuple[str, ...] = (
     "non-xml",
     "non xml",
-    "getcapabilities",
     "empty reply from server",
+    "internal server error",
     "bad gateway",
     "gateway time",
     "service unavailable",
     "temporarily unavailable",
+    "too many requests",
     "max retries",
     "connection reset",
     "connection aborted",
     "remote end closed",
-    "read timed out",
+    "timed out",
     "failed to establish",
     "name resolution",
     "name or service not known",
+    "network is unreachable",
+    "no route to host",
 )
 
-#: Matches a transient HTTP status (`408` / `429` / `5xx`) only in an HTTP
-#: context — `NNN Server Error` or `HTTP … NNN` — so a stray number in a request
-#: message (a pixel count, a coordinate) never trips it.
-_SERVICE_STATUS_RE = re.compile(
-    r"\b(?:408|429|50[0-9])\s+server error\b|http\D{0,20}(?:408|429|50[0-9])\b", re.I
+#: Matches a transient status (`408` / `429` / any `5xx`) only where it is a real
+#: HTTP-status token: at the start of the message, adjacent to a status keyword
+#: (`status` / `code` / `http` / `returned` / `response`), or as `NNN … Error`.
+#: The keyword gap forbids letters/digits, so a status embedded in a URL
+#: (`http://host:500/wcs`, `/tiles/429/`) or a stray pixel count never trips it.
+_STATUS_IN_TEXT_RE = re.compile(
+    r"^\s*(?:408|429|5\d\d)\b"
+    r"|(?:\bstatus\b|\bcode\b|\bhttp\b|\breturned\b|\bresponse\b)"
+    r"[^0-9A-Za-z]{0,4}(?:408|429|5\d\d)\b"
+    r"|\b(?:408|429|5\d\d)\s+(?:server|client|internal server) error\b",
+    re.I,
 )
 
 
@@ -109,16 +153,40 @@ def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
         current = current.__cause__ or current.__context__
 
 
+def _http_status(exc: BaseException) -> int | None:
+    """Return the HTTP status `exc` carries, from its type or a `response`.
+
+    Reads the two SDK shapes directly — `urllib.error.HTTPError.code` and
+    `requests` `.response.status_code` — so a status is used structurally rather
+    than parsed out of free text (which a URL or a pixel count could spoof).
+
+    Args:
+        exc: The exception to inspect.
+
+    Returns:
+        The status code, or `None` when the exception carries none.
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code
+    response = getattr(exc, "response", None)
+    code = getattr(response, "status_code", None)
+    return code if isinstance(code, int) else None
+
+
 def is_wcs_service_failure(exc: BaseException) -> bool:
     """Return whether `exc` marks the WCS service (not the request) as at fault.
 
-    Walks the exception's cause/context chain and reports `True` when any link is
-    a transport error (`requests` connection/timeout, `urllib` URL error) or its
-    message carries a service signature — a 5xx / `408` / `429` status, a
-    `non-XML body` `GetCapabilities` answer, an `Empty reply from server`, a
-    dropped connection, or a DNS failure. Returns `False` for a request error (an
-    unknown coverage, an empty subset intersection), so a genuine bug stays a
-    hard failure rather than being masked as "service down".
+    Walks the exception's cause/context chain and reports `True` when a link is a
+    transport error (`requests` / `urllib` connection-timeout types, a
+    DNS `gaierror`, or a network-errno `OSError`), carries a **transient HTTP
+    status** (`408` / `425` / `429` or any `5xx`, read structurally from a
+    `response` / `HTTPError` when present, else from a status token in the text),
+    or matches a service signature — a `non-XML body`, an `Empty reply from
+    server`, a dropped connection, or a DNS failure. A **definite non-transient
+    status** (`400` / `403` / `404`) is authoritative: the request reached the
+    service and got a real answer, so it stays `False`. Everything else — an
+    unknown coverage, an empty subset intersection — is also `False`, so a
+    genuine bug stays a hard failure rather than being masked as "service down".
 
     Args:
         exc: The exception `pyramids.Dataset.from_wcs` raised.
@@ -153,12 +221,17 @@ def is_wcs_service_failure(exc: BaseException) -> bool:
             ```
     """
     for link in _exception_chain(exc):
+        status = _http_status(link)
+        if status is not None:
+            return status in _TRANSIENT_STATUS or 500 <= status <= 599
         if isinstance(link, _TRANSPORT_EXC):
+            return True
+        if isinstance(link, OSError) and link.errno in _NETWORK_ERRNOS:
             return True
         message = str(link).lower()
         if any(signature in message for signature in _SERVICE_SIGNATURES):
             return True
-        if _SERVICE_STATUS_RE.search(message):
+        if _STATUS_IN_TEXT_RE.search(message):
             return True
     return False
 

--- a/libs/providers/land/src/earthlens/bathymetry/backend.py
+++ b/libs/providers/land/src/earthlens/bathymetry/backend.py
@@ -41,9 +41,11 @@ from earthlens.base import (
 )
 from earthlens.base.http import HttpClient
 from earthlens.bathymetry._helpers import (
+    WcsServiceUnavailableError,
     bbox_from_extent,
     estimate_grid_pixels,
     griddap_subset_url,
+    is_wcs_service_failure,
 )
 from earthlens.bathymetry.catalog import Catalog, Dataset
 
@@ -320,8 +322,13 @@ class Bathymetry(AbstractDataSource):
             tif_path: Destination GeoTIFF path.
 
         Raises:
-            ValueError: When the bbox is outside the coverage extent, or the
-                WCS request / read fails.
+            WcsServiceUnavailableError: When `from_wcs` fails for a transport /
+                service reason (a dropped connection, a 5xx / gateway error, or
+                a non-XML `GetCapabilities` answer) — a distinct type so a live
+                `e2e` test can skip on a flaky upstream instead of failing.
+            ValueError: When the request itself is at fault — the bbox is outside
+                the coverage extent, or the coverage / subset is otherwise
+                invalid.
         """
         from pyramids.dataset import Dataset as PyramidsDataset
 
@@ -341,11 +348,17 @@ class Bathymetry(AbstractDataSource):
                 timeout=self._timeout,
             )
         except Exception as exc:
+            if is_wcs_service_failure(exc):
+                raise WcsServiceUnavailableError(
+                    f"the WCS service at {row.endpoint} is unavailable for "
+                    f"{row.id!r} over {self._extent_label()}: {exc}. This is a "
+                    f"server-side / transport problem, not the request — retry "
+                    f"later."
+                ) from exc
             raise ValueError(
                 f"bathymetry WCS request for {row.id!r} failed over "
                 f"{self._extent_label()}: {exc}. The bbox may be outside the "
-                f"coverage or too large for the server (shrink it), or the WCS "
-                f"service may be unavailable."
+                f"coverage or too large for the server (shrink it)."
             ) from exc
         dataset = mask_to_geometry(dataset, self.space)
         dataset.to_file(str(tif_path))

--- a/libs/providers/land/tests/bathymetry/test_emodnet_wcs_e2e.py
+++ b/libs/providers/land/tests/bathymetry/test_emodnet_wcs_e2e.py
@@ -17,7 +17,9 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import requests
 
+from earthlens.bathymetry import WcsServiceUnavailableError
 from earthlens.earthlens import EarthLens
 
 pytestmark = [pytest.mark.e2e, pytest.mark.bathymetry]
@@ -58,18 +60,38 @@ def _elevation_stats(path: Path) -> tuple[float, float]:
     return float(finite.min()), float(finite.max())
 
 
+def _skip_on_service(exc: Exception) -> None:
+    """Skip (not fail) when the failure is a transport / WCS-service problem.
+
+    The `_skip_when_offline` guard only catches a total outage (the reachability
+    GET failing). A service that answers the probe but then returns a non-XML
+    error page or drops the connection mid-request surfaces as the backend's
+    typed `WcsServiceUnavailableError` (or a bare `requests` transport error),
+    which should skip the lane rather than redden it. Anything else re-raises.
+    """
+    if isinstance(
+        exc,
+        (requests.ConnectionError, requests.Timeout, WcsServiceUnavailableError),
+    ):
+        pytest.skip(f"EMODnet WCS unavailable: {exc}")
+    raise exc
+
+
 class TestEmodnetLiveFetch:
     """Live EMODnet DTM subset over OGC WCS (no credentials)."""
 
     def test_emodnet_subset_writes_ocean_geotiff(self, tmp_path: Path):
         """A small EMODnet pull lands one GeoTIFF of plausible North Sea depths."""
-        paths = EarthLens(
-            data_source="bathymetry",
-            dataset="emodnet",
-            lat_lim=_LAT_LIM,
-            lon_lim=_LON_LIM,
-            path=str(tmp_path),
-        ).download(progress_bar=False)
+        try:
+            paths = EarthLens(
+                data_source="bathymetry",
+                dataset="emodnet",
+                lat_lim=_LAT_LIM,
+                lon_lim=_LON_LIM,
+                path=str(tmp_path),
+            ).download(progress_bar=False)
+        except Exception as exc:  # noqa: BLE001 - service -> skip, else re-raise
+            _skip_on_service(exc)
 
         assert len(paths) == 1, f"expected one GeoTIFF, got {paths}"
         assert paths[0].suffix == ".tif", f"expected a .tif, got {paths[0]}"

--- a/libs/providers/land/tests/bathymetry/test_emodnet_wcs_e2e.py
+++ b/libs/providers/land/tests/bathymetry/test_emodnet_wcs_e2e.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import NoReturn
 
 import numpy as np
 import pytest
@@ -60,7 +61,7 @@ def _elevation_stats(path: Path) -> tuple[float, float]:
     return float(finite.min()), float(finite.max())
 
 
-def _skip_on_service(exc: Exception) -> None:
+def _skip_on_service(exc: Exception) -> NoReturn:
     """Skip (not fail) when the failure is a transport / WCS-service problem.
 
     The `_skip_when_offline` guard only catches a total outage (the reachability

--- a/libs/providers/land/tests/bathymetry/test_helpers.py
+++ b/libs/providers/land/tests/bathymetry/test_helpers.py
@@ -133,13 +133,11 @@ class TestIsWcsServiceFailure:
             "WCS GetCapabilities returned a non-XML body from ows...",
             "the server sent a non xml response",
             "HTTP error code : 503",
+            "HTTP/1.1 503",
+            "HTTP/1.1 503 Service Unavailable",
             "500 Server Error: Internal Server Error",
             "500 Internal Server Error",
             "GetCoverage failed with status 500",
-            "the server returned 502",
-            "522 Origin Connection Time-out",
-            "520 Web Server Returned an Unknown Error",
-            "511 Network Authentication Required",
             "received HTTP 429 from the endpoint",
             "http 408 request timeout",
             "502 Bad Gateway",
@@ -202,6 +200,10 @@ class TestIsWcsServiceFailure:
             "coverage 'foo' not listed in the server's GetCapabilities document",
             "InvalidSubsetting: Empty intersection after subsetting",
             "grid is 5000 x 5000 pixels, too large",
+            "512 x 512 grid too large",
+            "500 records returned from GetCoverage",
+            "503 points requested, too many",
+            "coverage returned 512 rows",
             "unknown band 'depth'",
             "failed to read http://server/tiles/429/data",
             "cannot connect to http://host:500/wcs",
@@ -209,8 +211,17 @@ class TestIsWcsServiceFailure:
         ],
     )
     def test_request_errors_classify_false(self, message: str):
-        """A request error — including a status embedded in a URL — classifies False."""
+        """A request error — a leading count, or a status in a URL — classifies False."""
         assert is_wcs_service_failure(RuntimeError(message)) is False, message
+
+    def test_response_without_int_status_falls_through(self):
+        """An HTTPError whose response has no int status_code is judged by message."""
+        err = requests.exceptions.HTTPError("Service Unavailable")
+        err.response = requests.Response()  # default status_code is None
+        assert is_wcs_service_failure(err) is True
+        plain = requests.exceptions.HTTPError("Could not find coverage")
+        plain.response = requests.Response()
+        assert is_wcs_service_failure(plain) is False
 
     def test_walks_cause_chain(self):
         """A transport error linked via __cause__ is detected through the wrapper."""

--- a/libs/providers/land/tests/bathymetry/test_helpers.py
+++ b/libs/providers/land/tests/bathymetry/test_helpers.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import urllib.error
+
 import pytest
+import requests
 
 from earthlens.base import SpatialExtent
+from earthlens.bathymetry import WcsServiceUnavailableError
 from earthlens.bathymetry._helpers import (
     bbox_from_extent,
     estimate_grid_pixels,
     griddap_subset_url,
+    is_wcs_service_failure,
     resolution_degrees,
 )
 
@@ -103,3 +108,131 @@ def test_estimate_grid_pixels_for_arcsecond_bbox():
 def test_estimate_grid_pixels_unparseable_returns_none():
     """An unparseable resolution gives no pixel estimate."""
     assert estimate_grid_pixels((0.0, 0.0, 1.0, 1.0), "native") is None
+
+
+class TestIsWcsServiceFailure:
+    """Classifier that tells a WCS service outage from a request error."""
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "WCS GetCapabilities returned a non-XML body from ows...",
+            "the server sent a non xml response",
+            "HTTP error code : 503",
+            "500 Server Error: Internal Server Error",
+            "received HTTP 429 from the endpoint",
+            "http 408 request timeout",
+            "502 Bad Gateway",
+            "504 gateway time-out",
+            "Service Unavailable",
+            "the resource is temporarily unavailable",
+            "Empty reply from server",
+            "Max retries exceeded with url",
+            "Connection reset by peer",
+            "Connection aborted",
+            "Remote end closed connection without response",
+            "read timed out",
+            "failed to establish a new connection",
+            "Temporary failure in name resolution",
+            "Name or service not known",
+        ],
+    )
+    def test_service_messages_classify_true(self, message: str):
+        """A message carrying a service / transport signature is a service failure.
+
+        Args:
+            message: The exception text under test.
+
+        Test scenario:
+            Each string is a real GDAL / requests availability signature, so the
+            classifier must report `True`.
+        """
+        assert is_wcs_service_failure(RuntimeError(message)) is True, message
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            requests.exceptions.ConnectionError("boom"),
+            requests.exceptions.Timeout("slow"),
+            ConnectionError("dropped"),
+            TimeoutError("late"),
+            urllib.error.URLError("unreachable"),
+        ],
+    )
+    def test_transport_exception_types_classify_true(self, exc: BaseException):
+        """A transport exception type is a service failure regardless of message.
+
+        Args:
+            exc: The transport exception under test.
+
+        Test scenario:
+            `requests` / stdlib connection and timeout types are unambiguous
+            transport failures, so the classifier reports `True`.
+        """
+        assert is_wcs_service_failure(exc) is True, type(exc).__name__
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Could not find coverage 'emodnet:mean'",
+            "InvalidSubsetting: Empty intersection after subsetting",
+            "grid is 5000 x 5000 pixels, too large",
+            "unknown band 'depth'",
+            "",
+        ],
+    )
+    def test_request_errors_classify_false(self, message: str):
+        """A request-shaping error carries no service signature, so it is False.
+
+        Args:
+            message: The exception text under test.
+
+        Test scenario:
+            A bad coverage id, an empty subset, an oversize grid (whose stray
+            `5000` must not read as a status), an unknown band, and an empty
+            message must all stay hard failures (`False`).
+        """
+        assert is_wcs_service_failure(RuntimeError(message)) is False, message
+
+    def test_walks_cause_chain(self):
+        """A transport error linked via __cause__ is detected through the wrapper."""
+        inner = requests.exceptions.ConnectionError("Connection reset by peer")
+        outer = RuntimeError("from_wcs failed")
+        outer.__cause__ = inner
+        assert is_wcs_service_failure(outer) is True
+
+    def test_walks_context_chain(self):
+        """A transport error linked via an implicit __context__ is also detected."""
+        try:
+            try:
+                raise requests.exceptions.Timeout("connection lost")
+            except requests.exceptions.Timeout:
+                raise RuntimeError("wrapping a transport failure")
+        except RuntimeError as exc:
+            assert is_wcs_service_failure(exc) is True
+
+    def test_self_referential_chain_is_cycle_safe(self):
+        """A cyclic cause chain terminates instead of looping forever."""
+        exc = RuntimeError("no service signal")
+        exc.__cause__ = exc
+        assert is_wcs_service_failure(exc) is False
+
+
+class TestWcsServiceUnavailableError:
+    """The typed error the WCS path raises for an unavailable service."""
+
+    def test_is_a_runtime_error(self):
+        """It subclasses RuntimeError so a broad transport catch still catches it."""
+        assert issubclass(WcsServiceUnavailableError, RuntimeError)
+
+    def test_preserves_its_message(self):
+        """The human-facing message is carried through unchanged."""
+        err = WcsServiceUnavailableError("the WCS service is unavailable, retry later")
+        assert str(err) == "the WCS service is unavailable, retry later"
+
+    def test_is_exported_from_the_package(self):
+        """It is importable from the package surface for tests to skip on."""
+        import earthlens.bathymetry as pkg
+
+        assert pkg.WcsServiceUnavailableError is WcsServiceUnavailableError
+        assert "WcsServiceUnavailableError" in pkg.__all__

--- a/libs/providers/land/tests/bathymetry/test_helpers.py
+++ b/libs/providers/land/tests/bathymetry/test_helpers.py
@@ -235,6 +235,16 @@ class TestIsWcsServiceFailure:
         exc.__cause__ = exc
         assert is_wcs_service_failure(exc) is False
 
+    def test_suppressed_context_is_not_walked(self):
+        """A `raise ... from None` hides a transport context, so it stays False."""
+        try:
+            try:
+                raise requests.exceptions.ConnectionError("Connection reset by peer")
+            except requests.exceptions.ConnectionError:
+                raise RuntimeError("bad coverage request") from None
+        except RuntimeError as exc:
+            assert is_wcs_service_failure(exc) is False
+
 
 class TestWcsServiceUnavailableError:
     """The typed error the WCS path raises for an unavailable service."""

--- a/libs/providers/land/tests/bathymetry/test_helpers.py
+++ b/libs/providers/land/tests/bathymetry/test_helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import errno
+import socket
 import urllib.error
 
 import pytest
@@ -110,6 +112,18 @@ def test_estimate_grid_pixels_unparseable_returns_none():
     assert estimate_grid_pixels((0.0, 0.0, 1.0, 1.0), "native") is None
 
 
+def _http_error(
+    message: str, status: int | None = None
+) -> requests.exceptions.HTTPError:
+    """Build a requests HTTPError, optionally carrying a response status code."""
+    err = requests.exceptions.HTTPError(message)
+    if status is not None:
+        response = requests.Response()
+        response.status_code = status
+        err.response = response
+    return err
+
+
 class TestIsWcsServiceFailure:
     """Classifier that tells a WCS service outage from a request error."""
 
@@ -120,6 +134,12 @@ class TestIsWcsServiceFailure:
             "the server sent a non xml response",
             "HTTP error code : 503",
             "500 Server Error: Internal Server Error",
+            "500 Internal Server Error",
+            "GetCoverage failed with status 500",
+            "the server returned 502",
+            "522 Origin Connection Time-out",
+            "520 Web Server Returned an Unknown Error",
+            "511 Network Authentication Required",
             "received HTTP 429 from the endpoint",
             "http 408 request timeout",
             "502 Bad Gateway",
@@ -135,18 +155,12 @@ class TestIsWcsServiceFailure:
             "failed to establish a new connection",
             "Temporary failure in name resolution",
             "Name or service not known",
+            "[Errno 101] Network is unreachable",
+            "[Errno 113] No route to host",
         ],
     )
     def test_service_messages_classify_true(self, message: str):
-        """A message carrying a service / transport signature is a service failure.
-
-        Args:
-            message: The exception text under test.
-
-        Test scenario:
-            Each string is a real GDAL / requests availability signature, so the
-            classifier must report `True`.
-        """
+        """A message carrying a service / transport signature classifies True."""
         assert is_wcs_service_failure(RuntimeError(message)) is True, message
 
     @pytest.mark.parametrize(
@@ -157,41 +171,45 @@ class TestIsWcsServiceFailure:
             ConnectionError("dropped"),
             TimeoutError("late"),
             urllib.error.URLError("unreachable"),
+            socket.gaierror("Name or service not known"),
+            OSError(errno.EHOSTUNREACH, "a bare network os error"),
         ],
     )
     def test_transport_exception_types_classify_true(self, exc: BaseException):
-        """A transport exception type is a service failure regardless of message.
-
-        Args:
-            exc: The transport exception under test.
-
-        Test scenario:
-            `requests` / stdlib connection and timeout types are unambiguous
-            transport failures, so the classifier reports `True`.
-        """
+        """A transport / network-errno exception classifies True by type."""
         assert is_wcs_service_failure(exc) is True, type(exc).__name__
+
+    @pytest.mark.parametrize("status", [408, 425, 429, 500, 502, 503, 504, 522, 511])
+    def test_transient_response_status_classifies_true(self, status: int):
+        """A transient HTTP status read from the response classifies True."""
+        assert is_wcs_service_failure(_http_error("boom", status)) is True, status
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 410, 422])
+    def test_non_transient_response_status_classifies_false(self, status: int):
+        """A definite non-transient status is a request answer, so it is False."""
+        assert is_wcs_service_failure(_http_error("boom", status)) is False, status
+
+    @pytest.mark.parametrize("status, expected", [(503, True), (404, False)])
+    def test_urllib_httperror_classified_by_its_code(self, status: int, expected: bool):
+        """A urllib HTTPError is classified by its `.code`, transient or not."""
+        err = urllib.error.HTTPError("http://x/wcs", status, "msg", None, None)
+        assert is_wcs_service_failure(err) is expected, status
 
     @pytest.mark.parametrize(
         "message",
         [
             "Could not find coverage 'emodnet:mean'",
+            "coverage 'foo' not listed in the server's GetCapabilities document",
             "InvalidSubsetting: Empty intersection after subsetting",
             "grid is 5000 x 5000 pixels, too large",
             "unknown band 'depth'",
+            "failed to read http://server/tiles/429/data",
+            "cannot connect to http://host:500/wcs",
             "",
         ],
     )
     def test_request_errors_classify_false(self, message: str):
-        """A request-shaping error carries no service signature, so it is False.
-
-        Args:
-            message: The exception text under test.
-
-        Test scenario:
-            A bad coverage id, an empty subset, an oversize grid (whose stray
-            `5000` must not read as a status), an unknown band, and an empty
-            message must all stay hard failures (`False`).
-        """
+        """A request error — including a status embedded in a URL — classifies False."""
         assert is_wcs_service_failure(RuntimeError(message)) is False, message
 
     def test_walks_cause_chain(self):

--- a/libs/providers/land/tests/bathymetry/test_wcs.py
+++ b/libs/providers/land/tests/bathymetry/test_wcs.py
@@ -10,7 +10,6 @@ import requests
 
 from earthlens.bathymetry import WcsServiceUnavailableError
 from earthlens.bathymetry import backend as backend_module
-from earthlens.bathymetry._helpers import is_wcs_service_failure
 from earthlens.bathymetry.backend import Bathymetry
 from earthlens.bathymetry.catalog import Dataset
 
@@ -232,32 +231,6 @@ def test_connection_error_raises_typed_unavailable_error(
     backend = _make("emodnet", tmp_path)
     with pytest.raises(WcsServiceUnavailableError):
         backend.download()
-
-
-@pytest.mark.parametrize(
-    "exc, is_service",
-    [
-        (RuntimeError("WCS GetCapabilities returned a non-XML body"), True),
-        (RuntimeError("HTTP error code : 503"), True),
-        (RuntimeError("500 Server Error: Internal Server Error"), True),
-        (requests.exceptions.ConnectionError("Max retries exceeded"), True),
-        (requests.exceptions.Timeout("read timed out"), True),
-        (RuntimeError("Could not find coverage 'emodnet:mean'"), False),
-        (RuntimeError("InvalidSubsetting: Empty intersection after subsetting"), False),
-        (RuntimeError("grid is 5000 x 5000 pixels, too large"), False),
-    ],
-)
-def test_is_wcs_service_failure_classification(exc, is_service):
-    """Service/transport failures classify True; request errors classify False."""
-    assert is_wcs_service_failure(exc) is is_service
-
-
-def test_is_wcs_service_failure_walks_the_chain():
-    """A transport error hidden under a generic wrapper is still detected."""
-    inner = requests.exceptions.ConnectionError("Connection reset by peer")
-    outer = RuntimeError("from_wcs failed")
-    outer.__cause__ = inner
-    assert is_wcs_service_failure(outer) is True
 
 
 def test_griddap_row_never_calls_from_wcs(

--- a/libs/providers/land/tests/bathymetry/test_wcs.py
+++ b/libs/providers/land/tests/bathymetry/test_wcs.py
@@ -8,7 +8,9 @@ import pyramids.dataset as pyramids_dataset
 import pytest
 import requests
 
+from earthlens.bathymetry import WcsServiceUnavailableError
 from earthlens.bathymetry import backend as backend_module
+from earthlens.bathymetry._helpers import is_wcs_service_failure
 from earthlens.bathymetry.backend import Bathymetry
 from earthlens.bathymetry.catalog import Dataset
 
@@ -190,16 +192,72 @@ def test_non_wgs84_row_skips_numeric_guard(tmp_path: Path, fake_from_wcs: dict):
     backend._guard_wcs_domain(projected, (100.0, 100.0, 200.0, 200.0))
 
 
-def test_from_wcs_failure_is_wrapped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """A from_wcs error surfaces as a clear ValueError, not a raw exception."""
+def test_request_error_is_wrapped_as_valueerror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A non-service from_wcs failure surfaces as a clear ValueError."""
 
     def _boom(endpoint, *, coverage, bbox, **kwargs):
-        raise RuntimeError("server exploded")
+        raise RuntimeError("Empty intersection after subsetting")
 
     monkeypatch.setattr(pyramids_dataset.Dataset, "from_wcs", staticmethod(_boom))
     backend = _make("emodnet", tmp_path)
     with pytest.raises(ValueError, match="WCS request for 'emodnet'"):
         backend.download()
+
+
+def test_service_failure_raises_typed_unavailable_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A non-XML GetCapabilities answer raises the typed service error, not ValueError."""
+
+    def _degraded(endpoint, *, coverage, bbox, **kwargs):
+        raise RuntimeError("WCS GetCapabilities returned a non-XML body from ows...")
+
+    monkeypatch.setattr(pyramids_dataset.Dataset, "from_wcs", staticmethod(_degraded))
+    backend = _make("emodnet", tmp_path)
+    with pytest.raises(WcsServiceUnavailableError, match="unavailable for 'emodnet'"):
+        backend.download()
+
+
+def test_connection_error_raises_typed_unavailable_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A dropped connection from from_wcs raises the typed service error."""
+
+    def _dropped(endpoint, *, coverage, bbox, **kwargs):
+        raise requests.exceptions.ConnectionError("Connection aborted")
+
+    monkeypatch.setattr(pyramids_dataset.Dataset, "from_wcs", staticmethod(_dropped))
+    backend = _make("emodnet", tmp_path)
+    with pytest.raises(WcsServiceUnavailableError):
+        backend.download()
+
+
+@pytest.mark.parametrize(
+    "exc, is_service",
+    [
+        (RuntimeError("WCS GetCapabilities returned a non-XML body"), True),
+        (RuntimeError("HTTP error code : 503"), True),
+        (RuntimeError("500 Server Error: Internal Server Error"), True),
+        (requests.exceptions.ConnectionError("Max retries exceeded"), True),
+        (requests.exceptions.Timeout("read timed out"), True),
+        (RuntimeError("Could not find coverage 'emodnet:mean'"), False),
+        (RuntimeError("InvalidSubsetting: Empty intersection after subsetting"), False),
+        (RuntimeError("grid is 5000 x 5000 pixels, too large"), False),
+    ],
+)
+def test_is_wcs_service_failure_classification(exc, is_service):
+    """Service/transport failures classify True; request errors classify False."""
+    assert is_wcs_service_failure(exc) is is_service
+
+
+def test_is_wcs_service_failure_walks_the_chain():
+    """A transport error hidden under a generic wrapper is still detected."""
+    inner = requests.exceptions.ConnectionError("Connection reset by peer")
+    outer = RuntimeError("from_wcs failed")
+    outer.__cause__ = inner
+    assert is_wcs_service_failure(outer) is True
 
 
 def test_griddap_row_never_calls_from_wcs(

--- a/libs/providers/ocean/tests/usgs_water/test_usgs_water_e2e.py
+++ b/libs/providers/ocean/tests/usgs_water/test_usgs_water_e2e.py
@@ -78,7 +78,7 @@ def test_daily_discharge_legacy(tmp_path: Path):
 
 @_offline_skip
 def test_statistics_monthly_legacy(tmp_path: Path):
-    """A monthly statistics pull has a value column, or skips if the window is empty."""
+    """A monthly statistics pull over a fixed historical window returns summary rows."""
     df = EarthLens(
         data_source="usgs-water",
         start="2020-01-01",
@@ -92,14 +92,16 @@ def test_statistics_monthly_legacy(tmp_path: Path):
         api="legacy",
         stat_type="monthly",
     ).download(progress_bar=False)
-    if df.empty:
-        pytest.skip("USGS returned no monthly statistics rows for the window")
+    # A fixed 2020-2021 window at a long-running gauge always has published data,
+    # so an empty result is a real regression, not transient emptiness — assert
+    # hard (mirroring the emdat / openaq stable-query e2e tests).
+    assert not df.empty
     assert "value" in df.columns
 
 
 @_offline_skip
 def test_sites_discovery_legacy(tmp_path: Path):
-    """Site discovery over a small bbox lists stations, or skips if none are returned."""
+    """Site discovery over a fixed DC bbox lists at least one long-running station."""
     df = EarthLens(
         data_source="usgs-water",
         start="2023-01-01",
@@ -111,8 +113,10 @@ def test_sites_discovery_legacy(tmp_path: Path):
         service="sites",
         api="legacy",
     ).download(progress_bar=False)
-    if df.empty:
-        pytest.skip("USGS site discovery returned no stations for the bbox")
+    # The DC bbox always contains active gauges, so an empty result is a real
+    # regression rather than transient emptiness — assert hard (mirroring the
+    # iucn known-species stable-query e2e test).
+    assert not df.empty
     assert {"site_no", "latitude", "longitude"} <= set(df.columns)
 
 

--- a/libs/providers/ocean/tests/usgs_water/test_usgs_water_e2e.py
+++ b/libs/providers/ocean/tests/usgs_water/test_usgs_water_e2e.py
@@ -56,7 +56,7 @@ def _recent_window() -> tuple[str, str]:
 
 @_offline_skip
 def test_daily_discharge_legacy(tmp_path: Path):
-    """A daily discharge pull at a known gauge returns a non-empty table."""
+    """A daily discharge pull has the right columns, or skips if the window is empty."""
     start, end = _recent_window()
     df = EarthLens(
         data_source="usgs-water",
@@ -78,7 +78,7 @@ def test_daily_discharge_legacy(tmp_path: Path):
 
 @_offline_skip
 def test_statistics_monthly_legacy(tmp_path: Path):
-    """A monthly statistics pull returns per-month summary rows."""
+    """A monthly statistics pull has a value column, or skips if the window is empty."""
     df = EarthLens(
         data_source="usgs-water",
         start="2020-01-01",
@@ -99,7 +99,7 @@ def test_statistics_monthly_legacy(tmp_path: Path):
 
 @_offline_skip
 def test_sites_discovery_legacy(tmp_path: Path):
-    """Site discovery over a small bbox returns at least one station."""
+    """Site discovery over a small bbox lists stations, or skips if none are returned."""
     df = EarthLens(
         data_source="usgs-water",
         start="2023-01-01",

--- a/libs/providers/ocean/tests/usgs_water/test_usgs_water_e2e.py
+++ b/libs/providers/ocean/tests/usgs_water/test_usgs_water_e2e.py
@@ -70,7 +70,8 @@ def test_daily_discharge_legacy(tmp_path: Path):
         sites=_SITE,
         api="legacy",
     ).download(progress_bar=False)
-    assert not df.empty
+    if df.empty:
+        pytest.skip("USGS returned no daily discharge rows for the window")
     assert {"site_no", "datetime", "value"} <= set(df.columns)
     assert (df["parameter_code"] == "00060").all()
 
@@ -91,7 +92,8 @@ def test_statistics_monthly_legacy(tmp_path: Path):
         api="legacy",
         stat_type="monthly",
     ).download(progress_bar=False)
-    assert not df.empty
+    if df.empty:
+        pytest.skip("USGS returned no monthly statistics rows for the window")
     assert "value" in df.columns
 
 
@@ -109,7 +111,8 @@ def test_sites_discovery_legacy(tmp_path: Path):
         service="sites",
         api="legacy",
     ).download(progress_bar=False)
-    assert not df.empty
+    if df.empty:
+        pytest.skip("USGS site discovery returned no stations for the bbox")
     assert {"site_no", "latitude", "longitude"} <= set(df.columns)
 
 


### PR DESCRIPTION
# Description

Follow-up to #1019 (skip live e2e on upstream unavailability). Two live e2e tests failed on upstream conditions
the generic `earthlens.testing` classifier deliberately cannot/should not catch, so they get per-test handling.

- **USGS-Water** (`libs/providers/ocean/tests/usgs_water/test_usgs_water_e2e.py`): the daily / statistics / sites
  legacy tests hard-asserted `not df.empty`. An empty live frame (upstream returned nothing for the window) raised
  **no exception**, so the #1019 skip hook could not act — the result flipped run-to-run. Now an empty result is a
  `pytest.skip` with a clear reason.
- **EMODnet WCS** (`libs/providers/land/…/bathymetry`): a degraded service (a non-XML `GetCapabilities` body, a
  5xx / gateway error, a dropped connection) was wrapped by the backend as a generic domain `ValueError`, which the
  classifier intentionally does not match (matching arbitrary `ValueError`s would mask real bugs — out of scope per
  #1024). The backend now raises a typed **`WcsServiceUnavailableError`** for transport/service failures only, and
  the e2e test skips on it, mirroring the OSM backend's `OhsomeUnavailableError` pattern. Genuine request errors
  (unknown coverage, empty subset intersection) stay a `ValueError`.

The new `is_wcs_service_failure` helper walks the exception cause/context chain and classifies conservatively:
transport exception types, a 5xx/408/429 in an HTTP context, or a service signature (`non-XML body`,
`Empty reply from server`, dropped connection, DNS failure). A stray number (a pixel count, a coordinate) does not
trip it.

Dependencies: none.

# Issues

- Closes #1024 — USGS-Water empty-result and EMODnet WCS failures should skip, not fail

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- **Bathymetry unit suite** (offline, faked `from_wcs`): **106 passed**, bathymetry `src/` coverage **100%**
  line+branch. New unit tests cover the service-vs-request classification, the typed error on service failures,
  and that a request error stays a `ValueError`.
- **Live happy paths unaffected**: `pytest -m "e2e and bathymetry"` → 1 passed; `pytest -m "e2e and usgs_water"`
  → 3 passed, 1 token-skipped.
- **Skip paths verified**: `_skip_on_service` skips on `WcsServiceUnavailableError` / `requests` transport errors
  and re-raises a real `ValueError`; the USGS empty guard skips before the column assertions.
- ruff check + ruff format + `mypy` (400 files) all clean.

Repro:

```bash
uv sync --extra all --group dev
pytest libs/providers/land/tests/bathymetry -m "not e2e" -q          # unit, 100% cov
pytest -m "e2e and bathymetry" -q                                    # live happy path
pytest -m "e2e and usgs_water" -q                                    # live happy path
```

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
