### PR TITLE
fix(overture): resolve the release live instead of globbing the bundled pin

### DIFF
--- a/docs/examples/overture/06_multi_theme_download.ipynb
+++ b/docs/examples/overture/06_multi_theme_download.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Overture — multi-theme download (live)\n",
     "\n",
-    "A single request can pull several themes / types at once; one file is written per feature type. Here we grab places and building footprints for the same block, pinning a release for reproducibility."
+    "A single request can pull several themes / types at once; one file is written per feature type. Here we grab places and building footprints for the same block, targeting the release Overture publishes right now."
    ]
   },
   {
@@ -17,7 +17,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "Pull in the pieces we need: `Catalog` to discover the latest Overture release, the `EarthLens` entry point to run the download, and `geopandas` to inspect the written GeoParquet files."
+    "Pull in the pieces we need: the `EarthLens` entry point to run the download, `releases` to see which Overture release the download will target, and `geopandas` to inspect the written GeoParquet files."
    ]
   },
   {
@@ -30,7 +30,7 @@
     "import geopandas as gpd\n",
     "\n",
     "from earthlens.core import EarthLens\n",
-    "from earthlens.overture import Catalog"
+    "from earthlens.overture import releases"
    ]
   },
   {
@@ -60,9 +60,11 @@
    "id": "5",
    "metadata": {},
    "source": [
-    "## Pin a release\n",
+    "## Which release will this read?\n",
     "\n",
-    "Resolve the most recent Overture release id and pin it, so the download is reproducible even after Overture publishes a newer snapshot."
+    "Overture publishes a dated release roughly monthly and keeps only the newest one or two on S3, pruning the rest — so a release id is a moving target, and an id that worked last quarter may no longer exist. Leaving `release=None` (the default) targets whatever is published now, which is what we want here.\n",
+    "\n",
+    "You *can* pin a release when you need a byte-reproducible download, but the pin holds only while that release is still on S3; once it is pruned the fetch fails with `No files found that match the pattern`. Ask Overture what it is serving today:"
    ]
   },
   {
@@ -72,8 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catalog = Catalog()\n",
-    "release = catalog.latest_release()  # pin for reproducibility\n",
+    "release = releases.latest_release()\n",
     "release"
    ]
   },
@@ -99,7 +100,6 @@
     "    variables={\"places\": [], \"buildings\": []},\n",
     "    aoi=[LON_LIM[0], LAT_LIM[0], LON_LIM[1], LAT_LIM[1]],\n",
     "    path=OUT,\n",
-    "    release=release,\n",
     ")\n",
     "paths = engine.download()\n",
     "[p.name for p in paths]"

--- a/docs/reference/overture/datasets.md
+++ b/docs/reference/overture/datasets.md
@@ -15,7 +15,7 @@ cat = Catalog()
 cat.themes()                       # ['buildings', 'divisions', 'places', 'transportation']
 cat.get_theme("buildings").types   # ['building', 'building_part']
 cat.available_types()              # all 15 Overture types (curated + deferred)
-cat.available_releases             # ['2026-05-20.0', '2026-04-15.0']
+cat.available_releases             # ['2026-07-22.0']
 ```
 
 ## Curated vs available
@@ -127,10 +127,19 @@ address datasets and OSM.
 ## Releases
 
 Overture publishes a new **release** roughly monthly, identified
-`yyyy-mm-dd.x`. The bundled `available_releases:` index is informational
-(rebuilt by the [refresh tool](usage.md#catalog-tooling)); the SDK
-auto-targets the newest release when `release=None`. Pin a `release` for
-reproducible downloads.
+`yyyy-mm-dd.x`, and keeps only the newest one (or two) on S3 — older
+releases are pruned from the bucket and their paths stop resolving.
+
+`release=None` (the default) therefore targets whatever Overture publishes
+*now*: the SDK auto-targets it on the default fetch path, and the DuckDB
+`where=` / `columns=` path resolves it live before building the S3 glob.
+The bundled `available_releases:` index is informational (rebuilt by the
+[refresh tool](usage.md#catalog-tooling)) and serves only as an offline
+fallback.
+
+Pin a `release` when you need a byte-reproducible download, and expect the
+pin to stop resolving once Overture prunes that release — a pinned id is
+reproducible only for as long as it exists upstream.
 
 ## Coverage
 

--- a/docs/reference/overture/datasets.md
+++ b/docs/reference/overture/datasets.md
@@ -15,7 +15,7 @@ cat = Catalog()
 cat.themes()                       # ['buildings', 'divisions', 'places', 'transportation']
 cat.get_theme("buildings").types   # ['building', 'building_part']
 cat.available_types()              # all 15 Overture types (curated + deferred)
-cat.available_releases             # ['2026-07-22.0']
+cat.available_releases             # ['2026-06-17.0', '2026-07-22.0']
 ```
 
 ## Curated vs available

--- a/docs/reference/overture/introduction.md
+++ b/docs/reference/overture/introduction.md
@@ -36,8 +36,12 @@ features, not a gridded array. Two consequences follow:
   a feature table.
 - Overture is a **static per-release snapshot** with no temporal axis, so
   `start` / `end` are accepted but ignored. Time is expressed only by the
-  **release** (`yyyy-mm-dd.x`); the SDK auto-targets the newest release
-  when you do not pin one.
+  **release** (`yyyy-mm-dd.x`). When you do not pin one, the newest release
+  is targeted live: the SDK auto-targets it on the default fetch path, and
+  the DuckDB (`where=` / `columns=`) path looks it up from Overture's STAC
+  catalog at `https://stac.overturemaps.org` before building its S3 glob.
+  That is a second endpoint to allow through a proxy or firewall; pin a
+  `release` to skip the lookup entirely.
 
 The output is written as **GeoParquet** by default (which preserves
 Overture's deeply-nested schema — `names`, `categories`, `sources`, … —

--- a/docs/reference/overture/usage.md
+++ b/docs/reference/overture/usage.md
@@ -48,7 +48,7 @@ parquet statistics — no DuckDB), so only the rows inside the box are read.
 
 | Kwarg | Default | Meaning |
 |-------|---------|---------|
-| `release` | `None` | Overture release id (`"2026-05-20.0"`). `None` lets the SDK auto-target the newest release. List them with the refresh tool or `Catalog().available_releases`. |
+| `release` | `None` | Overture release id (`"2026-07-22.0"`). `None` targets the release Overture publishes now — auto-targeted by the SDK on the default path, resolved live on the DuckDB path. List them with the refresh tool or `Catalog().available_releases`. Pinning is reproducible only until Overture prunes that release from S3. |
 | `file_format` | `"geoparquet"` | Output format: `"geoparquet"` (default, lossless nested schema), `"gpkg"`, or `"geojson"`. |
 | `max_features` | `None` | Cap on rows kept per fetched type. When set, the read **streams** (via `record_batch_reader`) and stops early once the cap is reached, rather than fetching the whole bbox and discarding rows. `None` keeps all. |
 | `stream` | `False` | Force the streaming `record_batch_reader` path (lower peak memory) even without `max_features`. Streaming is used automatically whenever `max_features` is set. |
@@ -92,7 +92,7 @@ EarthLens(
 feature type. Filenames embed the theme, type, and release:
 
 ```
-out/overture_buildings_building_2026-05-20.0.parquet
+out/overture_buildings_building_2026-07-22.0.parquet
 out/overture_places_place_latest.parquet
 ```
 
@@ -115,19 +115,25 @@ the size guard protects you from misusing.
 
 ## Catalog tooling
 
-`tools/overture/refresh_overture_catalog.py` maintains the bundled
-catalog:
+The `earthlens datasets` commands maintain the bundled catalog:
 
 ```bash
-# Rewrite the available_releases index from the live SDK / STAC catalog
-uv run python tools/overture/refresh_overture_catalog.py refresh
+# Diff the live SDK / STAC release list against the bundled index
+earthlens datasets refresh overture
+
+# ... and rewrite the available_releases index from it
+earthlens datasets refresh overture --write
 
 # Confirm every curated theme/default-type resolves against live data
-uv run python tools/overture/refresh_overture_catalog.py validate --strict
+earthlens datasets validate overture --live
 
 # Inspect one type's columns when curating a new theme
-uv run python tools/overture/refresh_overture_catalog.py probe building
+earthlens datasets probe overture building
 ```
+
+Run the refresh whenever a DuckDB fetch reports `No files found that match
+the pattern`: it reports how far the bundled index has drifted from what
+Overture still serves.
 
 ## Streaming vs in-memory reads
 

--- a/docs/reference/overture/usage.md
+++ b/docs/reference/overture/usage.md
@@ -96,6 +96,27 @@ out/overture_buildings_building_2026-07-22.0.parquet
 out/overture_places_place_latest.parquet
 ```
 
+Which of the two you get follows one rule: **a name carries a release id when
+the backend knows it**, and `latest` when it does not.
+
+| Fetch | Filename stamp |
+|-------|----------------|
+| Any fetch with `release=` pinned | the pinned id |
+| Unpinned `where=` / `columns=` (DuckDB) | the release resolved for the glob |
+| Unpinned plain fetch (SDK) | `latest` |
+
+The SDK path is the odd one out because it hands `release=None` to the SDK and
+is never told which snapshot answered. Two consequences worth knowing:
+
+- A `_latest` file is **overwritten** by the next run, including across a
+  monthly rollover — convenient for a scratch directory, lossy if you meant to
+  keep both. A release-stamped file is not, so an unpinned DuckDB fetch
+  accumulates one file per release rather than overwriting.
+- The stamp does not encode `where=` / `columns=`, so a filtered and an
+  unfiltered fetch of the same theme, type, and release write to the **same
+  path** and the second silently replaces the first. Give them separate
+  `path=` directories when you need both.
+
 Every output carries a per-row **`license_id`** column and is tagged
 `EPSG:4326`. The SDK returns a CRS-less frame, so the backend sets the CRS
 explicitly before writing.
@@ -131,13 +152,20 @@ earthlens datasets validate overture --live
 earthlens datasets probe overture building
 ```
 
-`No files found that match the pattern` from a DuckDB fetch means the
-release being globbed holds no objects. With a pinned `release` that means
-the pin has been pruned — drop the pin, or move it to a live id (the
-refresh above lists them). Unpinned, the release is resolved live, so it
-means the lookup could not reach `https://stac.overturemaps.org` and the
-backend fell back to the bundled index; the preceding `WARNING` in the log
-says so, and refreshing the index will not fix it.
+`No files found that match the pattern` from a DuckDB fetch means the release
+being globbed holds no objects on S3. It has more than one cause, and the log
+line just above it tells you which:
+
+- **A pinned release that has been pruned.** Drop the pin, or move it to one
+  Overture still publishes — the refresh above lists them. Most common.
+- **The live lookup failed and the backend fell back to the bundled index.**
+  A `WARNING` naming the bundled id precedes the error. This is a
+  reachability problem with `https://stac.overturemaps.org`, not an index
+  problem, so refreshing will not fix it.
+- **A theme/type that exists but is empty for that release** — rare, and the
+  bbox guard usually catches the mistake first.
+
+Refreshing the index is the right first move only for the first cause.
 
 ## Streaming vs in-memory reads
 

--- a/docs/reference/overture/usage.md
+++ b/docs/reference/overture/usage.md
@@ -131,9 +131,13 @@ earthlens datasets validate overture --live
 earthlens datasets probe overture building
 ```
 
-Run the refresh whenever a DuckDB fetch reports `No files found that match
-the pattern`: it reports how far the bundled index has drifted from what
-Overture still serves.
+`No files found that match the pattern` from a DuckDB fetch means the
+release being globbed holds no objects. With a pinned `release` that means
+the pin has been pruned — drop the pin, or move it to a live id (the
+refresh above lists them). Unpinned, the release is resolved live, so it
+means the lookup could not reach `https://stac.overturemaps.org` and the
+backend fell back to the bundled index; the preceding `WARNING` in the log
+says so, and refreshing the index will not fix it.
 
 ## Streaming vs in-memory reads
 
@@ -192,8 +196,10 @@ Notes:
 
 - **No DuckDB attribute pushdown without `where=`** — the plain fetch path uses
   the SDK's PyArrow bbox pushdown only; attribute filtering needs `where=`.
-- **No temporal axis** — pin a `release` for reproducibility; `None` drifts
-  to the newest monthly release.
+- **No temporal axis** — pin a `release` for reproducibility; `None` follows
+  the newest monthly release. A pin is reproducible only while that release
+  exists: Overture keeps the newest one (or two) on S3 and prunes the rest,
+  after which the pinned id resolves to nothing.
 - **`base` types carry mixed geometries** — `land` / `water` /
   `infrastructure` return a mix of polygons, lines, and points. Filter
   `geometry.geom_type` client-side if you need a single kind.

--- a/libs/providers/hazards/src/earthlens/overture/backend.py
+++ b/libs/providers/hazards/src/earthlens/overture/backend.py
@@ -315,8 +315,9 @@ class Overture(AbstractDataSource):
         prunes the rest, so a bundled id goes stale within weeks. Globbing
         a pruned release matches no files and DuckDB fails the read with
         `No files found that match the pattern`. The bundled index stays
-        as an offline fallback, and the SDK caches the lookup per process
-        — successful lookups only, so an offline caller re-attempts it.
+        as an offline fallback. The SDK caches the lookup per process,
+        but only successful ones, so `_fetch` resolves once up front rather
+        than per requested type.
 
         What the SDK reports is checked against `RELEASE_ID` before it is
         used. `get_latest_release()` reads one key out of the upstream
@@ -467,6 +468,12 @@ class Overture(AbstractDataSource):
             self.space.north,
         )
         written: list[Path] = []
+        # Resolved once, before the loop: a mid-loop recovery from a failed
+        # lookup would otherwise read the first types from the bundled release
+        # and the rest from the live one, so a single download() could mix two
+        # snapshots. Offline callers also pay one connect attempt, not one per
+        # requested type — the SDK caches only successful lookups.
+        release = self._resolve_release() if (self._where or self._columns) else None
         for product in products:
             theme_name = product.metadata["theme_name"]
             overture_type = product.metadata["type"]
@@ -474,7 +481,6 @@ class Overture(AbstractDataSource):
             if self._where or self._columns:
                 from earthlens.overture.query import query_overture
 
-                release = self._resolve_release()
                 logger.info(
                     f"Querying Overture {overture_type!r} (theme {theme_name!r}) "
                     f"via DuckDB for bbox {bbox} (release={release}, "

--- a/libs/providers/hazards/src/earthlens/overture/backend.py
+++ b/libs/providers/hazards/src/earthlens/overture/backend.py
@@ -185,7 +185,8 @@ class Overture(AbstractDataSource):
         Raises:
             TypeError: If `variables` is not a mapping of theme -> types.
             ValueError: If `file_format` is not one of the supported
-                formats, or `variables` is empty.
+                formats, `variables` is empty, or `release` is not shaped
+                like an Overture release id.
             ImportError: If the `overturemaps` SDK is not installed.
         """
         if not isinstance(variables, dict):
@@ -203,6 +204,14 @@ class Overture(AbstractDataSource):
         if file_format not in _FORMATS:
             raise ValueError(
                 f"file_format must be one of {sorted(_FORMATS)}, got {file_format!r}."
+            )
+        if release is not None and not RELEASE_ID.match(release):
+            raise ValueError(
+                f"release must be an Overture release id, got {release!r}. "
+                "Ids are a release date plus an ordinal, e.g. "
+                "'2026-07-22.0'; list the known ones with "
+                "Catalog().available_releases. Leave it None to target "
+                "whatever Overture publishes now."
             )
         self._release = release
         self._max_features = max_features

--- a/libs/providers/hazards/src/earthlens/overture/backend.py
+++ b/libs/providers/hazards/src/earthlens/overture/backend.py
@@ -529,7 +529,7 @@ class Overture(AbstractDataSource):
                     f"{label}: no features matched the bbox; nothing written."
                 )
                 continue
-            out_path = self._write(collection, theme_name, overture_type)
+            out_path = self._write(collection, theme_name, overture_type, release)
             logger.info(f"{label}: wrote {len(collection)} feature(s) to {out_path}")
             written.append(out_path)
         return written
@@ -539,25 +539,38 @@ class Overture(AbstractDataSource):
         collection: FeatureCollection,
         theme_name: str,
         overture_type: str,
+        release: str | None = None,
     ) -> Path:
         """Write one type's FeatureCollection to a vector file under `root_dir`.
 
         The filename embeds the theme, type, and release
-        (`overture_<theme>_<type>_<release>.<ext>`) so successive
-        downloads land in distinct files. GeoParquet (the default) is
-        written with `to_parquet` to preserve Overture's nested schema;
-        GPKG / GeoJSON go through `to_file`.
+        (`overture_<theme>_<type>_<release>.<ext>`). Overture has no
+        temporal axis — the release *is* the version — so naming it is
+        what keeps successive downloads in distinct files across a
+        monthly rollover.
+
+        The DuckDB path knows the concrete release it globbed and passes
+        it in. The default path cannot: it hands `release=None` to the SDK
+        and never learns which snapshot answered, so an unpinned fetch
+        there still writes `..._latest`, and a rollover overwrites the
+        previous run. GeoParquet (the default) is written with
+        `to_parquet` to preserve Overture's nested schema; GPKG / GeoJSON
+        go through `to_file`.
 
         Args:
             collection: The features to write.
             theme_name: Friendly theme name (for the filename).
             overture_type: Overture feature type (for the filename).
+            release: The release the rows were read from, when the caller
+                resolved one. `None` falls back to the requested
+                `release`, then to `latest`.
 
         Returns:
             Path: Absolute path of the file written.
         """
         driver, ext = _FORMATS[self._file_format]
-        stem = f"overture_{theme_name}_{overture_type}_{self._release or 'latest'}"
+        stamp = release or self._release or "latest"
+        stem = f"overture_{theme_name}_{overture_type}_{stamp}"
         out_path = self.root_dir / f"{stem}.{ext}"
         if driver == "parquet":
             collection.to_parquet(str(out_path))

--- a/libs/providers/hazards/src/earthlens/overture/backend.py
+++ b/libs/providers/hazards/src/earthlens/overture/backend.py
@@ -323,6 +323,12 @@ class Overture(AbstractDataSource):
         Raises:
             RuntimeError: If the live lookup fails and the bundled index
                 is empty, leaving no release to glob.
+
+        See Also:
+            earthlens.overture.catalog.Catalog.latest_release: The offline
+                fallback this reads when the live lookup fails.
+            earthlens.overture.query.build_query: Builds the S3 glob from
+                the resolved release.
         """
         if self._release:
             return self._release

--- a/libs/providers/hazards/src/earthlens/overture/backend.py
+++ b/libs/providers/hazards/src/earthlens/overture/backend.py
@@ -46,7 +46,7 @@ from earthlens.base import (
     TemporalExtent,
     to_datetime,
 )
-from earthlens.overture.catalog import Catalog, Theme
+from earthlens.overture.catalog import RELEASE_ID, Catalog, Theme
 
 if TYPE_CHECKING:
     from pyramids.feature.collection import FeatureCollection
@@ -315,7 +315,17 @@ class Overture(AbstractDataSource):
         prunes the rest, so a bundled id goes stale within weeks. Globbing
         a pruned release matches no files and DuckDB fails the read with
         `No files found that match the pattern`. The bundled index stays
-        as an offline fallback, and the SDK caches the lookup per process.
+        as an offline fallback, and the SDK caches the lookup per process
+        — successful lookups only, so an offline caller re-attempts it.
+
+        What the SDK reports is checked against `RELEASE_ID` before it is
+        used. `get_latest_release()` reads one key out of the upstream
+        STAC catalog and returns `None` rather than raising when that key
+        moves, and the sibling release list already returns unparsed
+        `https:` fragments — so an unchecked value would build a glob like
+        `release/None/…` and fail with the very error this resolution
+        order exists to prevent. A value that is not release-shaped is
+        treated exactly like a failed lookup.
 
         Returns:
             str: A concrete release id (e.g. `"2026-07-22.0"`).
@@ -332,25 +342,31 @@ class Overture(AbstractDataSource):
         """
         if self._release:
             return self._release
+        cause: Exception | None = None
         try:
             from overturemaps.core import get_latest_release
 
-            return cast("str", get_latest_release())
+            live = get_latest_release()
         except Exception as exc:  # noqa: BLE001 - offline / upstream outage
-            indexed = self._catalog.latest_release()
-            if not indexed:
-                raise RuntimeError(
-                    "Could not resolve an Overture release for the DuckDB "
-                    f"query path: the live lookup failed ({exc}) and the "
-                    "bundled available_releases: index is empty. Pass an "
-                    "explicit release= (e.g. release='2026-07-22.0')."
-                ) from exc
-            logger.warning(
-                f"Live Overture release lookup failed ({exc}); falling back "
-                f"to the bundled index entry {indexed!r}. Overture prunes old "
-                "releases, so this id may no longer exist on S3."
-            )
-            return indexed
+            cause, reason = exc, f"the live lookup failed ({exc})"
+        else:
+            if live and RELEASE_ID.match(str(live)):
+                return str(live)
+            reason = f"the live lookup returned {live!r}, not a release id"
+        indexed = self._catalog.latest_release()
+        if not indexed:
+            raise RuntimeError(
+                "Could not resolve an Overture release for the DuckDB query "
+                f"path: {reason} and the bundled available_releases: index is "
+                "empty. Pass an explicit release= (e.g. "
+                "release='2026-07-22.0')."
+            ) from cause
+        logger.warning(
+            f"Could not resolve the live Overture release ({reason}); falling "
+            f"back to the bundled index entry {indexed!r}. Overture prunes old "
+            "releases, so this id may no longer exist on S3."
+        )
+        return indexed
 
     def _guard_bbox(self, theme_names: list[str]) -> None:
         """Reject an oversized / whole-Earth bbox for the guarded themes.

--- a/libs/providers/hazards/src/earthlens/overture/backend.py
+++ b/libs/providers/hazards/src/earthlens/overture/backend.py
@@ -46,7 +46,7 @@ from earthlens.base import (
     TemporalExtent,
     to_datetime,
 )
-from earthlens.overture.catalog import RELEASE_ID, Catalog, Theme
+from earthlens.overture.catalog import RELEASE_ID_RE, Catalog, Theme
 
 if TYPE_CHECKING:
     from pyramids.feature.collection import FeatureCollection
@@ -205,7 +205,7 @@ class Overture(AbstractDataSource):
             raise ValueError(
                 f"file_format must be one of {sorted(_FORMATS)}, got {file_format!r}."
             )
-        if release is not None and not RELEASE_ID.match(release):
+        if release is not None and not RELEASE_ID_RE.match(release):
             raise ValueError(
                 f"release must be an Overture release id, got {release!r}. "
                 "Ids are a release date plus an ordinal, e.g. "
@@ -337,7 +337,7 @@ class Overture(AbstractDataSource):
         SDK offers no timeout hook, so a second attempt would only double
         a stalled connect.
 
-        What the SDK reports is checked against `RELEASE_ID` before it is
+        What the SDK reports is checked against `RELEASE_ID_RE` before it is
         used. `get_latest_release()` reads one key out of the upstream
         STAC catalog and returns `None` rather than raising when that key
         moves, and the sibling release list already returns unparsed
@@ -371,7 +371,7 @@ class Overture(AbstractDataSource):
         except Exception as exc:  # noqa: BLE001 - offline / upstream outage
             cause, reason = exc, f"the live lookup failed ({exc})"
         else:
-            if live and RELEASE_ID.match(str(live)):
+            if live and RELEASE_ID_RE.match(str(live)):
                 return str(live)
             reason = f"the live lookup returned {live!r}, not a release id"
         indexed = self._catalog.latest_release()
@@ -492,13 +492,15 @@ class Overture(AbstractDataSource):
         # lookup would otherwise read the first types from the bundled release
         # and the rest from the live one, so a single download() could mix two
         # snapshots. Offline callers also pay one connect attempt, not one per
-        # requested type — the SDK caches only successful lookups.
+        # requested type — the SDK caches only successful lookups. It doubles
+        # as the branch flag below: it is set exactly when the DuckDB path is
+        # taken, which is the only path that needs a concrete id.
         release = self._resolve_release() if (self._where or self._columns) else None
         for product in products:
             theme_name = product.metadata["theme_name"]
             overture_type = product.metadata["type"]
             label = product.id
-            if self._where or self._columns:
+            if release is not None:
                 from earthlens.overture.query import query_overture
 
                 logger.info(

--- a/libs/providers/hazards/src/earthlens/overture/backend.py
+++ b/libs/providers/hazards/src/earthlens/overture/backend.py
@@ -46,7 +46,8 @@ from earthlens.base import (
     TemporalExtent,
     to_datetime,
 )
-from earthlens.overture.catalog import RELEASE_ID_RE, Catalog, Theme
+from earthlens.overture.catalog import Catalog, Theme
+from earthlens.overture.releases import ReleaseLookupError, is_release_id
 
 if TYPE_CHECKING:
     from pyramids.feature.collection import FeatureCollection
@@ -205,7 +206,7 @@ class Overture(AbstractDataSource):
             raise ValueError(
                 f"file_format must be one of {sorted(_FORMATS)}, got {file_format!r}."
             )
-        if release is not None and not RELEASE_ID_RE.match(release):
+        if release is not None and not is_release_id(release):
             raise ValueError(
                 f"release must be an Overture release id, got {release!r}. "
                 "Ids are a release date plus an ordinal, e.g. "
@@ -328,23 +329,22 @@ class Overture(AbstractDataSource):
         but only successful ones, so `_fetch` resolves once up front rather
         than per requested type.
 
-        Only an outage is absorbed. The import sits outside the `try`, and
-        `ImportError` / `AttributeError` propagate, so an SDK that has been
-        renamed or removed fails loudly instead of degrading to the stale
-        bundled id — which is issue #931 restored at `WARNING` level. The
-        catch has to stay broad for the rest because the SDK re-raises a
-        bare `Exception` for any transport error. There is no retry: the
-        SDK offers no timeout hook, so a second attempt would only double
-        a stalled connect.
+        Only a lookup failure is absorbed, and only that:
+        `earthlens.overture.releases.latest_release` raises the single
+        typed `ReleaseLookupError` for an unreachable, undecodable, or
+        nonsensical catalog, so a genuine code fault (a missing SDK
+        constant, say) propagates instead of degrading to the stale
+        bundled id — which would be issue #931 restored at `WARNING`
+        level. That read is bounded by `STAC_TIMEOUT`; the SDK's own
+        lookup is not, and an unbounded one would hang here rather than
+        fall through to the index.
 
-        What the SDK reports is checked against `RELEASE_ID_RE` before it is
-        used. `get_latest_release()` reads one key out of the upstream
-        STAC catalog and returns `None` rather than raising when that key
-        moves, and the sibling release list already returns unparsed
-        `https:` fragments — so an unchecked value would build a glob like
+        A catalog that reports something which is not release-shaped
+        counts as a failure too. Upstream's `latest` is one key in a
+        document whose sibling release list already arrives as unparsed
+        `https:` fragments, so an unchecked value would build a glob like
         `release/None/…` and fail with the very error this resolution
-        order exists to prevent. A value that is not release-shaped is
-        treated exactly like a failed lookup.
+        order exists to prevent.
 
         Returns:
             str: A concrete release id (e.g. `"2026-07-22.0"`).
@@ -361,26 +361,19 @@ class Overture(AbstractDataSource):
         """
         if self._release:
             return self._release
-        from overturemaps.core import get_latest_release
+        from earthlens.overture.releases import latest_release
 
-        cause: Exception | None = None
         try:
-            live = get_latest_release()
-        except (ImportError, AttributeError):
-            raise
-        except Exception as exc:  # noqa: BLE001 - offline / upstream outage
-            cause, reason = exc, f"the live lookup failed ({exc})"
-        else:
-            if live and RELEASE_ID_RE.match(str(live)):
-                return str(live)
-            reason = f"the live lookup returned {live!r}, not a release id"
+            return latest_release()
+        except ReleaseLookupError as exc:
+            cause, reason = exc, str(exc)
         indexed = self._catalog.latest_release()
         if not indexed:
             raise RuntimeError(
                 "Could not resolve an Overture release for the DuckDB query "
-                f"path: {reason} and the bundled available_releases: index is "
-                "empty. Pass an explicit release= (e.g. "
-                "release='2026-07-22.0')."
+                f"path: {reason}, and the bundled available_releases: index "
+                "is empty. Pass an explicit release= — the ids Overture "
+                "publishes are listed at https://stac.overturemaps.org."
             ) from cause
         logger.warning(
             f"Could not resolve the live Overture release ({reason}); falling "

--- a/libs/providers/hazards/src/earthlens/overture/backend.py
+++ b/libs/providers/hazards/src/earthlens/overture/backend.py
@@ -152,8 +152,12 @@ class Overture(AbstractDataSource):
                 Created by the parent class if absent.
             fmt: `strptime` format for `start` / `end` (only used when
                 they are supplied, for record-keeping).
-            release: Overture release id (`"2026-05-20.0"`). `None` (the
-                default) lets the SDK auto-target the newest release.
+            release: Overture release id (`"2026-07-22.0"`). `None` (the
+                default) targets the newest release Overture publishes —
+                the SDK auto-targets it on the default fetch path, and the
+                DuckDB path resolves it live (see `_resolve_release`). Pin
+                it only for reproducibility, and expect a pinned id to stop
+                resolving once Overture prunes that release from S3.
             max_features: Optional cap on the rows kept per fetched type;
                 excess rows are dropped with a warning. `None` keeps all.
             file_format: Output vector format — `"geoparquet"` (default,
@@ -300,22 +304,47 @@ class Overture(AbstractDataSource):
     def _resolve_release(self) -> str:
         """Resolve a concrete release id for the DuckDB S3 path.
 
-        Uses the explicit `release` if given, else the newest entry in the
-        catalog's bundled index, else asks the SDK for the latest release.
-        The DuckDB path needs a concrete id (the `geodataframe` path can
-        leave it `None` and let the SDK pick latest, but the S3 glob can't).
+        Uses the explicit `release` if given, else asks the SDK which
+        release Overture currently publishes, else falls back to the
+        newest entry in the catalog's bundled index. The DuckDB path
+        needs a concrete id (the `geodataframe` path can leave it `None`
+        and let the SDK pick latest, but the S3 glob cannot).
+
+        The live lookup comes first because Overture keeps only the
+        newest release (or two) on `s3://overturemaps-us-west-2` and
+        prunes the rest, so a bundled id goes stale within weeks. Globbing
+        a pruned release matches no files and DuckDB fails the read with
+        `No files found that match the pattern`. The bundled index stays
+        as an offline fallback, and the SDK caches the lookup per process.
 
         Returns:
-            str: A concrete release id (e.g. `"2026-05-20.0"`).
+            str: A concrete release id (e.g. `"2026-07-22.0"`).
+
+        Raises:
+            RuntimeError: If the live lookup fails and the bundled index
+                is empty, leaving no release to glob.
         """
         if self._release:
             return self._release
-        indexed = self._catalog.latest_release()
-        if indexed:
-            return indexed
-        from overturemaps.core import get_latest_release
+        try:
+            from overturemaps.core import get_latest_release
 
-        return cast("str", get_latest_release())
+            return cast("str", get_latest_release())
+        except Exception as exc:  # noqa: BLE001 - offline / upstream outage
+            indexed = self._catalog.latest_release()
+            if not indexed:
+                raise RuntimeError(
+                    "Could not resolve an Overture release for the DuckDB "
+                    f"query path: the live lookup failed ({exc}) and the "
+                    "bundled available_releases: index is empty. Pass an "
+                    "explicit release= (e.g. release='2026-07-22.0')."
+                ) from exc
+            logger.warning(
+                f"Live Overture release lookup failed ({exc}); falling back "
+                f"to the bundled index entry {indexed!r}. Overture prunes old "
+                "releases, so this id may no longer exist on S3."
+            )
+            return indexed
 
     def _guard_bbox(self, theme_names: list[str]) -> None:
         """Reject an oversized / whole-Earth bbox for the guarded themes.

--- a/libs/providers/hazards/src/earthlens/overture/backend.py
+++ b/libs/providers/hazards/src/earthlens/overture/backend.py
@@ -209,10 +209,10 @@ class Overture(AbstractDataSource):
         if release is not None and not is_release_id(release):
             raise ValueError(
                 f"release must be an Overture release id, got {release!r}. "
-                "Ids are a release date plus an ordinal, e.g. "
-                "'2026-07-22.0'; list the known ones with "
-                "Catalog().available_releases. Leave it None to target "
-                "whatever Overture publishes now."
+                "Ids are a release date plus an ordinal (yyyy-mm-dd.n); "
+                "list the ones Overture publishes with "
+                "earthlens.overture.releases.child_release_ids(). Leave it "
+                "None to target whatever is published now."
             )
         self._release = release
         self._max_features = max_features
@@ -485,26 +485,28 @@ class Overture(AbstractDataSource):
         # lookup would otherwise read the first types from the bundled release
         # and the rest from the live one, so a single download() could mix two
         # snapshots. Offline callers also pay one connect attempt, not one per
-        # requested type — the SDK caches only successful lookups. It doubles
-        # as the branch flag below: it is set exactly when the DuckDB path is
-        # taken, which is the only path that needs a concrete id.
-        release = self._resolve_release() if (self._where or self._columns) else None
+        # requested type. Its name says what it is: the release the DuckDB
+        # path will glob, present exactly when that path is taken, which is
+        # the only path needing a concrete id.
+        duckdb_release = (
+            self._resolve_release() if (self._where or self._columns) else None
+        )
         for product in products:
             theme_name = product.metadata["theme_name"]
             overture_type = product.metadata["type"]
             label = product.id
-            if release is not None:
+            if duckdb_release is not None:
                 from earthlens.overture.query import query_overture
 
                 logger.info(
                     f"Querying Overture {overture_type!r} (theme {theme_name!r}) "
-                    f"via DuckDB for bbox {bbox} (release={release}, "
+                    f"via DuckDB for bbox {bbox} (release={duckdb_release}, "
                     f"where={self._where!r})"
                 )
                 gdf = query_overture(
                     theme_name,
                     overture_type,
-                    release,
+                    duckdb_release,
                     bbox,
                     where=self._where,
                     columns=self._columns,
@@ -533,7 +535,9 @@ class Overture(AbstractDataSource):
                     f"{label}: no features matched the bbox; nothing written."
                 )
                 continue
-            out_path = self._write(collection, theme_name, overture_type, release)
+            out_path = self._write(
+                collection, theme_name, overture_type, duckdb_release
+            )
             logger.info(f"{label}: wrote {len(collection)} feature(s) to {out_path}")
             written.append(out_path)
         return written

--- a/libs/providers/hazards/src/earthlens/overture/backend.py
+++ b/libs/providers/hazards/src/earthlens/overture/backend.py
@@ -319,6 +319,15 @@ class Overture(AbstractDataSource):
         but only successful ones, so `_fetch` resolves once up front rather
         than per requested type.
 
+        Only an outage is absorbed. The import sits outside the `try`, and
+        `ImportError` / `AttributeError` propagate, so an SDK that has been
+        renamed or removed fails loudly instead of degrading to the stale
+        bundled id — which is issue #931 restored at `WARNING` level. The
+        catch has to stay broad for the rest because the SDK re-raises a
+        bare `Exception` for any transport error. There is no retry: the
+        SDK offers no timeout hook, so a second attempt would only double
+        a stalled connect.
+
         What the SDK reports is checked against `RELEASE_ID` before it is
         used. `get_latest_release()` reads one key out of the upstream
         STAC catalog and returns `None` rather than raising when that key
@@ -343,11 +352,13 @@ class Overture(AbstractDataSource):
         """
         if self._release:
             return self._release
+        from overturemaps.core import get_latest_release
+
         cause: Exception | None = None
         try:
-            from overturemaps.core import get_latest_release
-
             live = get_latest_release()
+        except (ImportError, AttributeError):
+            raise
         except Exception as exc:  # noqa: BLE001 - offline / upstream outage
             cause, reason = exc, f"the live lookup failed ({exc})"
         else:

--- a/libs/providers/hazards/src/earthlens/overture/catalog.py
+++ b/libs/providers/hazards/src/earthlens/overture/catalog.py
@@ -31,6 +31,7 @@ the path to the bundled YAML.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, cast
 
@@ -41,6 +42,12 @@ from earthlens.base.catalog_source import load_catalog
 from earthlens.base.yaml_loader import CatalogParseCache, load_yaml_strict
 
 CATALOG_PATH: Path = Path(__file__).parent / "overture_data_catalog.yaml"
+
+#: Shape of an Overture release id: a release date plus an ordinal
+#: (`2026-07-22.0`). The single definition of what counts as a release id —
+#: `latest_release` ignores anything that does not match, and the refresh
+#: tooling refuses to index it.
+RELEASE_ID = re.compile(r"^\d{4}-\d{2}-\d{2}\.\d+$")
 
 #: Module-level parse cache keyed on `(resolved_path, st_mtime_ns)` so a
 #: repeated `Catalog()` skips the YAML parse + pydantic validation. Stores the
@@ -60,8 +67,8 @@ def _release_sort_key(release: str) -> tuple[str, int]:
     Release ids are `yyyy-mm-dd.n`, so a plain string sort mis-orders
     the ordinal once it reaches two digits (`"2026-07-22.10"` sorts
     below `"2026-07-22.9"`). Splitting the ordinal off and comparing it
-    numerically fixes that; an id that does not carry a numeric ordinal
-    sorts below every id from the same date.
+    numerically fixes that. Callers filter through `RELEASE_ID` first, so
+    the ordinal is always numeric here.
 
     Args:
         release: A release id (`"2026-07-22.0"`).
@@ -79,7 +86,7 @@ def _release_sort_key(release: str) -> tuple[str, int]:
             ```
     """
     date, _, ordinal = release.partition(".")
-    return date, int(ordinal) if ordinal.isdigit() else -1
+    return date, int(ordinal)
 
 
 class Theme(BaseModel):
@@ -404,6 +411,8 @@ class Catalog(AbstractCatalog):
         rather than by position, so the index may be stored in any order
         — `earthlens datasets refresh overture --write` persists it
         ascending, while it was originally hand-written newest-first.
+        Entries that are not shaped like a release id are ignored, so a
+        malformed index yields `None` rather than a bogus release.
 
         The result is a stale-by-construction fallback: Overture prunes
         old releases from S3, so the backend prefers the release the SDK
@@ -434,4 +443,8 @@ class Catalog(AbstractCatalog):
 
                 ```
         """
-        return max(self.available_releases, key=_release_sort_key, default=None)
+        return max(
+            (r for r in self.available_releases if RELEASE_ID.match(r)),
+            key=_release_sort_key,
+            default=None,
+        )

--- a/libs/providers/hazards/src/earthlens/overture/catalog.py
+++ b/libs/providers/hazards/src/earthlens/overture/catalog.py
@@ -44,10 +44,13 @@ from earthlens.base.yaml_loader import CatalogParseCache, load_yaml_strict
 CATALOG_PATH: Path = Path(__file__).parent / "overture_data_catalog.yaml"
 
 #: Shape of an Overture release id: a release date plus an ordinal
-#: (`2026-07-22.0`). The single definition of what counts as a release id —
-#: `latest_release` ignores anything that does not match, and the refresh
-#: tooling refuses to index it.
-RELEASE_ID = re.compile(r"^\d{4}-\d{2}-\d{2}\.\d+$")
+#: (`2026-07-22.0`). The single definition of what a release id looks like —
+#: `latest_release` ignores anything that does not match, the backend rejects
+#: a `release=` that does not, and the refresh tooling refuses to index one.
+#: It is a *shape* check, not an existence one: `9999-99-99.0` matches and
+#: would sort above every real release, so it guards against garbage and
+#: typos, not against an id Overture has pruned.
+RELEASE_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}\.\d+$")
 
 #: Module-level parse cache keyed on `(resolved_path, st_mtime_ns)` so a
 #: repeated `Catalog()` skips the YAML parse + pydantic validation. Stores the
@@ -67,7 +70,7 @@ def _release_sort_key(release: str) -> tuple[str, int]:
     Release ids are `yyyy-mm-dd.n`, so a plain string sort mis-orders
     the ordinal once it reaches two digits (`"2026-07-22.10"` sorts
     below `"2026-07-22.9"`). Splitting the ordinal off and comparing it
-    numerically fixes that. Callers filter through `RELEASE_ID` first, so
+    numerically fixes that. Callers filter through `RELEASE_ID_RE` first, so
     the ordinal is always numeric here.
 
     Args:
@@ -469,7 +472,7 @@ class Catalog(AbstractCatalog):
                 live release and falls back to this one.
         """
         return max(
-            (r for r in self.available_releases if RELEASE_ID.match(r)),
+            (r for r in self.available_releases if RELEASE_ID_RE.match(r)),
             key=_release_sort_key,
             default=None,
         )

--- a/libs/providers/hazards/src/earthlens/overture/catalog.py
+++ b/libs/providers/hazards/src/earthlens/overture/catalog.py
@@ -31,7 +31,6 @@ the path to the bundled YAML.
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 from typing import Any, cast
 
@@ -40,17 +39,10 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from earthlens.base import AbstractCatalog
 from earthlens.base.catalog_source import load_catalog
 from earthlens.base.yaml_loader import CatalogParseCache, load_yaml_strict
+from earthlens.overture.releases import is_release_id
 
 CATALOG_PATH: Path = Path(__file__).parent / "overture_data_catalog.yaml"
 
-#: Shape of an Overture release id: a release date plus an ordinal
-#: (`2026-07-22.0`). The single definition of what a release id looks like —
-#: `latest_release` ignores anything that does not match, the backend rejects
-#: a `release=` that does not, and the refresh tooling refuses to index one.
-#: It is a *shape* check, not an existence one: `9999-99-99.0` matches and
-#: would sort above every real release, so it guards against garbage and
-#: typos, not against an id Overture has pruned.
-RELEASE_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}\.\d+$")
 
 #: Module-level parse cache keyed on `(resolved_path, st_mtime_ns)` so a
 #: repeated `Catalog()` skips the YAML parse + pydantic validation. Stores the
@@ -70,7 +62,7 @@ def _release_sort_key(release: str) -> tuple[str, int]:
     Release ids are `yyyy-mm-dd.n`, so a plain string sort mis-orders
     the ordinal once it reaches two digits (`"2026-07-22.10"` sorts
     below `"2026-07-22.9"`). Splitting the ordinal off and comparing it
-    numerically fixes that. Callers filter through `RELEASE_ID_RE` first, so
+    numerically fixes that. Callers filter through `is_release_id` first, so
     the ordinal is always numeric here.
 
     Args:
@@ -472,7 +464,7 @@ class Catalog(AbstractCatalog):
                 live release and falls back to this one.
         """
         return max(
-            (r for r in self.available_releases if RELEASE_ID_RE.match(r)),
+            (r for r in self.available_releases if is_release_id(r)),
             key=_release_sort_key,
             default=None,
         )

--- a/libs/providers/hazards/src/earthlens/overture/catalog.py
+++ b/libs/providers/hazards/src/earthlens/overture/catalog.py
@@ -270,7 +270,10 @@ class Catalog(AbstractCatalog):
             themes) — the full queryable universe the curated themes are a
             subset of. Rebuilt by the refresh tool.
         available_releases: Overture release identifiers (`yyyy-mm-dd.x`),
-            newest first, from the bundled YAML's informational index.
+            from the bundled YAML's informational index, in whatever
+            order the refresh tooling wrote them. `latest_release`
+            picks the newest by date and ordinal rather than by
+            position, so the order here is not load-bearing.
 
     Examples:
         - List themes and resolve one:

--- a/libs/providers/hazards/src/earthlens/overture/catalog.py
+++ b/libs/providers/hazards/src/earthlens/overture/catalog.py
@@ -447,15 +447,17 @@ class Catalog(AbstractCatalog):
                 True
 
                 ```
-            - Position in the index does not decide the winner:
+            - Position in the index does not decide the winner (these ids
+              are deliberately unlike the bundled ones, so the answer can
+              only have come from the list supplied here):
                 ```python
                 >>> from earthlens.overture import Catalog
                 >>> cat = Catalog(
                 ...     datasets={},
-                ...     available_releases=["2026-06-17.0", "2026-07-22.0"],
+                ...     available_releases=["2031-03-03.0", "2030-01-01.0"],
                 ... )
                 >>> cat.latest_release()
-                '2026-07-22.0'
+                '2031-03-03.0'
 
                 ```
 

--- a/libs/providers/hazards/src/earthlens/overture/catalog.py
+++ b/libs/providers/hazards/src/earthlens/overture/catalog.py
@@ -84,6 +84,24 @@ def _release_sort_key(release: str) -> tuple[str, int]:
             True
 
             ```
+        - The key splits an id into the pair it sorts on:
+            ```python
+            >>> from earthlens.overture.catalog import _release_sort_key
+            >>> _release_sort_key("2026-07-22.0")
+            ('2026-07-22', 0)
+
+            ```
+        - Sorting a release list puts the newest last:
+            ```python
+            >>> from earthlens.overture.catalog import _release_sort_key
+            >>> releases = ["2026-07-22.0", "2026-06-17.0", "2026-07-22.1"]
+            >>> sorted(releases, key=_release_sort_key)[-1]
+            '2026-07-22.1'
+
+            ```
+
+    See Also:
+        Catalog.latest_release: Picks the newest indexed release with this key.
     """
     date, _, ordinal = release.partition(".")
     return date, int(ordinal)
@@ -442,6 +460,10 @@ class Catalog(AbstractCatalog):
                 '2026-07-22.0'
 
                 ```
+
+        See Also:
+            earthlens.overture.backend.Overture._resolve_release: Prefers the
+                live release and falls back to this one.
         """
         return max(
             (r for r in self.available_releases if RELEASE_ID.match(r)),

--- a/libs/providers/hazards/src/earthlens/overture/catalog.py
+++ b/libs/providers/hazards/src/earthlens/overture/catalog.py
@@ -13,12 +13,13 @@ geometry kind, representative key columns, and the licenses its rows
 typically carry.
 
 The one moving part Overture has is the monthly **release**
-(`yyyy-mm-dd.x`). `tools/overture/refresh_overture_catalog.py` lists the
+(`yyyy-mm-dd.x`). `earthlens datasets refresh overture --write` lists the
 available releases — via the official `overturemaps` SDK (which reads
 the Overture STAC catalog) — into the bundled YAML's informational
 `available_releases:` block; the theme/type set itself is fixed and
-hand-curated. The SDK auto-targets the newest release when `release` is
-`None`, so the index is for discoverability, not dispatch.
+hand-curated. The index is for discoverability, not dispatch: Overture
+keeps only the newest release or two on S3, so a bundled release id goes
+stale within weeks and the backend resolves the release live instead.
 
 `Catalog` is a thin `earthlens.base.AbstractCatalog` subclass that loads
 the bundled `overture_data_catalog.yaml` and exposes each theme as a
@@ -51,6 +52,34 @@ _CATALOG_CACHE: CatalogParseCache = CatalogParseCache()
 def clear_catalog_cache() -> None:
     """Empty the module-level catalog parse cache (for tests that rewrite YAML)."""
     _CATALOG_CACHE.clear()
+
+
+def _release_sort_key(release: str) -> tuple[str, int]:
+    """Order an Overture release id by its date, then its ordinal.
+
+    Release ids are `yyyy-mm-dd.n`, so a plain string sort mis-orders
+    the ordinal once it reaches two digits (`"2026-07-22.10"` sorts
+    below `"2026-07-22.9"`). Splitting the ordinal off and comparing it
+    numerically fixes that; an id that does not carry a numeric ordinal
+    sorts below every id from the same date.
+
+    Args:
+        release: A release id (`"2026-07-22.0"`).
+
+    Returns:
+        tuple[str, int]: The `(date, ordinal)` pair to sort on.
+
+    Examples:
+        - The ordinal compares numerically, not lexicographically:
+            ```python
+            >>> from earthlens.overture.catalog import _release_sort_key
+            >>> _release_sort_key("2026-07-22.10") > _release_sort_key("2026-07-22.9")
+            True
+
+            ```
+    """
+    date, _, ordinal = release.partition(".")
+    return date, int(ordinal) if ordinal.isdigit() else -1
 
 
 class Theme(BaseModel):
@@ -370,17 +399,22 @@ class Catalog(AbstractCatalog):
     def latest_release(self) -> str | None:
         """Return the newest indexed Overture release, or `None` if unindexed.
 
-        Reads only the bundled `available_releases:` index (newest
-        first); it makes no network call. When the index is empty the
-        backend leaves `release=None` and lets the `overturemaps` SDK
-        auto-target the newest release at fetch time.
+        Reads only the bundled `available_releases:` index; it makes no
+        network call. The newest entry is chosen by date and ordinal
+        rather than by position, so the index may be stored in any order
+        — `earthlens datasets refresh overture --write` persists it
+        ascending, while it was originally hand-written newest-first.
+
+        The result is a stale-by-construction fallback: Overture prunes
+        old releases from S3, so the backend prefers the release the SDK
+        reports live and only falls back to this when that read fails.
 
         Returns:
-            str | None: The newest release id (e.g. `"2026-05-20.0"`), or
+            str | None: The newest release id (e.g. `"2026-07-22.0"`), or
                 `None` when the index is empty.
 
         Examples:
-            - The newest release is the head of the index (no network):
+            - The newest release wins regardless of index order (no network):
                 ```python
                 >>> from earthlens.overture import Catalog
                 >>> release = Catalog().latest_release()
@@ -388,5 +422,16 @@ class Catalog(AbstractCatalog):
                 True
 
                 ```
+            - Position in the index does not decide the winner:
+                ```python
+                >>> from earthlens.overture import Catalog
+                >>> cat = Catalog(
+                ...     datasets={},
+                ...     available_releases=["2026-06-17.0", "2026-07-22.0"],
+                ... )
+                >>> cat.latest_release()
+                '2026-07-22.0'
+
+                ```
         """
-        return self.available_releases[0] if self.available_releases else None
+        return max(self.available_releases, key=_release_sort_key, default=None)

--- a/libs/providers/hazards/src/earthlens/overture/cli.py
+++ b/libs/providers/hazards/src/earthlens/overture/cli.py
@@ -64,29 +64,33 @@ def _release_ids() -> list[str]:
     )
 
     result = get_available_releases()
-    releases, latest = result if isinstance(result, tuple) else (result, None)
-    reported = {str(release) for release in releases}
+    if isinstance(result, tuple):
+        listed, latest = (list(result) + [None, None])[:2]
+    else:
+        listed, latest = result, None
+    reported = [str(release) for release in listed or []]
     if latest is not None:
-        reported.add(str(latest))
+        reported.append(str(latest))
     parsed = {ident for ident in reported if is_release_id(ident)}
-    # The SDK reports one child link per release, so fewer parsed ids than
-    # reported entries means its parser lost some — as it does today for
-    # every absolute href.
-    if len(parsed) < len(reported):
+    unparsed = [ident for ident in reported if not is_release_id(ident)]
+    # Recover whenever the SDK's own list is unusable — every id mangled, or
+    # no list at all. Either way `latest` alone would leave the index holding
+    # one of the several releases upstream publishes and call that clean.
+    if unparsed or not listed:
         try:
             recovered = {i for i in child_release_ids() if is_release_id(i)}
         except ReleaseLookupError as exc:
             logger.warning(
-                f"The overturemaps SDK reported {len(reported - parsed)} "
-                f"unparsed release id(s); could not recover them from the "
-                f"STAC catalog either ({exc})."
+                f"The overturemaps SDK reported {len(unparsed)} unparsed "
+                f"release id(s); could not recover them from the STAC "
+                f"catalog either ({exc})."
             )
         else:
             logger.warning(
-                f"The overturemaps SDK reported {len(reported - parsed)} "
-                f"unparsed release id(s) ({sorted(reported - parsed)}); "
-                f"recovered {len(recovered - parsed)} from the STAC "
-                "catalog's child links."
+                f"The overturemaps SDK reported {len(unparsed)} unparsed "
+                f"release id(s) ({sorted(set(unparsed))}); recovered "
+                f"{len(recovered - parsed)} from the STAC catalog's child "
+                "links."
             )
             parsed |= recovered
     if not parsed:
@@ -100,15 +104,19 @@ def _release_ids() -> list[str]:
 
 
 def refresher(_catalog: Any) -> dict[str, list[str]]:
-    """List every available Overture release via the `overturemaps` SDK.
+    """List every available Overture release.
+
+    Reads the `overturemaps` SDK, falling back to Overture's STAC catalog
+    directly for the ids the SDK cannot parse (see `_release_ids`).
 
     Args:
-        _catalog: The loaded Overture `Catalog` (unused; the SDK is the source).
+        _catalog: The loaded Overture `Catalog` (unused; upstream is the
+            source).
 
     Returns:
         A single-group mapping `{"overture": [sorted release ids]}`.
     """
-    return {"overture": sorted(set(_release_ids()))}
+    return {"overture": _release_ids()}
 
 
 def curated_ids(catalog: Any) -> list[str]:

--- a/libs/providers/hazards/src/earthlens/overture/cli.py
+++ b/libs/providers/hazards/src/earthlens/overture/cli.py
@@ -8,21 +8,17 @@ the catalog's `available_releases:` index rather than `available_datasets:`.
 
 The shared machinery (`index_writer`, `require`, `lint`, `BackendInfo`) comes
 from the public `earthlens.cli.toolkit`; the live reads use the public
-`overturemaps` SDK, imported lazily so discovery never pulls it in.
+`overturemaps` SDK and `earthlens.overture.releases`, imported lazily so
+discovery never pulls them in.
 """
 
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import urlparse
 
-import requests
 from loguru import logger
 
 from earthlens.cli.toolkit import index_writer, lint, require
-
-#: Seconds to wait on the STAC catalog when recovering ids the SDK mangled.
-_STAC_TIMEOUT = 30
 
 #: A tiny bbox (Times Square block: W, S, E, N) for the Overture live reads.
 _OVERTURE_BBOX = (-73.9876, 40.7561, -73.9851, 40.7577)
@@ -31,40 +27,11 @@ _OVERTURE_BBOX = (-73.9876, 40.7561, -73.9851, 40.7577)
 writer = index_writer("available_releases")
 
 
-def _child_release_ids() -> list[str]:
-    """Read the release ids out of the STAC catalog's own child links.
-
-    Used when the SDK's release list arrives unparsed. Each child link
-    points at `<base>/<release>/catalog.json`, so the release is the
-    second-to-last path segment — the same value the SDK is trying to
-    derive, taken from the URL path instead of a `/`-split of the whole
-    href.
-
-    Returns:
-        Every release id the catalog links to, in the order it lists them.
-        Empty when the catalog lists no children.
-    """
-    from overturemaps.core import STAC_CATALOG_URL
-
-    response = requests.get(STAC_CATALOG_URL, timeout=_STAC_TIMEOUT)
-    response.raise_for_status()
-    ids: list[str] = []
-    for link in response.json().get("links", []):
-        if link.get("rel") != "child":
-            continue
-        segments = [
-            part for part in urlparse(link.get("href", "")).path.split("/") if part
-        ]
-        if len(segments) >= 2:
-            ids.append(segments[-2])
-    return ids
-
-
 def _release_ids() -> list[str]:
     """Return every available Overture release id.
 
     `get_available_releases()` returns an `(all_releases, latest)` tuple.
-    Both halves are used and both are filtered through `RELEASE_ID_RE`,
+    Both halves are used and both are filtered through `is_release_id`,
     because only one of them is trustworthy: the SDK derives
     `all_releases` by splitting each STAC child href on `/` after
     stripping `./`, which yields `"https:"` now that the catalog serves
@@ -73,41 +40,57 @@ def _release_ids() -> list[str]:
     persisting nothing, so anything that is not release-shaped is dropped.
 
     Dropping them silently would leave the index recording one of the two
-    releases upstream actually publishes, and report that as clean, so the
-    ids are recovered from the catalog's child links (`_child_release_ids`)
-    and the recovery is logged.
+    releases upstream publishes and report that as clean, so whenever the
+    SDK's list looks lossy the ids are re-read from the catalog's child
+    links (`earthlens.overture.releases.child_release_ids`) and the
+    recovery is logged. A recovery that cannot reach the catalog is
+    logged and skipped rather than failing the refresh — whatever the SDK
+    did parse is still worth reporting.
 
     Returns:
-        The available release ids, de-duplicated and sorted ascending.
+        The available release ids, de-duplicated and sorted.
 
     Raises:
-        RuntimeError: If nothing upstream said parses as a release id.
-            Refusing here keeps `--write` from blanking the bundled index,
-            which is the backend's only offline fallback.
+        ReleaseLookupError: If nothing upstream said parses as a release
+            id. Refusing here keeps `--write` from blanking the bundled
+            index, which is the backend's only offline fallback.
     """
     from overturemaps.core import get_available_releases
 
-    from earthlens.overture.catalog import RELEASE_ID_RE
+    from earthlens.overture.releases import (
+        ReleaseLookupError,
+        child_release_ids,
+        is_release_id,
+    )
 
     result = get_available_releases()
     releases, latest = result if isinstance(result, tuple) else (result, None)
     reported = {str(release) for release in releases}
     if latest is not None:
         reported.add(str(latest))
-    parsed = {ident for ident in reported if RELEASE_ID_RE.match(ident)}
-    dropped = reported - parsed
-    if dropped:
-        recovered = {
-            ident for ident in _child_release_ids() if RELEASE_ID_RE.match(ident)
-        }
-        logger.warning(
-            f"The overturemaps SDK reported {len(dropped)} unparsed release "
-            f"id(s) ({sorted(dropped)}); recovered "
-            f"{len(recovered - parsed)} from the STAC catalog's child links."
-        )
-        parsed |= recovered
+    parsed = {ident for ident in reported if is_release_id(ident)}
+    # The SDK reports one child link per release, so fewer parsed ids than
+    # reported entries means its parser lost some — as it does today for
+    # every absolute href.
+    if len(parsed) < len(reported):
+        try:
+            recovered = {i for i in child_release_ids() if is_release_id(i)}
+        except ReleaseLookupError as exc:
+            logger.warning(
+                f"The overturemaps SDK reported {len(reported - parsed)} "
+                f"unparsed release id(s); could not recover them from the "
+                f"STAC catalog either ({exc})."
+            )
+        else:
+            logger.warning(
+                f"The overturemaps SDK reported {len(reported - parsed)} "
+                f"unparsed release id(s) ({sorted(reported - parsed)}); "
+                f"recovered {len(recovered - parsed)} from the STAC "
+                "catalog's child links."
+            )
+            parsed |= recovered
     if not parsed:
-        raise RuntimeError(
+        raise ReleaseLookupError(
             "No Overture release id could be parsed from the STAC catalog "
             f"(the SDK reported {sorted(reported)}). Refusing to rewrite "
             "available_releases: with an empty list — it is the backend's "

--- a/libs/providers/hazards/src/earthlens/overture/cli.py
+++ b/libs/providers/hazards/src/earthlens/overture/cli.py
@@ -20,7 +20,6 @@ import requests
 from loguru import logger
 
 from earthlens.cli.toolkit import index_writer, lint, require
-from earthlens.overture.catalog import RELEASE_ID
 
 #: Seconds to wait on the STAC catalog when recovering ids the SDK mangled.
 _STAC_TIMEOUT = 30
@@ -42,9 +41,8 @@ def _child_release_ids() -> list[str]:
     href.
 
     Returns:
-        Every release id the catalog links to, in the order it lists
-            them. Empty when the catalog cannot be read or lists no
-            children.
+        Every release id the catalog links to, in the order it lists them.
+        Empty when the catalog lists no children.
     """
     from overturemaps.core import STAC_CATALOG_URL
 
@@ -66,7 +64,7 @@ def _release_ids() -> list[str]:
     """Return every available Overture release id.
 
     `get_available_releases()` returns an `(all_releases, latest)` tuple.
-    Both halves are used and both are filtered through `RELEASE_ID`,
+    Both halves are used and both are filtered through `RELEASE_ID_RE`,
     because only one of them is trustworthy: the SDK derives
     `all_releases` by splitting each STAC child href on `/` after
     stripping `./`, which yields `"https:"` now that the catalog serves
@@ -89,15 +87,19 @@ def _release_ids() -> list[str]:
     """
     from overturemaps.core import get_available_releases
 
+    from earthlens.overture.catalog import RELEASE_ID_RE
+
     result = get_available_releases()
     releases, latest = result if isinstance(result, tuple) else (result, None)
     reported = {str(release) for release in releases}
     if latest is not None:
         reported.add(str(latest))
-    parsed = {ident for ident in reported if RELEASE_ID.match(ident)}
+    parsed = {ident for ident in reported if RELEASE_ID_RE.match(ident)}
     dropped = reported - parsed
     if dropped:
-        recovered = {ident for ident in _child_release_ids() if RELEASE_ID.match(ident)}
+        recovered = {
+            ident for ident in _child_release_ids() if RELEASE_ID_RE.match(ident)
+        }
         logger.warning(
             f"The overturemaps SDK reported {len(dropped)} unparsed release "
             f"id(s) ({sorted(dropped)}); recovered "

--- a/libs/providers/hazards/src/earthlens/overture/cli.py
+++ b/libs/providers/hazards/src/earthlens/overture/cli.py
@@ -13,18 +13,13 @@ from the public `earthlens.cli.toolkit`; the live reads use the public
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from earthlens.cli.toolkit import index_writer, lint, require
+from earthlens.overture.catalog import RELEASE_ID
 
 #: A tiny bbox (Times Square block: W, S, E, N) for the Overture live reads.
 _OVERTURE_BBOX = (-73.9876, 40.7561, -73.9851, 40.7577)
-
-#: Shape of an Overture release id: a release date plus an ordinal
-#: (`2026-07-22.0`). Anything else the SDK reports is dropped rather than
-#: written into the bundled index.
-_RELEASE_ID = re.compile(r"^\d{4}-\d{2}-\d{2}\.\d+$")
 
 #: Persists a live release fetch into the bundled `available_releases:` block.
 writer = index_writer("available_releases")
@@ -34,7 +29,7 @@ def _release_ids() -> list[str]:
     """Return every available Overture release id (`overturemaps` SDK).
 
     `get_available_releases()` returns an `(all_releases, latest)` tuple.
-    Both halves are used and both are filtered through `_RELEASE_ID`: the
+    Both halves are used and both are filtered through `RELEASE_ID`: the
     SDK derives `all_releases` by splitting each STAC child href on `/`
     after stripping `./`, which yields `"https:"` now that the catalog
     serves absolute hrefs, whereas `latest` is read from a dedicated
@@ -54,7 +49,7 @@ def _release_ids() -> list[str]:
     ids = {str(release) for release in releases}
     if latest is not None:
         ids.add(str(latest))
-    return sorted(ident for ident in ids if _RELEASE_ID.match(ident))
+    return sorted(ident for ident in ids if RELEASE_ID.match(ident))
 
 
 def refresher(_catalog: Any) -> dict[str, list[str]]:

--- a/libs/providers/hazards/src/earthlens/overture/cli.py
+++ b/libs/providers/hazards/src/earthlens/overture/cli.py
@@ -13,12 +13,18 @@ from the public `earthlens.cli.toolkit`; the live reads use the public
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from earthlens.cli.toolkit import index_writer, lint, require
 
 #: A tiny bbox (Times Square block: W, S, E, N) for the Overture live reads.
 _OVERTURE_BBOX = (-73.9876, 40.7561, -73.9851, 40.7577)
+
+#: Shape of an Overture release id: a release date plus an ordinal
+#: (`2026-07-22.0`). Anything else the SDK reports is dropped rather than
+#: written into the bundled index.
+_RELEASE_ID = re.compile(r"^\d{4}-\d{2}-\d{2}\.\d+$")
 
 #: Persists a live release fetch into the bundled `available_releases:` block.
 writer = index_writer("available_releases")
@@ -27,17 +33,28 @@ writer = index_writer("available_releases")
 def _release_ids() -> list[str]:
     """Return every available Overture release id (`overturemaps` SDK).
 
-    `get_available_releases()` returns a `(all_releases, latest)` tuple; only
-    the release list is taken.
+    `get_available_releases()` returns an `(all_releases, latest)` tuple.
+    Both halves are used and both are filtered through `_RELEASE_ID`: the
+    SDK derives `all_releases` by splitting each STAC child href on `/`
+    after stripping `./`, which yields `"https:"` now that the catalog
+    serves absolute hrefs, whereas `latest` is read from a dedicated
+    catalog field and is unaffected. Validating the shape keeps that
+    upstream breakage — and any future variant of it — out of the bundled
+    `available_releases:` index instead of persisting `https:` as a
+    release id.
 
     Returns:
-        Every release id the SDK reports, as strings.
+        The release ids the SDK reports that are shaped like a release,
+            de-duplicated and sorted ascending.
     """
     from overturemaps.core import get_available_releases
 
     result = get_available_releases()
-    releases = result[0] if isinstance(result, tuple) else result
-    return [str(release) for release in releases]
+    releases, latest = result if isinstance(result, tuple) else (result, None)
+    ids = {str(release) for release in releases}
+    if latest is not None:
+        ids.add(str(latest))
+    return sorted(ident for ident in ids if _RELEASE_ID.match(ident))
 
 
 def refresher(_catalog: Any) -> dict[str, list[str]]:

--- a/libs/providers/hazards/src/earthlens/overture/cli.py
+++ b/libs/providers/hazards/src/earthlens/overture/cli.py
@@ -14,9 +14,16 @@ from the public `earthlens.cli.toolkit`; the live reads use the public
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
+
+import requests
+from loguru import logger
 
 from earthlens.cli.toolkit import index_writer, lint, require
 from earthlens.overture.catalog import RELEASE_ID
+
+#: Seconds to wait on the STAC catalog when recovering ids the SDK mangled.
+_STAC_TIMEOUT = 30
 
 #: A tiny bbox (Times Square block: W, S, E, N) for the Overture live reads.
 _OVERTURE_BBOX = (-73.9876, 40.7561, -73.9851, 40.7577)
@@ -25,31 +32,86 @@ _OVERTURE_BBOX = (-73.9876, 40.7561, -73.9851, 40.7577)
 writer = index_writer("available_releases")
 
 
-def _release_ids() -> list[str]:
-    """Return every available Overture release id (`overturemaps` SDK).
+def _child_release_ids() -> list[str]:
+    """Read the release ids out of the STAC catalog's own child links.
 
-    `get_available_releases()` returns an `(all_releases, latest)` tuple.
-    Both halves are used and both are filtered through `RELEASE_ID`: the
-    SDK derives `all_releases` by splitting each STAC child href on `/`
-    after stripping `./`, which yields `"https:"` now that the catalog
-    serves absolute hrefs, whereas `latest` is read from a dedicated
-    catalog field and is unaffected. Validating the shape keeps that
-    upstream breakage — and any future variant of it — out of the bundled
-    `available_releases:` index instead of persisting `https:` as a
-    release id.
+    Used when the SDK's release list arrives unparsed. Each child link
+    points at `<base>/<release>/catalog.json`, so the release is the
+    second-to-last path segment — the same value the SDK is trying to
+    derive, taken from the URL path instead of a `/`-split of the whole
+    href.
 
     Returns:
-        The release ids the SDK reports that are shaped like a release,
-            de-duplicated and sorted ascending.
+        Every release id the catalog links to, in the order it lists
+            them. Empty when the catalog cannot be read or lists no
+            children.
+    """
+    from overturemaps.core import STAC_CATALOG_URL
+
+    response = requests.get(STAC_CATALOG_URL, timeout=_STAC_TIMEOUT)
+    response.raise_for_status()
+    ids: list[str] = []
+    for link in response.json().get("links", []):
+        if link.get("rel") != "child":
+            continue
+        segments = [
+            part for part in urlparse(link.get("href", "")).path.split("/") if part
+        ]
+        if len(segments) >= 2:
+            ids.append(segments[-2])
+    return ids
+
+
+def _release_ids() -> list[str]:
+    """Return every available Overture release id.
+
+    `get_available_releases()` returns an `(all_releases, latest)` tuple.
+    Both halves are used and both are filtered through `RELEASE_ID`,
+    because only one of them is trustworthy: the SDK derives
+    `all_releases` by splitting each STAC child href on `/` after
+    stripping `./`, which yields `"https:"` now that the catalog serves
+    absolute hrefs, while `latest` is read from a dedicated catalog field
+    and is unaffected. Persisting `https:` as a release id is worse than
+    persisting nothing, so anything that is not release-shaped is dropped.
+
+    Dropping them silently would leave the index recording one of the two
+    releases upstream actually publishes, and report that as clean, so the
+    ids are recovered from the catalog's child links (`_child_release_ids`)
+    and the recovery is logged.
+
+    Returns:
+        The available release ids, de-duplicated and sorted ascending.
+
+    Raises:
+        RuntimeError: If nothing upstream said parses as a release id.
+            Refusing here keeps `--write` from blanking the bundled index,
+            which is the backend's only offline fallback.
     """
     from overturemaps.core import get_available_releases
 
     result = get_available_releases()
     releases, latest = result if isinstance(result, tuple) else (result, None)
-    ids = {str(release) for release in releases}
+    reported = {str(release) for release in releases}
     if latest is not None:
-        ids.add(str(latest))
-    return sorted(ident for ident in ids if RELEASE_ID.match(ident))
+        reported.add(str(latest))
+    parsed = {ident for ident in reported if RELEASE_ID.match(ident)}
+    dropped = reported - parsed
+    if dropped:
+        recovered = {ident for ident in _child_release_ids() if RELEASE_ID.match(ident)}
+        logger.warning(
+            f"The overturemaps SDK reported {len(dropped)} unparsed release "
+            f"id(s) ({sorted(dropped)}); recovered "
+            f"{len(recovered - parsed)} from the STAC catalog's child links."
+        )
+        parsed |= recovered
+    if not parsed:
+        raise RuntimeError(
+            "No Overture release id could be parsed from the STAC catalog "
+            f"(the SDK reported {sorted(reported)}). Refusing to rewrite "
+            "available_releases: with an empty list — it is the backend's "
+            "offline fallback."
+        )
+    return sorted(parsed)
 
 
 def refresher(_catalog: Any) -> dict[str, list[str]]:

--- a/libs/providers/hazards/src/earthlens/overture/overture_data_catalog.yaml
+++ b/libs/providers/hazards/src/earthlens/overture/overture_data_catalog.yaml
@@ -8,7 +8,7 @@
 # theme name passed in `variables={theme: [type, ...]}`.
 #
 # Unlike GDACS, Overture *does* have a moving part worth indexing: the monthly
-# release (`yyyy-mm-dd.x`). `tools/overture/refresh_overture_catalog.py` lists
+# release (`yyyy-mm-dd.x`). `earthlens datasets refresh overture --write` lists
 # the available releases (via the official `overturemaps` SDK / the Overture
 # STAC catalog) into the informational `available_releases:` block below; the
 # theme/type set itself is fixed and hand-curated.
@@ -82,13 +82,19 @@ themes:
 
 # Informational index of every Overture feature type the SDK exposes (across
 # all themes, including the uncurated `base` / `addresses` themes). Rebuilt by
-# `tools/overture/refresh_overture_catalog.py` from the live SDK; the curated
+# `earthlens datasets refresh overture --write` from the live SDK; the curated
 # `themes:` block above is a subset. For discoverability, not dispatch.
 available_datasets: [address, bathymetry, building, building_part, connector, division, division_area, division_boundary, infrastructure, land, land_cover, land_use, place, segment, water]
 
-# Informational index of Overture releases, newest first. Rebuilt by
-# `tools/overture/refresh_overture_catalog.py`; the SDK auto-targets the newest
-# when `release=None`, so this block is for discoverability, not dispatch.
+# Informational index of the Overture releases the STAC catalog exposes,
+# sorted ascending. Rebuilt by `earthlens datasets refresh overture --write`;
+# `Catalog.latest_release()` picks the newest by date and ordinal, so the order
+# here is not load-bearing.
+#
+# For discoverability, not dispatch. Overture keeps only the newest release (or
+# two) on `s3://overturemaps-us-west-2` and prunes the rest, so any id bundled
+# here goes stale within weeks. `release=None` therefore resolves the release
+# live at fetch time (the SDK on the default path, `get_latest_release()` on the
+# DuckDB path) and treats this block only as an offline fallback.
 available_releases:
-  - 2026-05-20.0
-  - 2026-04-15.0
+- 2026-07-22.0

--- a/libs/providers/hazards/src/earthlens/overture/overture_data_catalog.yaml
+++ b/libs/providers/hazards/src/earthlens/overture/overture_data_catalog.yaml
@@ -97,4 +97,5 @@ available_datasets: [address, bathymetry, building, building_part, connector, di
 # live at fetch time (the SDK on the default path, `get_latest_release()` on the
 # DuckDB path) and treats this block only as an offline fallback.
 available_releases:
+- 2026-06-17.0
 - 2026-07-22.0

--- a/libs/providers/hazards/src/earthlens/overture/overture_data_catalog.yaml
+++ b/libs/providers/hazards/src/earthlens/overture/overture_data_catalog.yaml
@@ -86,10 +86,11 @@ themes:
 # `themes:` block above is a subset. For discoverability, not dispatch.
 available_datasets: [address, bathymetry, building, building_part, connector, division, division_area, division_boundary, infrastructure, land, land_cover, land_use, place, segment, water]
 
-# Informational index of the Overture releases the STAC catalog exposes,
-# sorted ascending. Rebuilt by `earthlens datasets refresh overture --write`;
-# `Catalog.latest_release()` picks the newest by date and ordinal, so the order
-# here is not load-bearing.
+# Informational index of the Overture releases the STAC catalog exposes.
+# Rebuilt by `earthlens datasets refresh overture --write`, which sorts every
+# provider's index the same way — lexicographically — so a two-digit ordinal
+# (`.10`) lands before `.9`. That is harmless: `Catalog.latest_release()` picks
+# the newest by date and ordinal, so the order here is not load-bearing.
 #
 # For discoverability, not dispatch. Overture keeps only the newest release (or
 # two) on `s3://overturemaps-us-west-2` and prunes the rest, so any id bundled

--- a/libs/providers/hazards/src/earthlens/overture/query.py
+++ b/libs/providers/hazards/src/earthlens/overture/query.py
@@ -39,7 +39,7 @@ def _dataset_path(theme: str, overture_type: str, release: str) -> str:
     Args:
         theme: Friendly theme name (the Overture `theme=` partition).
         overture_type: Overture feature type (the `type=` partition).
-        release: Concrete release id (`"2026-05-20.0"`).
+        release: Concrete release id (`"2026-07-22.0"`).
 
     Returns:
         str: An `s3://…/*` glob over the partition's parquet files.

--- a/libs/providers/hazards/src/earthlens/overture/releases.py
+++ b/libs/providers/hazards/src/earthlens/overture/releases.py
@@ -92,7 +92,9 @@ def stac_catalog(client: HttpClient | None = None) -> dict[str, Any]:
     transport = client or HttpClient(timeout=STAC_TIMEOUT)
     try:
         document = transport.get_json(STAC_CATALOG_URL)
-    except Exception as exc:  # noqa: BLE001 - transport/decode, reported as one
+    # Transport, status, and decode failures all mean the same thing to every
+    # caller — the catalog could not be read — so they are reported as one.
+    except Exception as exc:  # noqa: BLE001
         raise ReleaseLookupError(
             f"could not read Overture's STAC catalog at {STAC_CATALOG_URL} ({exc})"
         ) from exc

--- a/libs/providers/hazards/src/earthlens/overture/releases.py
+++ b/libs/providers/hazards/src/earthlens/overture/releases.py
@@ -1,0 +1,172 @@
+"""The live Overture release axis: what a release id is, and which exist.
+
+Overture publishes a dated release roughly monthly (`yyyy-mm-dd.x`) and
+keeps only the newest one or two on `s3://overturemaps-us-west-2`, pruning
+the rest. Every consumer in this package therefore needs the same two
+things — a way to recognise a release id, and the ids Overture publishes
+*now* — so both live here rather than being re-derived per module.
+
+The live reads go through `earthlens.base.HttpClient`, not the
+`overturemaps` SDK. The SDK's own lookups call `urlopen(STAC_CATALOG_URL)`
+with no `timeout=`, which inherits the global socket default of `None`: on
+a route that drops rather than refuses — a firewall that allows the public
+S3 bucket but not `stac.overturemaps.org` — a download would block
+indefinitely, and the offline fallback that exists for exactly that
+situation would never be reached. `HttpClient` bounds the request and
+applies the repo's shared retry and user-agent policy. Only the SDK's
+`STAC_CATALOG_URL` constant is reused, so the endpoint stays in one place.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+from earthlens.base import HttpClient
+
+#: Shape of an Overture release id: a release date plus an ordinal
+#: (`2026-07-22.0`). Matched with `fullmatch`, so no trailing newline slips
+#: through. This is a *shape* check, not an existence or validity one —
+#: `9999-99-99.0` matches — so it guards against garbage (the `https:`
+#: fragments the SDK's own parser emits) and typos, not against an id
+#: Overture has pruned.
+RELEASE_ID_RE = re.compile(r"\d{4}-\d{2}-\d{2}\.\d+")
+
+#: Bounds the STAC read: `(connect, read)` seconds. Short enough that a
+#: black-holed route degrades to the bundled index promptly rather than
+#: stalling a download.
+STAC_TIMEOUT = (5.0, 15.0)
+
+
+class ReleaseLookupError(RuntimeError):
+    """Raised when Overture's STAC catalog cannot be read or parsed."""
+
+
+def is_release_id(value: object) -> bool:
+    """Return whether `value` is shaped like an Overture release id.
+
+    Args:
+        value: Any object. A non-string is never a release id, which keeps
+            callers from having to pre-check the type.
+
+    Returns:
+        bool: `True` when `value` is a string of the form
+            `yyyy-mm-dd.<ordinal>`.
+
+    Examples:
+        - A published release id is accepted:
+            ```python
+            >>> from earthlens.overture.releases import is_release_id
+            >>> is_release_id("2026-07-22.0")
+            True
+
+            ```
+        - The `https:` fragment the SDK's parser emits is not:
+            ```python
+            >>> from earthlens.overture.releases import is_release_id
+            >>> [is_release_id(v) for v in ("https:", "2026-7-22.0", None)]
+            [False, False, False]
+
+            ```
+    """
+    return isinstance(value, str) and RELEASE_ID_RE.fullmatch(value) is not None
+
+
+def stac_catalog(client: HttpClient | None = None) -> dict[str, Any]:
+    """Fetch Overture's STAC root catalog, bounded and retry-wrapped.
+
+    Args:
+        client: Transport to read through. Defaults to a `HttpClient`
+            carrying `STAC_TIMEOUT`.
+
+    Returns:
+        dict[str, Any]: The decoded catalog document.
+
+    Raises:
+        ReleaseLookupError: If the catalog cannot be fetched, is not JSON,
+            or is not a JSON object.
+    """
+    from overturemaps.core import STAC_CATALOG_URL
+
+    transport = client or HttpClient(timeout=STAC_TIMEOUT)
+    try:
+        document = transport.get_json(STAC_CATALOG_URL)
+    except Exception as exc:  # noqa: BLE001 - transport/decode, reported as one
+        raise ReleaseLookupError(
+            f"could not read Overture's STAC catalog at {STAC_CATALOG_URL} ({exc})"
+        ) from exc
+    if not isinstance(document, dict):
+        raise ReleaseLookupError(
+            f"Overture's STAC catalog at {STAC_CATALOG_URL} is not a JSON object"
+        )
+    return document
+
+
+def latest_release(client: HttpClient | None = None) -> str:
+    """Return the release id Overture currently publishes.
+
+    Reads the catalog's dedicated `latest` key — the same value the SDK's
+    `get_latest_release()` returns, but over a bounded transport.
+
+    Args:
+        client: Transport to read through (see `stac_catalog`).
+
+    Returns:
+        str: The published release id.
+
+    Raises:
+        ReleaseLookupError: If the catalog cannot be read, or its `latest`
+            is missing or not shaped like a release id.
+    """
+    latest = stac_catalog(client).get("latest")
+    if not is_release_id(latest):
+        raise ReleaseLookupError(
+            f"Overture's STAC catalog reported latest={latest!r}, which is not "
+            "a release id"
+        )
+    return str(latest)
+
+
+def child_release_ids(client: HttpClient | None = None) -> list[str]:
+    """Return every release id the STAC catalog links to as a child.
+
+    Each child link points at `<base>/<release>/catalog.json`, so the
+    release is the second-to-last segment of the URL *path*. Read directly
+    rather than through the SDK, whose `get_available_releases()` derives
+    the ids by splitting the whole href on `/` after stripping `./` —
+    which yields `https:` now that the catalog serves absolute hrefs.
+    Parsing the path rather than the raw href is what keeps the scheme and
+    host out of the result.
+
+    Args:
+        client: Transport to read through (see `stac_catalog`).
+
+    Returns:
+        list[str]: The linked release ids, in catalog order, skipping any
+            href too short to carry one.
+
+    Raises:
+        ReleaseLookupError: If the catalog cannot be read or parsed.
+    """
+    ids: list[str] = []
+    links = stac_catalog(client).get("links")
+    for link in links if isinstance(links, list) else []:
+        if not isinstance(link, dict) or link.get("rel") != "child":
+            continue
+        path = urlparse(str(link.get("href", ""))).path
+        segments = [part for part in path.split("/") if part]
+        if len(segments) >= 2:
+            ids.append(segments[-2])
+    return ids
+
+
+__all__ = [
+    "RELEASE_ID_RE",
+    "STAC_TIMEOUT",
+    "ReleaseLookupError",
+    "child_release_ids",
+    "is_release_id",
+    "latest_release",
+    "stac_catalog",
+]

--- a/libs/providers/hazards/tests/overture/conftest.py
+++ b/libs/providers/hazards/tests/overture/conftest.py
@@ -158,16 +158,20 @@ def fake_overture(monkeypatch: pytest.MonkeyPatch) -> _FakeOverture:
     monkeypatch.setattr(
         "overturemaps.core.record_batch_reader", state.record_batch_reader
     )
-    monkeypatch.setattr("overturemaps.core.get_latest_release", state.latest_release)
+    monkeypatch.setattr(
+        "earthlens.overture.releases.latest_release", state.latest_release
+    )
     return state
 
 
-def _refuse_urlopen(*_args: Any, **_kwargs: Any) -> None:
-    """Fail the test rather than let it reach the live STAC catalog."""
+def _refuse_transport(*_args: Any, **_kwargs: Any) -> None:
+    """Fail the test rather than let it build a live STAC transport."""
     pytest.fail(
-        "an offline Overture test reached the live STAC catalog; patch "
-        "overturemaps.core.get_latest_release (the fake_overture fixture "
-        "does) instead of relying on the backend's offline fallback",
+        "an offline Overture test tried to reach the live STAC catalog; "
+        "patch earthlens.overture.releases.latest_release / "
+        ".child_release_ids (the fake_overture fixture patches the first), "
+        "or pass a fake client to the releases helpers, instead of relying "
+        "on the backend's offline fallback",
         pytrace=False,
     )
 
@@ -178,8 +182,14 @@ def no_live_stac(
 ) -> None:
     """Block the live release lookup for every non-e2e Overture test.
 
-    Both live doors are covered: the SDK's `urlopen` (the release lookup)
-    and the refresher's `requests.get` (the STAC child-link recovery).
+    Every live release read — the backend's lookup and the refresher's
+    child-link recovery alike — goes through `releases.stac_catalog`,
+    which builds its own `HttpClient` when the caller injects none. Making
+    *that* construction fail closes the live door while leaving an
+    injected fake client working, and without reaching into `requests`
+    (which the whole process shares) or depending on whether an SDK-level
+    cache happens to be warm.
+
     `_resolve_release` falls back to the bundled index on any failure, so
     an accidental live call passes the suite and only shows up as a slow,
     network-dependent run. `pytest.fail` raises a `BaseException`, which
@@ -187,5 +197,4 @@ def no_live_stac(
     """
     if request.node.get_closest_marker("e2e"):
         return
-    monkeypatch.setattr("overturemaps.core.urlopen", _refuse_urlopen)
-    monkeypatch.setattr("earthlens.overture.cli.requests.get", _refuse_urlopen)
+    monkeypatch.setattr("earthlens.overture.releases.HttpClient", _refuse_transport)

--- a/libs/providers/hazards/tests/overture/conftest.py
+++ b/libs/providers/hazards/tests/overture/conftest.py
@@ -3,8 +3,13 @@
 Builds synthetic Overture `GeoDataFrame`s (no network) and a recording
 fake for `overturemaps.core.geodataframe`, so the backend can be
 exercised end-to-end offline. The `fake_overture` fixture patches the
-SDK entry point the backend imports inside `_fetch` and records every
-`(overture_type, bbox, release)` call.
+SDK entry points the backend imports inside `_fetch` — the readers and
+`get_latest_release` — and records every `(overture_type, bbox, release)`
+call.
+
+An autouse guard keeps that promise honest: any non-`e2e` test that
+reaches the live STAC catalog fails instead of quietly succeeding
+through the backend's offline fallback.
 """
 
 from __future__ import annotations
@@ -27,6 +32,10 @@ OSM_SECOND_SOURCES = [
     {"dataset": "OpenStreetMap", "license": "ODbL-1.0"},
 ]
 NO_LICENSE_SOURCES = [{"dataset": "Overture"}]
+
+#: The release the offline fake reports as the one Overture publishes. Distinct
+#: from every id in the bundled index, so a test can tell the two apart.
+FAKE_RELEASE = "2099-12-31.0"
 
 
 def _make_gdf(
@@ -77,8 +86,15 @@ class _FakeOverture:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
         self.reader_calls: list[dict[str, Any]] = []
+        self.latest_calls: int = 0
+        self.latest: str = FAKE_RELEASE
         self._gdf_for_type: dict[str, gpd.GeoDataFrame] = {}
         self.default_gdf: gpd.GeoDataFrame = _make_gdf()
+
+    def latest_release(self) -> str:
+        """Stand in for the SDK's live release lookup, counting the calls."""
+        self.latest_calls += 1
+        return self.latest
 
     def __call__(
         self,
@@ -136,10 +152,37 @@ def make_gdf() -> Callable[..., gpd.GeoDataFrame]:
 
 @pytest.fixture
 def fake_overture(monkeypatch: pytest.MonkeyPatch) -> _FakeOverture:
-    """Patch `overturemaps.core.geodataframe` with the recording fake."""
+    """Patch the SDK readers and the release lookup with the recording fake."""
     state = _FakeOverture()
     monkeypatch.setattr("overturemaps.core.geodataframe", state)
     monkeypatch.setattr(
         "overturemaps.core.record_batch_reader", state.record_batch_reader
     )
+    monkeypatch.setattr("overturemaps.core.get_latest_release", state.latest_release)
     return state
+
+
+def _refuse_urlopen(*_args: Any, **_kwargs: Any) -> None:
+    """Fail the test rather than let it reach the live STAC catalog."""
+    pytest.fail(
+        "an offline Overture test reached the live STAC catalog; patch "
+        "overturemaps.core.get_latest_release (the fake_overture fixture "
+        "does) instead of relying on the backend's offline fallback",
+        pytrace=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def no_live_stac(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Block the live release lookup for every non-e2e Overture test.
+
+    `_resolve_release` falls back to the bundled index on any failure, so
+    an accidental live call passes the suite and only shows up as a slow,
+    network-dependent run. `pytest.fail` raises a `BaseException`, which
+    that fallback does not catch, so the leak surfaces as a failure.
+    """
+    if request.node.get_closest_marker("e2e"):
+        return
+    monkeypatch.setattr("overturemaps.core.urlopen", _refuse_urlopen)

--- a/libs/providers/hazards/tests/overture/conftest.py
+++ b/libs/providers/hazards/tests/overture/conftest.py
@@ -178,6 +178,8 @@ def no_live_stac(
 ) -> None:
     """Block the live release lookup for every non-e2e Overture test.
 
+    Both live doors are covered: the SDK's `urlopen` (the release lookup)
+    and the refresher's `requests.get` (the STAC child-link recovery).
     `_resolve_release` falls back to the bundled index on any failure, so
     an accidental live call passes the suite and only shows up as a slow,
     network-dependent run. `pytest.fail` raises a `BaseException`, which
@@ -186,3 +188,4 @@ def no_live_stac(
     if request.node.get_closest_marker("e2e"):
         return
     monkeypatch.setattr("overturemaps.core.urlopen", _refuse_urlopen)
+    monkeypatch.setattr("earthlens.overture.cli.requests.get", _refuse_urlopen)

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -585,6 +585,14 @@ class TestDuckDBQueryPath:
         )
         assert backend._resolve_release() == "2020-01-01.0"
 
+    @pytest.mark.parametrize(
+        "release", ["not-a-release", "2026-07-22", "2026-7-22.0", ""]
+    )
+    def test_release_must_be_shaped_like_a_release_id(self, tmp_path: Path, release):
+        """A mistyped pin is rejected at construction, not by an opaque S3 miss."""
+        with pytest.raises(ValueError, match=r"release must be an Overture release id"):
+            _make_backend(tmp_path, variables={"places": []}, release=release)
+
     def test_resolve_release_explicit_skips_the_live_lookup(
         self, tmp_path: Path, monkeypatch
     ):

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -499,6 +499,20 @@ class TestDuckDBQueryPath:
         assert seen["columns"] == ["names"]
         assert seen["limit"] == 5
 
+    def test_duckdb_filename_records_the_resolved_release(
+        self, tmp_path: Path, fake_overture, make_gdf, monkeypatch
+    ):
+        """An unpinned DuckDB write names the snapshot it read, not `latest`."""
+        monkeypatch.setattr(
+            "earthlens.overture.query.query_overture",
+            lambda *a, **k: make_gdf([PERMISSIVE_SOURCES]),
+        )
+        backend = _make_backend(
+            tmp_path, variables={"places": []}, where="confidence > 0.9"
+        )
+        paths = backend.download()
+        assert paths[0].name == f"overture_places_place_{FAKE_RELEASE}.parquet"
+
     def test_release_is_resolved_once_per_download(
         self, tmp_path: Path, fake_overture, make_gdf, monkeypatch
     ):

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -13,6 +13,7 @@ from earthlens.base import RemoteProduct, SpatialExtent, TemporalExtent
 from earthlens.overture import Overture
 from earthlens.overture._helpers import ODBL, LicenseWarning
 from earthlens.overture.backend import _require_overturemaps, _stream_to_geodataframe
+from earthlens.overture.releases import ReleaseLookupError
 
 from .conftest import FAKE_RELEASE, OSM_SOURCES, PERMISSIVE_SOURCES
 
@@ -29,19 +30,26 @@ def _make_backend(tmp_path: Path, **overrides) -> Overture:
     return Overture(**params)
 
 
+def _stac(monkeypatch, document: dict) -> None:
+    """Serve `document` as Overture's STAC catalog for one test."""
+    monkeypatch.setattr(
+        "earthlens.overture.releases.stac_catalog", lambda *_a, **_k: document
+    )
+
+
 def _boom() -> str:
     """Stand in for a live release lookup that cannot reach Overture."""
-    raise OSError("no route to stac.overturemaps.org")
+    raise ReleaseLookupError("could not read Overture's STAC catalog (no route)")
 
 
 def _missing_sdk() -> str:
     """Stand in for a release lookup whose SDK entry point is gone."""
-    raise ImportError("cannot import name 'get_latest_release'")
+    raise ImportError("cannot import name 'STAC_CATALOG_URL'")
 
 
 def _renamed_sdk() -> str:
     """Stand in for a release lookup whose SDK internals moved."""
-    raise AttributeError("'module' object has no attribute 'get_available_releases'")
+    raise AttributeError("'module' object has no attribute 'STAC_CATALOG_URL'")
 
 
 @pytest.mark.overture
@@ -523,11 +531,9 @@ class TestDuckDBQueryPath:
 
     def test_fallback_to_the_index_is_warned_about(self, tmp_path: Path, monkeypatch):
         """Falling back to the bundled index says so, and says it may be stale."""
-        import overturemaps.core as core
-
         backend = _make_backend(tmp_path, variables={"places": []})
         backend._catalog.available_releases = ["2020-01-01.0"]
-        monkeypatch.setattr(core, "get_latest_release", _boom)
+        monkeypatch.setattr("earthlens.overture.releases.latest_release", _boom)
         messages: list[str] = []
         sink = logger.add(lambda record: messages.append(str(record)), level="WARNING")
         try:
@@ -590,9 +596,7 @@ class TestDuckDBQueryPath:
         self, tmp_path: Path, monkeypatch
     ):
         """An explicit release is used without asking the SDK."""
-        import overturemaps.core as core
-
-        monkeypatch.setattr(core, "get_latest_release", _boom)
+        monkeypatch.setattr("earthlens.overture.releases.latest_release", _boom)
         backend = _make_backend(
             tmp_path, variables={"places": []}, release="2020-01-01.0"
         )
@@ -601,23 +605,19 @@ class TestDuckDBQueryPath:
     def test_resolve_release_prefers_the_live_release(
         self, tmp_path: Path, monkeypatch
     ):
-        """With no explicit release, the live SDK release beats the bundled index."""
-        import overturemaps.core as core
-
+        """With no explicit release, the published release beats the bundled index."""
         backend = _make_backend(tmp_path, variables={"places": []})
         backend._catalog.available_releases = ["2020-01-01.0"]
-        monkeypatch.setattr(core, "get_latest_release", lambda: "2099-12-31.0")
+        _stac(monkeypatch, {"latest": "2099-12-31.0"})
         assert backend._resolve_release() == "2099-12-31.0"
 
     def test_resolve_release_falls_back_to_index_when_live_fails(
         self, tmp_path: Path, monkeypatch
     ):
         """A failed live lookup falls back to the newest bundled release."""
-        import overturemaps.core as core
-
         backend = _make_backend(tmp_path, variables={"places": []})
         backend._catalog.available_releases = ["2020-01-01.0", "2021-01-01.0"]
-        monkeypatch.setattr(core, "get_latest_release", _boom)
+        monkeypatch.setattr("earthlens.overture.releases.latest_release", _boom)
         assert backend._resolve_release() == "2021-01-01.0"
 
     @pytest.mark.parametrize("live", [None, "", "https:", "2026-7-22.0"])
@@ -625,11 +625,9 @@ class TestDuckDBQueryPath:
         self, tmp_path: Path, monkeypatch, live
     ):
         """A live reply that is not release-shaped falls back like a failure."""
-        import overturemaps.core as core
-
         backend = _make_backend(tmp_path, variables={"places": []})
         backend._catalog.available_releases = ["2020-01-01.0"]
-        monkeypatch.setattr(core, "get_latest_release", lambda: live)
+        _stac(monkeypatch, {"latest": live})
         assert backend._resolve_release() == "2020-01-01.0", (
             f"a live {live!r} must not reach the S3 glob"
         )
@@ -638,11 +636,9 @@ class TestDuckDBQueryPath:
         self, tmp_path: Path, monkeypatch
     ):
         """A junk live reply and an empty index name the junk in the error."""
-        import overturemaps.core as core
-
         backend = _make_backend(tmp_path, variables={"places": []})
         backend._catalog.available_releases = []
-        monkeypatch.setattr(core, "get_latest_release", lambda: "https:")
+        _stac(monkeypatch, {"latest": "https:"})
         with pytest.raises(RuntimeError, match=r"not a release id"):
             backend._resolve_release()
 
@@ -654,11 +650,9 @@ class TestDuckDBQueryPath:
         self, tmp_path: Path, monkeypatch, lookup, error
     ):
         """A missing or renamed SDK entry point fails loudly, not into the index."""
-        import overturemaps.core as core
-
         backend = _make_backend(tmp_path, variables={"places": []})
         backend._catalog.available_releases = ["2020-01-01.0"]
-        monkeypatch.setattr(core, "get_latest_release", lookup)
+        monkeypatch.setattr("earthlens.overture.releases.latest_release", lookup)
         with pytest.raises(error):
             backend._resolve_release()
 
@@ -666,14 +660,12 @@ class TestDuckDBQueryPath:
         self, tmp_path: Path, monkeypatch
     ):
         """No live release and no bundled one is an error naming the way out."""
-        import overturemaps.core as core
-
         backend = _make_backend(tmp_path, variables={"places": []})
         backend._catalog.available_releases = []
-        monkeypatch.setattr(core, "get_latest_release", _boom)
+        monkeypatch.setattr("earthlens.overture.releases.latest_release", _boom)
         with pytest.raises(RuntimeError, match=r"explicit release=") as excinfo:
             backend._resolve_release()
-        assert isinstance(excinfo.value.__cause__, OSError), (
+        assert isinstance(excinfo.value.__cause__, ReleaseLookupError), (
             "the live-lookup failure should be chained, not swallowed"
         )
 

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -13,7 +13,7 @@ from earthlens.overture import Overture
 from earthlens.overture._helpers import ODBL, LicenseWarning
 from earthlens.overture.backend import _require_overturemaps, _stream_to_geodataframe
 
-from .conftest import OSM_SOURCES, PERMISSIVE_SOURCES
+from .conftest import FAKE_RELEASE, OSM_SOURCES, PERMISSIVE_SOURCES
 
 
 def _make_backend(tmp_path: Path, **overrides) -> Overture:
@@ -488,6 +488,33 @@ class TestDuckDBQueryPath:
         backend.download()
         assert seen["columns"] == ["names"]
         assert seen["limit"] == 5
+
+    def test_release_is_resolved_once_per_download(
+        self, tmp_path: Path, fake_overture, make_gdf, monkeypatch
+    ):
+        """Two requested types share one release lookup, so one download is one snapshot."""
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "earthlens.overture.query.query_overture",
+            lambda theme, otype, release, *a, **k: (
+                seen.append(release) or make_gdf([PERMISSIVE_SOURCES])
+            ),
+        )
+        backend = _make_backend(
+            tmp_path,
+            variables={"buildings": ["building", "building_part"]},
+            where="height > 10",
+        )
+        backend.download()
+        assert fake_overture.latest_calls == 1, "one lookup for the whole download"
+        assert seen == [FAKE_RELEASE, FAKE_RELEASE], "both types read one release"
+
+    def test_default_path_never_resolves_a_release(self, tmp_path: Path, fake_overture):
+        """Without where=/columns= the fetch stays offline and asks for no release."""
+        _make_backend(tmp_path, variables={"places": []}).download()
+        assert fake_overture.latest_calls == 0, (
+            "the SDK path auto-targets latest itself; it must not look one up"
+        )
 
     def test_resolve_release_explicit(self, tmp_path: Path):
         """`_resolve_release` returns the explicit release when given."""

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -30,6 +30,26 @@ def _make_backend(tmp_path: Path, **overrides) -> Overture:
     return Overture(**params)
 
 
+def _record_releases(seen: list, gdf):
+    """Build a `query_overture` stand-in that records each release it is given."""
+
+    def _query(theme, otype, release, *_args, **_kwargs):
+        seen.append(release)
+        return gdf
+
+    return _query
+
+
+def _record_query(seen: dict, gdf):
+    """Build a `query_overture` stand-in that records its call and returns `gdf`."""
+
+    def _query(theme, otype, release, bbox, **kwargs):
+        seen.update(theme=theme, otype=otype, release=release, bbox=bbox, **kwargs)
+        return gdf
+
+    return _query
+
+
 def _stac(monkeypatch, document: dict) -> None:
     """Serve `document` as Overture's STAC catalog for one test."""
     monkeypatch.setattr(
@@ -496,7 +516,7 @@ class TestDuckDBQueryPath:
         seen: dict = {}
         monkeypatch.setattr(
             "earthlens.overture.query.query_overture",
-            lambda *a, **k: seen.update(k) or make_gdf([PERMISSIVE_SOURCES]),
+            _record_query(seen, make_gdf([PERMISSIVE_SOURCES])),
         )
         backend = _make_backend(
             tmp_path,

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -28,6 +28,11 @@ def _make_backend(tmp_path: Path, **overrides) -> Overture:
     return Overture(**params)
 
 
+def _boom() -> str:
+    """Stand in for a live release lookup that cannot reach Overture."""
+    raise OSError("no route to stac.overturemaps.org")
+
+
 @pytest.mark.overture
 class TestOvertureConstruction:
     """`__init__` wiring and validation."""
@@ -489,19 +494,51 @@ class TestDuckDBQueryPath:
         )
         assert backend._resolve_release() == "2020-01-01.0"
 
-    def test_resolve_release_falls_back_to_index(self, tmp_path: Path):
-        """With no explicit release, `_resolve_release` uses the catalog index."""
-        backend = _make_backend(tmp_path, variables={"places": []})
-        assert backend._resolve_release() == backend._catalog.latest_release()
+    def test_resolve_release_explicit_skips_the_live_lookup(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """An explicit release is used without asking the SDK."""
+        import overturemaps.core as core
 
-    def test_resolve_release_falls_back_to_sdk(self, tmp_path: Path, monkeypatch):
-        """With no release and an empty index, it asks the SDK for the latest."""
+        monkeypatch.setattr(core, "get_latest_release", _boom)
+        backend = _make_backend(
+            tmp_path, variables={"places": []}, release="2020-01-01.0"
+        )
+        assert backend._resolve_release() == "2020-01-01.0"
+
+    def test_resolve_release_prefers_the_live_release(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """With no explicit release, the live SDK release beats the bundled index."""
+        import overturemaps.core as core
+
+        backend = _make_backend(tmp_path, variables={"places": []})
+        backend._catalog.available_releases = ["2020-01-01.0"]
+        monkeypatch.setattr(core, "get_latest_release", lambda: "2099-12-31.0")
+        assert backend._resolve_release() == "2099-12-31.0"
+
+    def test_resolve_release_falls_back_to_index_when_live_fails(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """A failed live lookup falls back to the newest bundled release."""
+        import overturemaps.core as core
+
+        backend = _make_backend(tmp_path, variables={"places": []})
+        backend._catalog.available_releases = ["2020-01-01.0", "2021-01-01.0"]
+        monkeypatch.setattr(core, "get_latest_release", _boom)
+        assert backend._resolve_release() == "2021-01-01.0"
+
+    def test_resolve_release_raises_when_live_fails_and_index_empty(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """No live release and no bundled one is an error naming the way out."""
         import overturemaps.core as core
 
         backend = _make_backend(tmp_path, variables={"places": []})
         backend._catalog.available_releases = []
-        monkeypatch.setattr(core, "get_latest_release", lambda: "2099-12-31.0")
-        assert backend._resolve_release() == "2099-12-31.0"
+        monkeypatch.setattr(core, "get_latest_release", _boom)
+        with pytest.raises(RuntimeError, match=r"explicit release="):
+            backend._resolve_release()
 
 
 @pytest.mark.overture

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -537,8 +537,11 @@ class TestDuckDBQueryPath:
         backend = _make_backend(tmp_path, variables={"places": []})
         backend._catalog.available_releases = []
         monkeypatch.setattr(core, "get_latest_release", _boom)
-        with pytest.raises(RuntimeError, match=r"explicit release="):
+        with pytest.raises(RuntimeError, match=r"explicit release=") as excinfo:
             backend._resolve_release()
+        assert isinstance(excinfo.value.__cause__, OSError), (
+            "the live-lookup failure should be chained, not swallowed"
+        )
 
 
 @pytest.mark.overture

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -33,6 +33,16 @@ def _boom() -> str:
     raise OSError("no route to stac.overturemaps.org")
 
 
+def _missing_sdk() -> str:
+    """Stand in for a release lookup whose SDK entry point is gone."""
+    raise ImportError("cannot import name 'get_latest_release'")
+
+
+def _renamed_sdk() -> str:
+    """Stand in for a release lookup whose SDK internals moved."""
+    raise AttributeError("'module' object has no attribute 'get_available_releases'")
+
+
 @pytest.mark.overture
 class TestOvertureConstruction:
     """`__init__` wiring and validation."""
@@ -581,6 +591,22 @@ class TestDuckDBQueryPath:
         backend._catalog.available_releases = []
         monkeypatch.setattr(core, "get_latest_release", lambda: "https:")
         with pytest.raises(RuntimeError, match=r"not a release id"):
+            backend._resolve_release()
+
+    @pytest.mark.parametrize(
+        "lookup, error",
+        [(_missing_sdk, ImportError), (_renamed_sdk, AttributeError)],
+    )
+    def test_resolve_release_propagates_a_code_level_failure(
+        self, tmp_path: Path, monkeypatch, lookup, error
+    ):
+        """A missing or renamed SDK entry point fails loudly, not into the index."""
+        import overturemaps.core as core
+
+        backend = _make_backend(tmp_path, variables={"places": []})
+        backend._catalog.available_releases = ["2020-01-01.0"]
+        monkeypatch.setattr(core, "get_latest_release", lookup)
+        with pytest.raises(error):
             backend._resolve_release()
 
     def test_resolve_release_raises_when_live_fails_and_index_empty(

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -528,6 +528,32 @@ class TestDuckDBQueryPath:
         monkeypatch.setattr(core, "get_latest_release", _boom)
         assert backend._resolve_release() == "2021-01-01.0"
 
+    @pytest.mark.parametrize("live", [None, "", "https:", "2026-7-22.0"])
+    def test_resolve_release_rejects_a_live_value_that_is_not_a_release(
+        self, tmp_path: Path, monkeypatch, live
+    ):
+        """A live reply that is not release-shaped falls back like a failure."""
+        import overturemaps.core as core
+
+        backend = _make_backend(tmp_path, variables={"places": []})
+        backend._catalog.available_releases = ["2020-01-01.0"]
+        monkeypatch.setattr(core, "get_latest_release", lambda: live)
+        assert backend._resolve_release() == "2020-01-01.0", (
+            f"a live {live!r} must not reach the S3 glob"
+        )
+
+    def test_resolve_release_raises_on_a_bad_live_value_with_no_index(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """A junk live reply and an empty index name the junk in the error."""
+        import overturemaps.core as core
+
+        backend = _make_backend(tmp_path, variables={"places": []})
+        backend._catalog.available_releases = []
+        monkeypatch.setattr(core, "get_latest_release", lambda: "https:")
+        with pytest.raises(RuntimeError, match=r"not a release id"):
+            backend._resolve_release()
+
     def test_resolve_release_raises_when_live_fails_and_index_empty(
         self, tmp_path: Path, monkeypatch
     ):

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import geopandas as gpd
 import pytest
+from loguru import logger
 
 from earthlens.base import RemoteProduct, SpatialExtent, TemporalExtent
 from earthlens.overture import Overture
@@ -498,6 +499,43 @@ class TestDuckDBQueryPath:
         backend.download()
         assert seen["columns"] == ["names"]
         assert seen["limit"] == 5
+
+    def test_resolved_release_reaches_the_query(
+        self, tmp_path: Path, fake_overture, make_gdf, monkeypatch
+    ):
+        """The release the backend resolves is the one the S3 glob is built from."""
+        seen: dict = {}
+        monkeypatch.setattr(
+            "earthlens.overture.query.query_overture",
+            lambda theme, otype, release, bbox, **k: (
+                seen.update(release=release) or make_gdf([PERMISSIVE_SOURCES])
+            ),
+        )
+        fake_overture.latest = "2031-03-03.0"
+        backend = _make_backend(
+            tmp_path, variables={"places": []}, where="confidence > 0.9"
+        )
+        backend.download()
+        assert seen["release"] == "2031-03-03.0", (
+            "an unpinned DuckDB fetch must glob the live release, not the "
+            "bundled index entry"
+        )
+
+    def test_fallback_to_the_index_is_warned_about(self, tmp_path: Path, monkeypatch):
+        """Falling back to the bundled index says so, and says it may be stale."""
+        import overturemaps.core as core
+
+        backend = _make_backend(tmp_path, variables={"places": []})
+        backend._catalog.available_releases = ["2020-01-01.0"]
+        monkeypatch.setattr(core, "get_latest_release", _boom)
+        messages: list[str] = []
+        sink = logger.add(lambda record: messages.append(str(record)), level="WARNING")
+        try:
+            assert backend._resolve_release() == "2020-01-01.0"
+        finally:
+            logger.remove(sink)
+        assert any("2020-01-01.0" in message for message in messages), messages
+        assert any("may no longer exist" in message for message in messages), messages
 
     def test_duckdb_filename_records_the_resolved_release(
         self, tmp_path: Path, fake_overture, make_gdf, monkeypatch

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -470,7 +470,9 @@ class TestDuckDBQueryPath:
         assert fake_overture.reader_calls == [], "reader must not be used with where="
         assert "license_id" in gpd.read_parquet(paths[0]).columns
 
-    def test_columns_and_limit_forwarded(self, tmp_path: Path, make_gdf, monkeypatch):
+    def test_columns_and_limit_forwarded(
+        self, tmp_path: Path, fake_overture, make_gdf, monkeypatch
+    ):
         """`columns` and `max_features` reach query_overture (limit)."""
         seen: dict = {}
         monkeypatch.setattr(

--- a/libs/providers/hazards/tests/overture/test_backend.py
+++ b/libs/providers/hazards/tests/overture/test_backend.py
@@ -578,13 +578,6 @@ class TestDuckDBQueryPath:
             "the SDK path auto-targets latest itself; it must not look one up"
         )
 
-    def test_resolve_release_explicit(self, tmp_path: Path):
-        """`_resolve_release` returns the explicit release when given."""
-        backend = _make_backend(
-            tmp_path, variables={"places": []}, release="2020-01-01.0"
-        )
-        assert backend._resolve_release() == "2020-01-01.0"
-
     @pytest.mark.parametrize(
         "release", ["not-a-release", "2026-07-22", "2026-7-22.0", ""]
     )

--- a/libs/providers/hazards/tests/overture/test_catalog.py
+++ b/libs/providers/hazards/tests/overture/test_catalog.py
@@ -7,7 +7,12 @@ from pathlib import Path
 import pytest
 
 from earthlens.overture import catalog as overture_catalog
-from earthlens.overture.catalog import CATALOG_PATH, RELEASE_ID, Catalog, Theme
+from earthlens.overture.catalog import (
+    CATALOG_PATH,
+    RELEASE_ID_RE,
+    Catalog,
+    Theme,
+)
 
 
 @pytest.mark.overture
@@ -140,7 +145,7 @@ class TestCatalog:
         """The bundled YAML ships a non-empty, well-formed release index."""
         releases = Catalog().available_releases
         assert releases, "the bundled catalog should ship a release index"
-        assert all(RELEASE_ID.match(r) for r in releases), releases
+        assert all(RELEASE_ID_RE.match(r) for r in releases), releases
 
     def test_latest_release_is_the_newest_indexed(self):
         """`latest_release` returns the newest release the index carries."""

--- a/libs/providers/hazards/tests/overture/test_catalog.py
+++ b/libs/providers/hazards/tests/overture/test_catalog.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
 
-from earthlens.overture.catalog import CATALOG_PATH, Catalog, Theme
-
-#: Shape of an Overture release id (`2026-07-22.0`).
-_RELEASE_ID = re.compile(r"^\d{4}-\d{2}-\d{2}\.\d+$")
+from earthlens.overture import catalog as overture_catalog
+from earthlens.overture.catalog import CATALOG_PATH, RELEASE_ID, Catalog, Theme
 
 
 @pytest.mark.overture
@@ -143,7 +140,7 @@ class TestCatalog:
         """The bundled YAML ships a non-empty, well-formed release index."""
         releases = Catalog().available_releases
         assert releases, "the bundled catalog should ship a release index"
-        assert all(_RELEASE_ID.match(r) for r in releases), releases
+        assert all(RELEASE_ID.match(r) for r in releases), releases
 
     def test_latest_release_is_the_newest_indexed(self):
         """`latest_release` returns the newest release the index carries."""
@@ -178,6 +175,35 @@ class TestCatalog:
             available_releases=["2026-07-22.9", "2026-07-22.10"],
         )
         assert cat.latest_release() == "2026-07-22.10"
+
+    def test_latest_release_ignores_an_id_without_an_ordinal(self):
+        """An id with no ordinal is not a release id and loses to one that is."""
+        cat = Catalog(
+            datasets=Catalog().datasets,
+            available_releases=["2026-07-22.0", "2026-07-22"],
+        )
+        assert cat.latest_release() == "2026-07-22.0"
+
+    def test_latest_release_ignores_a_malformed_entry(self):
+        """A junk entry is skipped rather than sorted above a real release."""
+        cat = Catalog(
+            datasets=Catalog().datasets,
+            available_releases=["2026-07-22.0", "https:"],
+        )
+        assert cat.latest_release() == "2026-07-22.0"
+
+    def test_latest_release_none_when_every_entry_is_malformed(self):
+        """An index with nothing release-shaped resolves to no release at all."""
+        cat = Catalog(datasets=Catalog().datasets, available_releases=["https:"])
+        assert cat.latest_release() is None
+
+    def test_clear_catalog_cache_empties_the_parse_cache(self):
+        """Clearing the cache drops the memoised parse and reloading still works."""
+        Catalog()
+        assert overture_catalog._CATALOG_CACHE, "loading memoises the parse"
+        overture_catalog.clear_catalog_cache()
+        assert not overture_catalog._CATALOG_CACHE, "the cache is emptied"
+        assert Catalog().themes(), "the catalog reloads after a clear"
 
     def test_load_missing_themes_block_raises(self, tmp_path: Path):
         """A YAML without a `themes:` block is rejected."""

--- a/libs/providers/hazards/tests/overture/test_catalog.py
+++ b/libs/providers/hazards/tests/overture/test_catalog.py
@@ -144,9 +144,13 @@ class TestCatalog:
         assert all(is_release_id(r) for r in releases), releases
 
     def test_latest_release_is_the_newest_indexed(self):
-        """`latest_release` returns the newest release the index carries."""
+        """`latest_release` returns the newest release the bundled index carries."""
         cat = Catalog()
-        assert cat.latest_release() == max(cat.available_releases)
+        newest = sorted(
+            cat.available_releases,
+            key=lambda r: (r.split(".")[0], int(r.split(".")[1])),
+        )[-1]
+        assert cat.latest_release() == newest
 
     def test_latest_release_none_when_index_empty(self):
         """`latest_release` is `None` when the index is explicitly empty."""

--- a/libs/providers/hazards/tests/overture/test_catalog.py
+++ b/libs/providers/hazards/tests/overture/test_catalog.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
 
 from earthlens.overture.catalog import CATALOG_PATH, Catalog, Theme
+
+#: Shape of an Overture release id (`2026-07-22.0`).
+_RELEASE_ID = re.compile(r"^\d{4}-\d{2}-\d{2}\.\d+$")
 
 
 @pytest.mark.overture
@@ -139,12 +143,12 @@ class TestCatalog:
         """The bundled YAML ships a non-empty, well-formed release index."""
         releases = Catalog().available_releases
         assert releases, "the bundled catalog should ship a release index"
-        assert all(r[:2] == "20" for r in releases), releases
+        assert all(_RELEASE_ID.match(r) for r in releases), releases
 
-    def test_latest_release_matches_first_indexed(self):
-        """`latest_release` returns the first (newest) indexed release."""
+    def test_latest_release_is_the_newest_indexed(self):
+        """`latest_release` returns the newest release the index carries."""
         cat = Catalog()
-        assert cat.latest_release() == cat.available_releases[0]
+        assert cat.latest_release() == max(cat.available_releases)
 
     def test_latest_release_none_when_index_empty(self):
         """`latest_release` is `None` when the index is explicitly empty."""
@@ -152,12 +156,28 @@ class TestCatalog:
         assert cat.latest_release() is None
 
     def test_latest_release_returns_newest(self):
-        """`latest_release` returns the first (newest) of a supplied index."""
+        """`latest_release` returns the newest of a supplied index."""
         cat = Catalog(
             datasets=Catalog().datasets,
             available_releases=["2026-05-20.0", "2026-04-15.0"],
         )
         assert cat.latest_release() == "2026-05-20.0"
+
+    def test_latest_release_ignores_index_order(self):
+        """An ascending index — the order a refresh writes — still yields the newest."""
+        cat = Catalog(
+            datasets=Catalog().datasets,
+            available_releases=["2026-04-15.0", "2026-05-20.0"],
+        )
+        assert cat.latest_release() == "2026-05-20.0"
+
+    def test_latest_release_compares_the_ordinal_numerically(self):
+        """A two-digit ordinal beats a one-digit one from the same date."""
+        cat = Catalog(
+            datasets=Catalog().datasets,
+            available_releases=["2026-07-22.9", "2026-07-22.10"],
+        )
+        assert cat.latest_release() == "2026-07-22.10"
 
     def test_load_missing_themes_block_raises(self, tmp_path: Path):
         """A YAML without a `themes:` block is rejected."""

--- a/libs/providers/hazards/tests/overture/test_catalog.py
+++ b/libs/providers/hazards/tests/overture/test_catalog.py
@@ -7,12 +7,8 @@ from pathlib import Path
 import pytest
 
 from earthlens.overture import catalog as overture_catalog
-from earthlens.overture.catalog import (
-    CATALOG_PATH,
-    RELEASE_ID_RE,
-    Catalog,
-    Theme,
-)
+from earthlens.overture.catalog import CATALOG_PATH, Catalog, Theme
+from earthlens.overture.releases import is_release_id
 
 
 @pytest.mark.overture
@@ -145,7 +141,7 @@ class TestCatalog:
         """The bundled YAML ships a non-empty, well-formed release index."""
         releases = Catalog().available_releases
         assert releases, "the bundled catalog should ship a release index"
-        assert all(RELEASE_ID_RE.match(r) for r in releases), releases
+        assert all(is_release_id(r) for r in releases), releases
 
     def test_latest_release_is_the_newest_indexed(self):
         """`latest_release` returns the newest release the index carries."""

--- a/libs/providers/hazards/tests/overture/test_cli.py
+++ b/libs/providers/hazards/tests/overture/test_cli.py
@@ -124,6 +124,22 @@ class TestRefresher:
         )
         assert overture_cli._child_release_ids() == ["2026-07-22.0", "2026-06-17.0"]
 
+    def test_child_release_ids_skip_a_href_with_no_release_segment(self, monkeypatch):
+        """A child link too short to carry a release contributes nothing."""
+        monkeypatch.setattr(
+            overture_cli.requests,
+            "get",
+            lambda url, timeout: _StacResponse(
+                {
+                    "links": [
+                        {"rel": "child", "href": "https://stac.example/catalog.json"},
+                        {"rel": "child", "href": ""},
+                    ]
+                }
+            ),
+        )
+        assert overture_cli._child_release_ids() == []
+
     def test_release_ids_keep_latest_when_list_is_unusable(self, monkeypatch):
         """The latest release still lands even when every listed id is junk."""
         import overturemaps.core as core

--- a/libs/providers/hazards/tests/overture/test_cli.py
+++ b/libs/providers/hazards/tests/overture/test_cli.py
@@ -19,27 +19,19 @@ from earthlens.cli.curate import probe_dataset
 from earthlens.cli.refresh import refresh_one
 from earthlens.cli.validate import validate_one
 from earthlens.overture import catalog as overture_catalog
+from earthlens.overture.releases import ReleaseLookupError
 
 pytestmark = pytest.mark.cli
-
-
-class _StacResponse:
-    """Minimal stand-in for the STAC catalog HTTP response."""
-
-    def __init__(self, payload: dict):
-        self._payload = payload
-
-    def raise_for_status(self) -> None:
-        """Accept the response (the fake never carries an error status)."""
-
-    def json(self) -> dict:
-        """Return the canned catalog document."""
-        return self._payload
 
 
 def _info():
     """Return the BackendInfo for the overture backend."""
     return next(b for b in list_backends() if b.provider == "overture")
+
+
+def _unreachable_stac() -> list[str]:
+    """Stand in for a child-link read that cannot reach the STAC catalog."""
+    raise ReleaseLookupError("could not read Overture's STAC catalog (no route)")
 
 
 class TestRefresher:
@@ -71,7 +63,21 @@ class TestRefresher:
             "get_available_releases",
             lambda: (["https:", "https:"], "2026-07-22.0"),
         )
-        monkeypatch.setattr(overture_cli, "_child_release_ids", list)
+        monkeypatch.setattr("earthlens.overture.releases.child_release_ids", list)
+        assert overture_cli._release_ids() == ["2026-07-22.0"]
+
+    def test_release_ids_survive_an_unreachable_recovery(self, monkeypatch):
+        """A recovery that cannot reach the catalog keeps whatever did parse."""
+        import overturemaps.core as core
+
+        monkeypatch.setattr(
+            core,
+            "get_available_releases",
+            lambda: (["https:", "2026-07-22.0"], "2026-07-22.0"),
+        )
+        monkeypatch.setattr(
+            "earthlens.overture.releases.child_release_ids", _unreachable_stac
+        )
         assert overture_cli._release_ids() == ["2026-07-22.0"]
 
     def test_release_ids_recover_the_list_from_the_child_links(self, monkeypatch):
@@ -84,8 +90,7 @@ class TestRefresher:
             lambda: (["https:", "https:"], "2026-07-22.0"),
         )
         monkeypatch.setattr(
-            overture_cli,
-            "_child_release_ids",
+            "earthlens.overture.releases.child_release_ids",
             lambda: ["2026-07-22.0", "2026-06-17.0"],
         )
         assert overture_cli._release_ids() == ["2026-06-17.0", "2026-07-22.0"], (
@@ -97,48 +102,9 @@ class TestRefresher:
         import overturemaps.core as core
 
         monkeypatch.setattr(core, "get_available_releases", lambda: (["https:"], None))
-        monkeypatch.setattr(overture_cli, "_child_release_ids", list)
-        with pytest.raises(RuntimeError, match=r"offline fallback"):
+        monkeypatch.setattr("earthlens.overture.releases.child_release_ids", list)
+        with pytest.raises(ReleaseLookupError, match=r"offline fallback"):
             overture_cli._release_ids()
-
-    def test_child_release_ids_read_the_release_out_of_each_href(self, monkeypatch):
-        """The release is the path segment before catalog.json, not a naive split."""
-        monkeypatch.setattr(
-            overture_cli.requests,
-            "get",
-            lambda url, timeout: _StacResponse(
-                {
-                    "links": [
-                        {"rel": "root", "href": "https://stac.example/catalog.json"},
-                        {
-                            "rel": "child",
-                            "href": "https://stac.example/2026-07-22.0/catalog.json",
-                        },
-                        {
-                            "rel": "child",
-                            "href": "https://stac.example/2026-06-17.0/catalog.json",
-                        },
-                    ]
-                }
-            ),
-        )
-        assert overture_cli._child_release_ids() == ["2026-07-22.0", "2026-06-17.0"]
-
-    def test_child_release_ids_skip_a_href_with_no_release_segment(self, monkeypatch):
-        """A child link too short to carry a release contributes nothing."""
-        monkeypatch.setattr(
-            overture_cli.requests,
-            "get",
-            lambda url, timeout: _StacResponse(
-                {
-                    "links": [
-                        {"rel": "child", "href": "https://stac.example/catalog.json"},
-                        {"rel": "child", "href": ""},
-                    ]
-                }
-            ),
-        )
-        assert overture_cli._child_release_ids() == []
 
     def test_release_ids_keep_latest_when_list_is_unusable(self, monkeypatch):
         """The latest release still lands even when every listed id is junk."""
@@ -156,7 +122,7 @@ class TestRefresher:
         monkeypatch.setattr(
             core, "get_available_releases", lambda: ["2026-07-22.0", "junk"]
         )
-        monkeypatch.setattr(overture_cli, "_child_release_ids", list)
+        monkeypatch.setattr("earthlens.overture.releases.child_release_ids", list)
         assert overture_cli._release_ids() == ["2026-07-22.0"]
 
     def test_release_ids_without_a_latest(self, monkeypatch):

--- a/libs/providers/hazards/tests/overture/test_cli.py
+++ b/libs/providers/hazards/tests/overture/test_cli.py
@@ -23,6 +23,20 @@ from earthlens.overture import catalog as overture_catalog
 pytestmark = pytest.mark.cli
 
 
+class _StacResponse:
+    """Minimal stand-in for the STAC catalog HTTP response."""
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        """Accept the response (the fake never carries an error status)."""
+
+    def json(self) -> dict:
+        """Return the canned catalog document."""
+        return self._payload
+
+
 def _info():
     """Return the BackendInfo for the overture backend."""
     return next(b for b in list_backends() if b.provider == "overture")
@@ -57,7 +71,58 @@ class TestRefresher:
             "get_available_releases",
             lambda: (["https:", "https:"], "2026-07-22.0"),
         )
+        monkeypatch.setattr(overture_cli, "_child_release_ids", list)
         assert overture_cli._release_ids() == ["2026-07-22.0"]
+
+    def test_release_ids_recover_the_list_from_the_child_links(self, monkeypatch):
+        """Unparsed ids are re-read from the STAC catalog's child links."""
+        import overturemaps.core as core
+
+        monkeypatch.setattr(
+            core,
+            "get_available_releases",
+            lambda: (["https:", "https:"], "2026-07-22.0"),
+        )
+        monkeypatch.setattr(
+            overture_cli,
+            "_child_release_ids",
+            lambda: ["2026-07-22.0", "2026-06-17.0"],
+        )
+        assert overture_cli._release_ids() == ["2026-06-17.0", "2026-07-22.0"], (
+            "the release the SDK could not parse must still be indexed"
+        )
+
+    def test_release_ids_raise_rather_than_blank_the_index(self, monkeypatch):
+        """Nothing parseable upstream is an error, not an empty index."""
+        import overturemaps.core as core
+
+        monkeypatch.setattr(core, "get_available_releases", lambda: (["https:"], None))
+        monkeypatch.setattr(overture_cli, "_child_release_ids", list)
+        with pytest.raises(RuntimeError, match=r"offline fallback"):
+            overture_cli._release_ids()
+
+    def test_child_release_ids_read_the_release_out_of_each_href(self, monkeypatch):
+        """The release is the path segment before catalog.json, not a naive split."""
+        monkeypatch.setattr(
+            overture_cli.requests,
+            "get",
+            lambda url, timeout: _StacResponse(
+                {
+                    "links": [
+                        {"rel": "root", "href": "https://stac.example/catalog.json"},
+                        {
+                            "rel": "child",
+                            "href": "https://stac.example/2026-07-22.0/catalog.json",
+                        },
+                        {
+                            "rel": "child",
+                            "href": "https://stac.example/2026-06-17.0/catalog.json",
+                        },
+                    ]
+                }
+            ),
+        )
+        assert overture_cli._child_release_ids() == ["2026-07-22.0", "2026-06-17.0"]
 
     def test_release_ids_keep_latest_when_list_is_unusable(self, monkeypatch):
         """The latest release still lands even when every listed id is junk."""
@@ -75,6 +140,7 @@ class TestRefresher:
         monkeypatch.setattr(
             core, "get_available_releases", lambda: ["2026-07-22.0", "junk"]
         )
+        monkeypatch.setattr(overture_cli, "_child_release_ids", list)
         assert overture_cli._release_ids() == ["2026-07-22.0"]
 
     def test_release_ids_without_a_latest(self, monkeypatch):

--- a/libs/providers/hazards/tests/overture/test_cli.py
+++ b/libs/providers/hazards/tests/overture/test_cli.py
@@ -77,6 +77,26 @@ class TestRefresher:
         )
         assert overture_cli._release_ids() == ["2026-07-22.0"]
 
+    def test_release_ids_without_a_latest(self, monkeypatch):
+        """A `None` latest is skipped rather than indexed as a release."""
+        import overturemaps.core as core
+
+        monkeypatch.setattr(
+            core, "get_available_releases", lambda: (["2026-07-22.0"], None)
+        )
+        assert overture_cli._release_ids() == ["2026-07-22.0"]
+
+    def test_release_ids_deduplicate_the_latest(self, monkeypatch):
+        """A latest already present in the list is not indexed twice."""
+        import overturemaps.core as core
+
+        monkeypatch.setattr(
+            core,
+            "get_available_releases",
+            lambda: (["2026-07-22.0", "2026-07-22.0"], "2026-07-22.0"),
+        )
+        assert overture_cli._release_ids() == ["2026-07-22.0"]
+
     def test_diffs_releases_not_feature_types(self, monkeypatch):
         """overture diffs the live releases against available_releases."""
         monkeypatch.setattr(
@@ -185,3 +205,11 @@ class TestValidator:
         monkeypatch.setattr(overture_cli, "_live_sample", boom)
         result = validate_one(_info(), live=True)
         assert any("fetch failed" in i for i in result.issues), "fetch failure reported"
+
+    def test_live_reports_nothing_when_every_type_resolves(self, monkeypatch):
+        """A catalog whose types all serve sources yields no live issues."""
+        monkeypatch.setattr(overture_cli, "_live_sample", lambda t: (3, True))
+        result = validate_one(_info(), live=True)
+        assert not result.issues, (
+            f"expected a clean live validation, got {result.issues}"
+        )

--- a/libs/providers/hazards/tests/overture/test_cli.py
+++ b/libs/providers/hazards/tests/overture/test_cli.py
@@ -47,12 +47,9 @@ class TestRefresher:
             lambda: (["2026-07-22.0", "2026-06-17.0"], "2026-07-22.0"),
         )
         assert overture_cli._release_ids() == ["2026-06-17.0", "2026-07-22.0"]
-        monkeypatch.setattr(
-            overture_cli, "_release_ids", lambda: ["2026-07-22.0", "2026-06-17.0"]
-        )
         assert overture_cli.refresher(None) == {
             "overture": ["2026-06-17.0", "2026-07-22.0"]
-        }
+        }, "the refresher reports what the lister found, already sorted"
 
     def test_release_ids_drop_unparsed_hrefs(self, monkeypatch):
         """Ids that are not shaped like a release never reach the index."""
@@ -106,13 +103,29 @@ class TestRefresher:
         with pytest.raises(ReleaseLookupError, match=r"offline fallback"):
             overture_cli._release_ids()
 
-    def test_release_ids_keep_latest_when_list_is_unusable(self, monkeypatch):
-        """The latest release still lands even when every listed id is junk."""
+    def test_release_ids_recover_when_the_sdk_lists_nothing(self, monkeypatch):
+        """An empty SDK list triggers recovery too, not just a malformed one."""
         import overturemaps.core as core
 
         monkeypatch.setattr(
             core, "get_available_releases", lambda: ([], "2026-07-22.0")
         )
+        monkeypatch.setattr(
+            "earthlens.overture.releases.child_release_ids",
+            lambda: ["2026-07-22.0", "2026-06-17.0"],
+        )
+        assert overture_cli._release_ids() == ["2026-06-17.0", "2026-07-22.0"], (
+            "a short list leaves the index as wrong as a mangled one"
+        )
+
+    def test_release_ids_keep_latest_when_recovery_finds_nothing(self, monkeypatch):
+        """The latest release still lands when recovery turns up empty."""
+        import overturemaps.core as core
+
+        monkeypatch.setattr(
+            core, "get_available_releases", lambda: ([], "2026-07-22.0")
+        )
+        monkeypatch.setattr("earthlens.overture.releases.child_release_ids", list)
         assert overture_cli._release_ids() == ["2026-07-22.0"]
 
     def test_release_ids_tolerate_a_bare_list(self, monkeypatch):
@@ -255,9 +268,16 @@ class TestValidator:
         assert any("fetch failed" in i for i in result.issues), "fetch failure reported"
 
     def test_live_reports_nothing_when_every_type_resolves(self, monkeypatch):
-        """A catalog whose types all serve sources yields no live issues."""
-        monkeypatch.setattr(overture_cli, "_live_sample", lambda t: (3, True))
+        """A clean live validation walks every curated theme and flags none."""
+        sampled: list[str] = []
+        monkeypatch.setattr(
+            overture_cli, "_live_sample", lambda t: (sampled.append(t), (3, True))[1]
+        )
         result = validate_one(_info(), live=True)
         assert not result.issues, (
             f"expected a clean live validation, got {result.issues}"
         )
+        catalog = load_catalog(_info())
+        assert sorted(sampled) == sorted(
+            getattr(r, "default_type", None) or k for k, r in catalog.datasets.items()
+        ), "every curated theme's default type should have been sampled"

--- a/libs/providers/hazards/tests/overture/test_cli.py
+++ b/libs/providers/hazards/tests/overture/test_cli.py
@@ -32,19 +32,50 @@ class TestRefresher:
     """Tests for the Overture releases lister."""
 
     def test_release_ids_unwrap_tuple(self, monkeypatch):
-        """release ids unwrap the (releases, latest) tuple; grouped sorts them."""
+        """release ids unwrap the (releases, latest) tuple and sort them."""
         import overturemaps.core as core
 
         monkeypatch.setattr(
             core,
             "get_available_releases",
-            lambda: (["2024-01", "2023-12"], "2024-01"),
+            lambda: (["2026-07-22.0", "2026-06-17.0"], "2026-07-22.0"),
         )
-        assert overture_cli._release_ids() == ["2024-01", "2023-12"]
+        assert overture_cli._release_ids() == ["2026-06-17.0", "2026-07-22.0"]
         monkeypatch.setattr(
-            overture_cli, "_release_ids", lambda: ["2024-01", "2023-12"]
+            overture_cli, "_release_ids", lambda: ["2026-07-22.0", "2026-06-17.0"]
         )
-        assert overture_cli.refresher(None) == {"overture": ["2023-12", "2024-01"]}
+        assert overture_cli.refresher(None) == {
+            "overture": ["2026-06-17.0", "2026-07-22.0"]
+        }
+
+    def test_release_ids_drop_unparsed_hrefs(self, monkeypatch):
+        """Ids that are not shaped like a release never reach the index."""
+        import overturemaps.core as core
+
+        monkeypatch.setattr(
+            core,
+            "get_available_releases",
+            lambda: (["https:", "https:"], "2026-07-22.0"),
+        )
+        assert overture_cli._release_ids() == ["2026-07-22.0"]
+
+    def test_release_ids_keep_latest_when_list_is_unusable(self, monkeypatch):
+        """The latest release still lands even when every listed id is junk."""
+        import overturemaps.core as core
+
+        monkeypatch.setattr(
+            core, "get_available_releases", lambda: ([], "2026-07-22.0")
+        )
+        assert overture_cli._release_ids() == ["2026-07-22.0"]
+
+    def test_release_ids_tolerate_a_bare_list(self, monkeypatch):
+        """A non-tuple return is treated as the release list alone."""
+        import overturemaps.core as core
+
+        monkeypatch.setattr(
+            core, "get_available_releases", lambda: ["2026-07-22.0", "junk"]
+        )
+        assert overture_cli._release_ids() == ["2026-07-22.0"]
 
     def test_diffs_releases_not_feature_types(self, monkeypatch):
         """overture diffs the live releases against available_releases."""

--- a/libs/providers/hazards/tests/overture/test_overture_e2e.py
+++ b/libs/providers/hazards/tests/overture/test_overture_e2e.py
@@ -7,7 +7,7 @@ needed. A default `pytest` invocation skips them.
 
 Run with:
 
-    pixi run -e dev pytest -m "e2e and overture" tests/overture
+    uv run --locked pytest -m "e2e and overture" -v
 """
 
 from __future__ import annotations
@@ -127,3 +127,21 @@ class TestOvertureLiveFetch:
 
         release = get_latest_release()
         assert release and release[:2] == "20", f"unexpected release {release!r}"
+
+    def test_duckdb_release_is_resolved_live(self, tmp_path: Path):
+        """The DuckDB path globs the published release, not the bundled index."""
+        from overturemaps.core import get_latest_release
+
+        backend = EarthLens(
+            data_source="overture",
+            variables={"places": []},
+            lat_lim=_LAT_LIM,
+            lon_lim=_LON_LIM,
+            path=str(tmp_path),
+            where="confidence > 0.95",
+        ).datasource
+
+        assert backend._resolve_release() == get_latest_release(), (
+            "an unpinned DuckDB fetch must target the release Overture "
+            "publishes; the bundled index goes stale as releases are pruned"
+        )

--- a/libs/providers/hazards/tests/overture/test_overture_e2e.py
+++ b/libs/providers/hazards/tests/overture/test_overture_e2e.py
@@ -19,7 +19,8 @@ import geopandas as gpd
 import pytest
 
 from earthlens.earthlens import EarthLens
-from earthlens.overture import LicenseWarning
+from earthlens.overture import LicenseWarning, query_overture
+from earthlens.overture.catalog import RELEASE_ID
 
 #: A tiny bbox over a dense Manhattan block (Times Square), small enough to
 #: fetch in seconds and reliably non-empty for both places and buildings.
@@ -122,16 +123,14 @@ class TestOvertureLiveFetch:
         assert gdf.crs.to_epsg() == 4326
 
     def test_release_helpers_live(self):
-        """The SDK's release helpers resolve a real, recent release id."""
+        """The SDK's release helpers resolve a real, well-formed release id."""
         from overturemaps.core import get_latest_release
 
         release = get_latest_release()
-        assert release and release[:2] == "20", f"unexpected release {release!r}"
+        assert release and RELEASE_ID.match(release), f"unexpected release {release!r}"
 
     def test_duckdb_release_is_resolved_live(self, tmp_path: Path):
-        """The DuckDB path globs the published release, not the bundled index."""
-        from overturemaps.core import get_latest_release
-
+        """The release the DuckDB path resolves has objects under it on S3."""
         backend = EarthLens(
             data_source="overture",
             variables={"places": []},
@@ -141,7 +140,21 @@ class TestOvertureLiveFetch:
             where="confidence > 0.95",
         ).datasource
 
-        assert backend._resolve_release() == get_latest_release(), (
-            "an unpinned DuckDB fetch must target the release Overture "
-            "publishes; the bundled index goes stale as releases are pruned"
+        release = backend._resolve_release()
+        assert RELEASE_ID.match(release), f"resolved a non-release {release!r}"
+        assert release not in backend._catalog.available_releases or (
+            release == backend._catalog.latest_release()
+        ), "the resolved id must come from upstream, not from a stale index"
+
+        # The #931 failure was an id that resolved to nothing on S3, so glob
+        # the resolved release directly: an aged-out id raises
+        # `No files found that match the pattern` here rather than silently
+        # returning an empty frame.
+        gdf = query_overture(
+            "places",
+            "place",
+            release,
+            (_LON_LIM[0], _LAT_LIM[0], _LON_LIM[1], _LAT_LIM[1]),
+            limit=1,
         )
+        assert len(gdf) == 1, f"release {release!r} served no rows for the block"

--- a/libs/providers/hazards/tests/overture/test_overture_e2e.py
+++ b/libs/providers/hazards/tests/overture/test_overture_e2e.py
@@ -20,7 +20,7 @@ import pytest
 
 from earthlens.earthlens import EarthLens
 from earthlens.overture import LicenseWarning, query_overture
-from earthlens.overture.catalog import RELEASE_ID
+from earthlens.overture.catalog import RELEASE_ID_RE
 
 #: A tiny bbox over a dense Manhattan block (Times Square), small enough to
 #: fetch in seconds and reliably non-empty for both places and buildings.
@@ -127,7 +127,9 @@ class TestOvertureLiveFetch:
         from overturemaps.core import get_latest_release
 
         release = get_latest_release()
-        assert release and RELEASE_ID.match(release), f"unexpected release {release!r}"
+        assert release and RELEASE_ID_RE.match(release), (
+            f"unexpected release {release!r}"
+        )
 
     def test_duckdb_release_is_resolved_live(self, tmp_path: Path):
         """The release the DuckDB path resolves has objects under it on S3."""
@@ -141,7 +143,7 @@ class TestOvertureLiveFetch:
         ).datasource
 
         release = backend._resolve_release()
-        assert RELEASE_ID.match(release), f"resolved a non-release {release!r}"
+        assert RELEASE_ID_RE.match(release), f"resolved a non-release {release!r}"
         assert release not in backend._catalog.available_releases or (
             release == backend._catalog.latest_release()
         ), "the resolved id must come from upstream, not from a stale index"

--- a/libs/providers/hazards/tests/overture/test_overture_e2e.py
+++ b/libs/providers/hazards/tests/overture/test_overture_e2e.py
@@ -20,7 +20,8 @@ import pytest
 
 from earthlens.earthlens import EarthLens
 from earthlens.overture import LicenseWarning, query_overture
-from earthlens.overture.catalog import RELEASE_ID_RE
+from earthlens.overture.releases import is_release_id
+from earthlens.overture.releases import latest_release as live_latest_release
 
 #: A tiny bbox over a dense Manhattan block (Times Square), small enough to
 #: fetch in seconds and reliably non-empty for both places and buildings.
@@ -127,9 +128,7 @@ class TestOvertureLiveFetch:
         from overturemaps.core import get_latest_release
 
         release = get_latest_release()
-        assert release and RELEASE_ID_RE.match(release), (
-            f"unexpected release {release!r}"
-        )
+        assert is_release_id(release), f"unexpected release {release!r}"
 
     def test_duckdb_release_is_resolved_live(self, tmp_path: Path):
         """The release the DuckDB path resolves has objects under it on S3."""
@@ -143,10 +142,11 @@ class TestOvertureLiveFetch:
         ).datasource
 
         release = backend._resolve_release()
-        assert RELEASE_ID_RE.match(release), f"resolved a non-release {release!r}"
-        assert release not in backend._catalog.available_releases or (
-            release == backend._catalog.latest_release()
-        ), "the resolved id must come from upstream, not from a stale index"
+        assert is_release_id(release), f"resolved a non-release {release!r}"
+        assert release == live_latest_release(), (
+            "an unpinned DuckDB fetch must target the release Overture "
+            "publishes now, not whatever the bundled index happens to hold"
+        )
 
         # The #931 failure was an id that resolved to nothing on S3, so glob
         # the resolved release directly: an aged-out id raises

--- a/libs/providers/hazards/tests/overture/test_releases.py
+++ b/libs/providers/hazards/tests/overture/test_releases.py
@@ -77,8 +77,9 @@ class TestStacCatalog:
 
     def test_rejects_a_document_that_is_not_an_object(self):
         """A JSON array is not a catalog."""
+        client = _FakeClient(["2026-07-22.0"])
         with pytest.raises(ReleaseLookupError, match=r"not a JSON object"):
-            stac_catalog(_FakeClient(["2026-07-22.0"]))
+            stac_catalog(client)
 
     def test_default_client_is_bounded(self):
         """The default transport carries the module's timeout."""
@@ -96,13 +97,15 @@ class TestLatestRelease:
     @pytest.mark.parametrize("latest", [None, "", "https:", "2026-7-22.0"])
     def test_rejects_a_latest_that_is_not_a_release(self, latest):
         """A missing or malformed `latest` is a lookup failure, not a release."""
+        client = _FakeClient({"latest": latest})
         with pytest.raises(ReleaseLookupError, match=r"not a release id"):
-            latest_release(_FakeClient({"latest": latest}))
+            latest_release(client)
 
     def test_propagates_a_catalog_failure(self):
         """An unreadable catalog fails here too."""
+        client = _FakeClient(error=OSError("no route"))
         with pytest.raises(ReleaseLookupError):
-            latest_release(_FakeClient(error=OSError("no route")))
+            latest_release(client)
 
 
 @pytest.mark.overture

--- a/libs/providers/hazards/tests/overture/test_releases.py
+++ b/libs/providers/hazards/tests/overture/test_releases.py
@@ -1,0 +1,159 @@
+"""Unit tests for `earthlens.overture.releases`."""
+
+from __future__ import annotations
+
+import pytest
+
+from earthlens.overture.releases import (
+    STAC_TIMEOUT,
+    ReleaseLookupError,
+    child_release_ids,
+    is_release_id,
+    latest_release,
+    stac_catalog,
+)
+
+
+class _FakeClient:
+    """Stand-in transport that returns or raises a canned STAC response."""
+
+    def __init__(self, payload=None, error: Exception | None = None):
+        self.payload = payload
+        self.error = error
+        self.urls: list[str] = []
+
+    def get_json(self, url: str):
+        """Record the URL and return the canned payload, or raise."""
+        self.urls.append(url)
+        if self.error is not None:
+            raise self.error
+        return self.payload
+
+
+@pytest.mark.overture
+class TestIsReleaseId:
+    """Shape check for an Overture release id."""
+
+    @pytest.mark.parametrize(
+        "value", ["2026-07-22.0", "2026-06-17.1", "2026-07-22.10", "9999-99-99.0"]
+    )
+    def test_accepts_a_release_shaped_id(self, value):
+        """Anything of the form yyyy-mm-dd.<ordinal> is release-shaped."""
+        assert is_release_id(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["https:", "2026-7-22.0", "2026-07-22", "", "latest", "2026-07-22.0 "],
+    )
+    def test_rejects_anything_else(self, value):
+        """Fragments, typos, and ordinal-less ids are not release ids."""
+        assert not is_release_id(value)
+
+    def test_rejects_a_trailing_newline(self):
+        """A trailing newline does not sneak past the anchors."""
+        assert not is_release_id("2026-07-22.0\n")
+
+    @pytest.mark.parametrize("value", [None, 20260722, ["2026-07-22.0"]])
+    def test_rejects_a_non_string(self, value):
+        """A non-string is answered, not raised at."""
+        assert not is_release_id(value)
+
+
+@pytest.mark.overture
+class TestStacCatalog:
+    """Fetching Overture's STAC root document."""
+
+    def test_returns_the_decoded_document(self):
+        """A JSON object comes back as-is."""
+        client = _FakeClient({"latest": "2026-07-22.0"})
+        assert stac_catalog(client) == {"latest": "2026-07-22.0"}
+        assert client.urls == ["https://stac.overturemaps.org/catalog.json"]
+
+    def test_wraps_a_transport_failure(self):
+        """A 5xx, timeout, or decode error surfaces as one typed error."""
+        client = _FakeClient(error=OSError("connection reset"))
+        with pytest.raises(ReleaseLookupError, match=r"connection reset"):
+            stac_catalog(client)
+
+    def test_rejects_a_document_that_is_not_an_object(self):
+        """A JSON array is not a catalog."""
+        with pytest.raises(ReleaseLookupError, match=r"not a JSON object"):
+            stac_catalog(_FakeClient(["2026-07-22.0"]))
+
+    def test_default_client_is_bounded(self):
+        """The default transport carries the module's timeout."""
+        assert STAC_TIMEOUT == (5.0, 15.0)
+
+
+@pytest.mark.overture
+class TestLatestRelease:
+    """Reading the published release id."""
+
+    def test_returns_the_latest_key(self):
+        """The catalog's own `latest` field is the answer."""
+        assert latest_release(_FakeClient({"latest": "2026-07-22.0"})) == "2026-07-22.0"
+
+    @pytest.mark.parametrize("latest", [None, "", "https:", "2026-7-22.0"])
+    def test_rejects_a_latest_that_is_not_a_release(self, latest):
+        """A missing or malformed `latest` is a lookup failure, not a release."""
+        with pytest.raises(ReleaseLookupError, match=r"not a release id"):
+            latest_release(_FakeClient({"latest": latest}))
+
+    def test_propagates_a_catalog_failure(self):
+        """An unreadable catalog fails here too."""
+        with pytest.raises(ReleaseLookupError):
+            latest_release(_FakeClient(error=OSError("no route")))
+
+
+@pytest.mark.overture
+class TestChildReleaseIds:
+    """Reading the release ids out of the catalog's child links."""
+
+    def test_reads_the_segment_before_catalog_json(self):
+        """The release is the second-to-last path segment of each child href."""
+        client = _FakeClient(
+            {
+                "links": [
+                    {"rel": "root", "href": "https://stac.example/catalog.json"},
+                    {
+                        "rel": "child",
+                        "href": "https://stac.example/2026-07-22.0/catalog.json",
+                    },
+                    {
+                        "rel": "child",
+                        "href": "https://stac.example/2026-06-17.0/catalog.json",
+                    },
+                    {"rel": "self", "href": "https://stac.example/catalog.json"},
+                ]
+            }
+        )
+        assert child_release_ids(client) == ["2026-07-22.0", "2026-06-17.0"]
+
+    def test_reads_a_relative_href(self):
+        """The SDK's documented relative form parses too."""
+        client = _FakeClient(
+            {"links": [{"rel": "child", "href": "./2026-07-22.0/catalog.json"}]}
+        )
+        assert child_release_ids(client) == ["2026-07-22.0"]
+
+    def test_skips_an_href_with_no_release_segment(self):
+        """A child link too short to carry a release contributes nothing."""
+        client = _FakeClient(
+            {
+                "links": [
+                    {"rel": "child", "href": "https://stac.example/catalog.json"},
+                    {"rel": "child", "href": ""},
+                ]
+            }
+        )
+        assert child_release_ids(client) == []
+
+    @pytest.mark.parametrize("links", [None, "not-a-list", []])
+    def test_tolerates_a_catalog_without_usable_links(self, links):
+        """A missing or malformed `links` block yields no ids rather than raising."""
+        assert child_release_ids(_FakeClient({"links": links})) == []
+
+    def test_skips_a_link_that_is_not_an_object(self):
+        """A non-object entry in `links` is ignored."""
+        client = _FakeClient({"links": ["https://stac.example/2026-07-22.0/"]})
+        assert child_release_ids(client) == []


### PR DESCRIPTION
# Description

The Overture DuckDB query path built its S3 glob from the **bundled** `available_releases:` catalog index rather
than from what Overture actually publishes. Overture keeps only the newest release (or two) on
`s3://overturemaps-us-west-2` and prunes the rest, so the pinned `2026-05-20.0` no longer exists and the glob
matched zero files:

```
_duckdb.IOException: IO Error: No files found that match the pattern
"s3://overturemaps-us-west-2/release/2026-05-20.0/theme=places/type=place/*"
```

Verified against the live bucket: `release/` holds one prefix, `2026-07-22.0`;
`release/2026-05-20.0/theme=places/` returns `KeyCount 0`. This is **not** e2e-only — no test or user pins
`release=`, so every `where=` / `columns=` fetch through the shipped wheel hit the same failure. The default
(non-DuckDB) path was unaffected: it leaves `release=None` and lets the SDK auto-target.

## What changed

**One home for the release axis.** A new `earthlens.overture.releases` owns what a release id is (`is_release_id`)
and what Overture publishes now (`latest_release`, `child_release_ids`). Both live reads go through core's
`HttpClient`: bounded by `STAC_TIMEOUT`, carrying the shared retry and user-agent policy, and raising a single
typed `ReleaseLookupError`. The `overturemaps` SDK is deliberately not used for these — its lookups call
`urlopen(STAC_CATALOG_URL)` with no `timeout=`, inheriting the global socket default of `None`, so a route that
drops rather than refuses would hang `download()` indefinitely and never reach the offline fallback built for
exactly that case. Only the SDK's `STAC_CATALOG_URL` constant is reused.

**Release resolution.** `Overture._resolve_release` resolves in order: explicit `release=` → the published
release, shape-checked → the newest bundled entry (offline fallback, with a `WARNING`) → a `RuntimeError` naming
the escape hatch. It runs **once per `download()`**, so a download is release-consistent by construction rather
than able to mix two snapshots when a mid-loop lookup recovers. A genuine code fault propagates instead of
degrading to the stale id, which would be #931 restored at `WARNING` level.

**The refresher was writing junk.** `overturemaps` derives its release list by splitting each STAC child href on
`/` after stripping `./`; the catalog now serves absolute hrefs, so `get_available_releases()` returns
`['https:', 'https:']` and `datasets refresh overture --write` would have persisted `https:` as a release id. Ids
are shape-validated, and whenever the SDK's list is unusable — mangled *or* empty — they are re-read from the
catalog's child links, with a warning naming what was dropped and recovered. An upstream reply with nothing
parseable raises rather than returning an empty list, because core's writer has no empty-payload guard and would
blank the block that is the backend's only offline fallback. The refreshed index carries both published releases.

**Filenames.** The DuckDB path knows the release it globbed, so `_write` stamps it — an unpinned fetch used to
write `..._latest.parquet` and silently overwrite the previous run after a monthly rollover. The SDK path still
writes `_latest`, because it is never told which snapshot answered. `usage.md` now states that rule and its
consequences instead of leaving it in a private docstring.

**Input validation.** A malformed `release=` is rejected at construction with a message naming the expected shape,
rather than failing later as the same opaque DuckDB miss.

**The example notebook taught the bug.** `06_multi_theme_download.ipynb` pinned `Catalog().latest_release()` and
called it reproducible "even after Overture publishes a newer snapshot" — the bundled index, handed straight to
the fetch. It would have failed with the #931 error at the next rollover, and `pytest --nbval` runs these
notebooks in pre-commit, so it would have surfaced as a CI failure. It now leaves `release` unset and shows
`releases.latest_release()` as the way to ask what is published.

**Behaviour notes.** `Catalog.latest_release()` changed from "element 0 of `available_releases`" to "the newest by
date and ordinal, ignoring entries that are not release-shaped" — index order is no longer load-bearing, and an
index holding nothing release-shaped returns `None`. Nothing in the repo indexed the list positionally. And an
unpinned `where=` / `columns=` fetch now contacts `https://stac.overturemaps.org` before touching S3; that is a
second outbound endpoint, documented in `introduction.md` for proxied environments, and pinning skips it.

On the decision the issue asked to make deliberately: this is its "reasonable middle", with the pin/live split
drawn one level lower. Pinning stays available and documented as a **reproducibility** knob (with the caveat that
a pin resolves only while that release exists upstream); the *default* resolves live, because a bundled default is
stale-by-construction against a bucket that keeps one release; and the refresher reports the gap.

No new dependencies, no lockfile change.

# Issues

- Fixes #931 — the pinned Overture S3 release has aged out of the bucket

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] **The failing e2e lane, live and in CI.** `pytest -m "e2e and overture"` → **7 passed** locally, and the
      `e2e (rest-of-hazards)` CI job passed all seven, including `test_duckdb_where_pushdown_live` — the test
      reported in the issue.
- [x] **A regression test for the real failure mode.** The e2e globs the resolved release for one row, so an
      aged-out id fails the way #931 did rather than passing on a re-derived call.
- [x] **Offline proof of the wiring.** A sentinel live release must reach `query_overture` and the written
      filename; the fallback warning must name the bundled id and that it may be gone; two requested types must
      share one lookup; the default path must perform none.
- [x] **The failure modes, not just the happy path** — a malformed, empty, non-string, or trailing-newline reply,
      a transport error, a non-object catalog, an SDK-level `ImportError` / `AttributeError`, an empty index, an
      unparseable upstream reply, an unreachable recovery, and a child href with no release segment.
- [x] **The unit lane is hermetic.** Resolving live put a silent GET on the non-e2e lane (the offline fallback
      masked it). An autouse guard blocks the transport construction and fails through `pytest.fail`, a
      `BaseException` the backend's broad `except` cannot swallow; instrumenting `urlopen` across the lane records
      no calls.
- [x] **The notebook runs.** `pytest --nbval --nbval-lax docs/examples/overture/06_multi_theme_download.ipynb` →
      5 passed, committed stripped.
- [x] **Coverage**: `earthlens.overture` at **100% line and branch** (423 statements, 106 branches).
- [x] **Full local suite**: `pytest libs/core/tests libs/providers/hazards/tests -m "not e2e"` → **4018 passed,
      14 skipped**. Doctests 15 passed. `ruff@0.15.22 check` + `format --check` clean, `mypy` clean (401 files).
      SonarCloud: quality gate OK, 0 open issues on this PR.

Reproduce:

```bash
uv run --locked pytest -m "e2e and overture" -v
```

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
