### PR TITLE
fix(gdacs): retry SEARCH and skip live tests on a persistent upstream failure

### DIFF
--- a/libs/core/src/earthlens/testing.py
+++ b/libs/core/src/earthlens/testing.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import re
 import urllib.error
 from collections.abc import Generator, Iterator
+from typing import NoReturn
 
 import pytest
 
@@ -208,6 +209,25 @@ def is_upstream_unavailable(exc: BaseException) -> str | None:
 #: Prefix stamped on every availability-skip reason, so the session-finish guard
 #: can tell a hook-induced skip from an ordinary `pytest.skip` (missing creds, …).
 _LIVE_SKIP_PREFIX = "live e2e skipped — "
+
+
+def skip_live_unavailable(reason: str) -> NoReturn:
+    """Skip the current live `e2e` test as an upstream-availability failure.
+
+    Stamps the same `_LIVE_SKIP_PREFIX` the automatic :func:`pytest_runtest_call`
+    hook uses, so the masked-lane guard in :func:`pytest_sessionfinish` still
+    counts the skip. A backend that raises a typed availability error which its
+    own e2e test catches — rather than letting the shared hook classify the raw
+    exception — calls this instead of a bare `pytest.skip`, so the guard stays
+    authoritative and a wholly-masked lane is never reported green.
+
+    Args:
+        reason: Human-readable reason, appended after the shared prefix.
+
+    Raises:
+        Skipped: Always — this is pytest's skip signal (never returns).
+    """
+    pytest.skip(f"{_LIVE_SKIP_PREFIX}{reason}")
 
 
 @pytest.hookimpl(wrapper=True)

--- a/libs/core/tests/test_upstream_skip.py
+++ b/libs/core/tests/test_upstream_skip.py
@@ -10,7 +10,12 @@ from pathlib import Path
 
 import pytest
 
-from earthlens.testing import is_upstream_unavailable, pytest_runtest_call
+from earthlens.testing import (
+    _LIVE_SKIP_PREFIX,
+    is_upstream_unavailable,
+    pytest_runtest_call,
+    skip_live_unavailable,
+)
 
 
 class _WithResponse(Exception):
@@ -259,3 +264,13 @@ def test_guard_fails_a_lane_mixing_creds_skip_and_availability_skip(
     )
     assert result.returncode != 0, result.stdout
     assert "wholly masked" in result.stdout
+
+
+def test_skip_live_unavailable_stamps_the_guard_prefix() -> None:
+    """The helper skips with the shared prefix so the masked-lane guard counts it."""
+    with pytest.raises(pytest.skip.Exception) as excinfo:
+        skip_live_unavailable("GDACS SEARCH unavailable: boom")
+    assert str(excinfo.value).startswith(_LIVE_SKIP_PREFIX), (
+        f"skip reason must carry the guard prefix, got {excinfo.value!r}"
+    )
+    assert "GDACS SEARCH unavailable: boom" in str(excinfo.value)

--- a/libs/providers/hazards/src/earthlens/gdacs/__init__.py
+++ b/libs/providers/hazards/src/earthlens/gdacs/__init__.py
@@ -27,6 +27,10 @@ Public surface (re-exported from this package):
 
 * :class:`GDACS` — the backend; instantiate with a date range, a bbox,
   and `variables=[hazard_code, ...]`, then call :meth:`GDACS.download`.
+* :class:`GdacsUnavailableError` — raised when the SEARCH feed is
+  unavailable after the backend's retries (a transport error or a
+  retry-worthy status that persisted); carries the originating
+  `status_code`. A live e2e test catches it and skips.
 * :class:`Catalog` — pydantic-backed loader for the bundled
   `gdacs_data_catalog.yaml` hazard-type dispatch table.
 * :class:`HazardType` — one hazard type's dispatch row (`name`,
@@ -49,6 +53,7 @@ Examples:
 
 from __future__ import annotations
 
+from earthlens.gdacs._helpers import GdacsUnavailableError
 from earthlens.gdacs.backend import GDACS
 from earthlens.gdacs.catalog import CATALOG_PATH, Catalog, HazardType
 from earthlens.gdacs.events import empty_fc, geojson_to_fc
@@ -57,6 +62,7 @@ __all__ = [
     "CATALOG_PATH",
     "Catalog",
     "GDACS",
+    "GdacsUnavailableError",
     "HazardType",
     "empty_fc",
     "geojson_to_fc",

--- a/libs/providers/hazards/src/earthlens/gdacs/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/gdacs/_helpers.py
@@ -75,6 +75,25 @@ class GdacsUnavailableError(RuntimeError):
     rather than fail. The composed query is validated offline by the gdacs unit
     tests, so a `400` reaching here is a spurious upstream `400` (issue #929),
     not a malformed request.
+
+    Examples:
+        - The typed error carries the status a caller branches on:
+            ```python
+            >>> from earthlens.gdacs import GdacsUnavailableError
+            >>> err = GdacsUnavailableError("SEARCH unavailable", status_code=503)
+            >>> err.status_code
+            503
+            >>> str(err)
+            'SEARCH unavailable'
+
+            ```
+        - A transport failure carries no status:
+            ```python
+            >>> from earthlens.gdacs import GdacsUnavailableError
+            >>> GdacsUnavailableError("connection dropped").status_code is None
+            True
+
+            ```
     """
 
     def __init__(self, message: str, status_code: int | None = None) -> None:
@@ -149,6 +168,36 @@ def service_failure_reason(exc: BaseException) -> str | None:
     Returns:
         str | None: A human-readable reason when `exc` is an availability
             failure, else `None`.
+
+    Examples:
+        - A 5xx — and GDACS's spurious 400 — count as availability failures:
+            ```python
+            >>> import requests
+            >>> from earthlens.gdacs._helpers import service_failure_reason
+            >>> service_failure_reason(requests.HTTPError("503 Server Error"))
+            'HTTP 503'
+            >>> service_failure_reason(requests.HTTPError("400 Client Error"))
+            'HTTP 400'
+
+            ```
+        - A genuine 404 and a decode error are not availability failures:
+            ```python
+            >>> import requests
+            >>> from earthlens.gdacs._helpers import service_failure_reason
+            >>> service_failure_reason(requests.HTTPError("404 Client Error")) is None
+            True
+            >>> service_failure_reason(ValueError("bad json")) is None
+            True
+
+            ```
+        - A dropped connection reports the transport failure by name:
+            ```python
+            >>> import requests
+            >>> from earthlens.gdacs._helpers import service_failure_reason
+            >>> service_failure_reason(requests.ConnectionError("boom"))
+            'upstream unreachable (ConnectionError)'
+
+            ```
     """
     status = gdacs_http_status(exc)
     if status is not None:

--- a/libs/providers/hazards/src/earthlens/gdacs/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/gdacs/_helpers.py
@@ -1,0 +1,158 @@
+"""Availability classification for the GDACS SEARCH backend.
+
+Factored out of `gdacs/backend.py` so the backend only routes: this module owns
+the typed `GdacsUnavailableError`, the retry-policy constants the backend hands
+to `HttpClient`, and the `service_failure_reason` classifier that decides whether
+a failed SEARCH call was the *service* being unavailable (retry, then skip a live
+test) or a genuine request error (fail).
+
+The one GDACS-specific twist lives here. GDACS SEARCH is observed to answer a
+*well-formed* query with a spurious `400 Bad Request` under load — issue #929,
+where the exact failing URL returned `200` on an immediate re-request and 6/6 on
+repeat — so a `400` is treated as retry-worthy (the backend retries it) and, only
+if it survives every retry, as an availability failure. A genuine
+query-composition regression does not reach this classifier: it is caught
+deterministically and offline by the gdacs unit tests (`test_forwards_params`
+asserts the composed `fromDate` / `toDate` / `eventlist` / `alertlevel`).
+
+Mirrors the OSM backend's `OhsomeUnavailableError` / `ohsome_http_status` pair and
+the EMODnet-WCS `is_wcs_service_failure` classifier: a live e2e test catches
+`GdacsUnavailableError` and skips, so a transient upstream condition reports
+`skipped`, not `failed`.
+"""
+
+from __future__ import annotations
+
+import re
+
+import requests
+
+#: HTTP statuses that mark the GDACS *service* — not the request — as the
+#: problem. The transient gateway / rate-limit family (`408` request timeout,
+#: `425` too early, `429` rate limited, and the `5xx` family) plus `400`: GDACS
+#: SEARCH returns a spurious `400` on a well-formed query under load (issue #929),
+#: so a `400` is retry-worthy here and, if it persists, an availability failure.
+#: The backend both retries these and re-raises a survivor as
+#: :class:`GdacsUnavailableError`; every other status (`403` / `404` / ...) stays
+#: an authoritative failure.
+GDACS_SERVICE_STATUSES: frozenset[int] = frozenset(
+    {400, 408, 425, 429, 500, 502, 503, 504}
+)
+
+#: The same set as a sorted tuple, for `HttpClient(status_forcelist=...)`.
+GDACS_RETRY_STATUSES: tuple[int, ...] = tuple(sorted(GDACS_SERVICE_STATUSES))
+
+#: Retries the backend allows before a retry-worthy status / transport error is
+#: re-raised. Small: GDACS's spurious `400`s and gateway hiccups clear within a
+#: couple of back-off waits (issue #929), and a live test should not stall long
+#: on a genuinely down service before it skips.
+GDACS_MAX_RETRIES: int = 3
+
+#: Transport exceptions that trigger a retry (and, if they survive, a skip): a
+#: dropped connection or a read timeout — the second failure mode in issue #929.
+GDACS_RETRY_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    requests.ConnectionError,
+    requests.Timeout,
+)
+
+#: `NNN Server Error` / `NNN Client Error` at the head of a `requests.HTTPError`
+#: message — the fallback when the exception carries no `response` object (as a
+#: hand-built `requests.HTTPError("500 Server Error")` in a test does).
+_STATUS_IN_MESSAGE = re.compile(
+    r"\s*(\d{3})\s+(?:server|client)\s+error", re.IGNORECASE
+)
+
+
+class GdacsUnavailableError(RuntimeError):
+    """The GDACS SEARCH feed was unavailable after the backend's retries.
+
+    Raised by the GDACS backend when a combined SEARCH request fails for a
+    reason that is the *service*, not the request: a dropped connection, a read
+    timeout, or a retry-worthy status (`400` / `408` / `425` / `429` / `5xx`)
+    that outlived every retry. Carries the originating HTTP `status_code` when
+    one is discernible, so a caller — a live e2e test especially — can tell a
+    transient upstream condition apart from a genuine request error and skip
+    rather than fail. The composed query is validated offline by the gdacs unit
+    tests, so a `400` reaching here is a spurious upstream `400` (issue #929),
+    not a malformed request.
+    """
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        """Store the actionable message and the originating HTTP status.
+
+        Args:
+            message: Human-facing explanation — what happened and what to do.
+            status_code: The HTTP status that triggered it, or `None` when the
+                failure was a transport error (no status) or the status could
+                not be recovered from the exception.
+        """
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def gdacs_http_status(exc: BaseException) -> int | None:
+    """Best-effort HTTP status behind a failed SEARCH call.
+
+    Reads the status from a `requests`-style `response.status_code` when the
+    exception carries a response, and otherwise parses a leading
+    `NNN Server/Client Error` out of the message — the shape a
+    `raise_for_status`-built `requests.HTTPError` has before it is attached to a
+    response. Walks the `__cause__` / `__context__` chain (cycle-safe) so a
+    wrapped error still yields its status.
+
+    Args:
+        exc: The exception raised by a SEARCH call.
+
+    Returns:
+        int | None: The HTTP status code, or `None` when none is discoverable
+            (for example a bare connection error or read timeout).
+
+    Examples:
+        - The status is recovered from a bare `raise_for_status` message:
+            ```python
+            >>> import requests
+            >>> from earthlens.gdacs._helpers import gdacs_http_status
+            >>> gdacs_http_status(requests.HTTPError("400 Client Error: Bad Request"))
+            400
+            >>> gdacs_http_status(requests.ConnectionError("boom")) is None
+            True
+
+            ```
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        response = getattr(current, "response", None)
+        status = getattr(response, "status_code", None)
+        if isinstance(status, int) and not isinstance(status, bool):
+            return status
+        match = _STATUS_IN_MESSAGE.match(str(current))
+        if match is not None:
+            return int(match.group(1))
+        current = current.__cause__ or current.__context__
+    return None
+
+
+def service_failure_reason(exc: BaseException) -> str | None:
+    """Classify `exc` as a GDACS *availability* failure, or not.
+
+    Returns a short reason string when the failure is the service being
+    unreachable or refusing the request in a retry-worthy way — a connection or
+    timeout error, or a status in :data:`GDACS_SERVICE_STATUSES` — and `None`
+    for anything else (a `403` / `404`, a JSON-decode `ValueError`, ...), which
+    the backend then propagates unchanged.
+
+    Args:
+        exc: The exception raised by a SEARCH call, after the backend's retries.
+
+    Returns:
+        str | None: A human-readable reason when `exc` is an availability
+            failure, else `None`.
+    """
+    status = gdacs_http_status(exc)
+    if status is not None:
+        return f"HTTP {status}" if status in GDACS_SERVICE_STATUSES else None
+    if isinstance(exc, GDACS_RETRY_EXCEPTIONS):
+        return f"upstream unreachable ({type(exc).__name__})"
+    return None

--- a/libs/providers/hazards/src/earthlens/gdacs/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/gdacs/_helpers.py
@@ -149,7 +149,16 @@ def gdacs_http_status(exc: BaseException) -> int | None:
         match = _STATUS_IN_MESSAGE.match(str(current))
         if match is not None:
             return int(match.group(1))
-        current = current.__cause__ or current.__context__
+        # Honour `raise … from None` like `testing._exception_chain`: an explicit
+        # cause wins; otherwise follow the implicit context unless it was
+        # suppressed, so a deliberately surfaced error is not reclassified via a
+        # context it asked to hide.
+        if current.__cause__ is not None:
+            current = current.__cause__
+        elif current.__suppress_context__:
+            current = None
+        else:
+            current = current.__context__
     return None
 
 

--- a/libs/providers/hazards/src/earthlens/gdacs/backend.py
+++ b/libs/providers/hazards/src/earthlens/gdacs/backend.py
@@ -43,6 +43,14 @@ from earthlens.base import (
 )
 from earthlens.base.http import HttpClient
 from earthlens.gdacs import events
+from earthlens.gdacs._helpers import (
+    GDACS_MAX_RETRIES,
+    GDACS_RETRY_EXCEPTIONS,
+    GDACS_RETRY_STATUSES,
+    GdacsUnavailableError,
+    gdacs_http_status,
+    service_failure_reason,
+)
 from earthlens.gdacs.catalog import Catalog
 
 if TYPE_CHECKING:
@@ -264,8 +272,15 @@ class GDACS(AbstractDataSource):
                 clipped alert collection.
 
         Raises:
-            requests.HTTPError: If the SEARCH endpoint returns a
-                non-2xx status.
+            GdacsUnavailableError: If the SEARCH request fails for a
+                service reason — a connection/timeout error or a
+                retry-worthy status (`400` / `408` / `425` / `429` /
+                `5xx`) — that outlived the backend's retries. A `400` is
+                treated this way because GDACS returns spurious `400`s on
+                well-formed queries (issue #929).
+            requests.HTTPError: On a non-retryable error status (for
+                example a `403` / `404`), which is a genuine request or
+                endpoint problem, not an availability one.
         """
         product = products[0]
         params = {
@@ -279,13 +294,20 @@ class GDACS(AbstractDataSource):
             f"{params['fromDate']}..{params['toDate']} "
             f"(levels {params['alertlevel']})"
         )
-        http = HttpClient(
-            timeout=self._timeout,
-            max_retries=0,
-            status_forcelist=(),
-            raise_for_status=True,
-        )
-        payload = http.get_json(SEARCH_URL, params=params)
+        try:
+            payload = self._http_client().get_json(SEARCH_URL, params=params)
+        except requests.RequestException as exc:
+            reason = service_failure_reason(exc)
+            if reason is None:
+                raise
+            raise GdacsUnavailableError(
+                f"GDACS SEARCH was unavailable after {GDACS_MAX_RETRIES} "
+                f"retries ({reason}). The composed query is well-formed (the "
+                "gdacs unit tests assert its parameters offline), so this is a "
+                "transient upstream condition — retry later or narrow the "
+                "date window.",
+                status_code=gdacs_http_status(exc),
+            ) from exc
         feature_count = len(payload.get("features") or [])
         if feature_count >= MAX_EVENTS_PER_RESPONSE:
             logger.warning(
@@ -302,6 +324,32 @@ class GDACS(AbstractDataSource):
             [self.space.west, self.space.east],
         )
         return [clipped]
+
+    def _http_client(self) -> HttpClient:
+        """Build the retry-configured client for the one SEARCH request.
+
+        GDACS SEARCH is a single unpaged GET whose two observed failure
+        modes are both transient (issue #929): a spurious `400 Bad
+        Request` on a well-formed query, and a read timeout. So the
+        client retries the service-status family
+        (:data:`~earthlens.gdacs._helpers.GDACS_RETRY_STATUSES` — the
+        `429` / `5xx` gateway family plus GDACS's spurious `400`) and the
+        transport errors
+        (:data:`~earthlens.gdacs._helpers.GDACS_RETRY_EXCEPTIONS`), up to
+        :data:`~earthlens.gdacs._helpers.GDACS_MAX_RETRIES` times, before
+        the survivor is re-raised (and wrapped by :meth:`_fetch` into a
+        :class:`~earthlens.gdacs._helpers.GdacsUnavailableError`).
+
+        Returns:
+            HttpClient: The configured transport for :meth:`_fetch`.
+        """
+        return HttpClient(
+            timeout=self._timeout,
+            max_retries=GDACS_MAX_RETRIES,
+            status_forcelist=GDACS_RETRY_STATUSES,
+            retry_on_exceptions=GDACS_RETRY_EXCEPTIONS,
+            raise_for_status=True,
+        )
 
     def download(
         self,

--- a/libs/providers/hazards/src/earthlens/gdacs/backend.py
+++ b/libs/providers/hazards/src/earthlens/gdacs/backend.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-import requests  # noqa: F401  # runtime seam so tests can monkeypatch this module's `requests`
+import requests  # module-level import so tests can monkeypatch this module's `requests.get`
 from loguru import logger
 
 from earthlens.base import (
@@ -343,17 +343,14 @@ class GDACS(AbstractDataSource):
         GDACS SEARCH is a single unpaged GET whose two observed failure
         modes are both transient (issue #929): a spurious `400 Bad
         Request` on a well-formed query, and a read timeout. So the
-        client retries the service-status family
-        (:data:`~earthlens.gdacs._helpers.GDACS_RETRY_STATUSES` — the
-        `429` / `5xx` gateway family plus GDACS's spurious `400`) and the
-        transport errors
-        (:data:`~earthlens.gdacs._helpers.GDACS_RETRY_EXCEPTIONS`), up to
-        :data:`~earthlens.gdacs._helpers.GDACS_MAX_RETRIES` times, before
-        the survivor is re-raised (and wrapped by :meth:`_fetch` into a
-        :class:`~earthlens.gdacs._helpers.GdacsUnavailableError`).
+        client retries the service-status family (`GDACS_RETRY_STATUSES`
+        — the `429` / `5xx` gateway family plus GDACS's spurious `400`)
+        and the transport errors (`GDACS_RETRY_EXCEPTIONS`), up to
+        `GDACS_MAX_RETRIES` times, before the survivor is re-raised (and
+        wrapped by `_fetch` into a `GdacsUnavailableError`).
 
         Returns:
-            HttpClient: The configured transport for :meth:`_fetch`.
+            HttpClient: The configured transport for `_fetch`.
         """
         return HttpClient(
             timeout=self._timeout,

--- a/libs/providers/hazards/src/earthlens/gdacs/backend.py
+++ b/libs/providers/hazards/src/earthlens/gdacs/backend.py
@@ -300,13 +300,25 @@ class GDACS(AbstractDataSource):
             reason = service_failure_reason(exc)
             if reason is None:
                 raise
+            status = gdacs_http_status(exc)
+            # A 400 is treated as availability (GDACS's spurious-400 under load,
+            # issue #929), which trades away the lane's ability to catch a real
+            # SEARCH-contract change. Make that unmistakable in the skip reason so
+            # a persistent 400 in the skip logs prompts a contract check rather
+            # than being silently masked.
+            contract_note = (
+                " This was a 400: if it persists across runs, verify GDACS has "
+                "not changed its SEARCH parameter contract (see test_forwards_params)."
+                if status == 400
+                else ""
+            )
             raise GdacsUnavailableError(
                 f"GDACS SEARCH was unavailable after {GDACS_MAX_RETRIES} "
                 f"retries ({reason}). The composed query is well-formed (the "
                 "gdacs unit tests assert its parameters offline), so this is a "
                 "transient upstream condition — retry later or narrow the "
-                "date window.",
-                status_code=gdacs_http_status(exc),
+                f"date window.{contract_note}",
+                status_code=status,
             ) from exc
         feature_count = len(payload.get("features") or [])
         if feature_count >= MAX_EVENTS_PER_RESPONSE:

--- a/libs/providers/hazards/src/earthlens/gdacs/backend.py
+++ b/libs/providers/hazards/src/earthlens/gdacs/backend.py
@@ -251,9 +251,12 @@ class GDACS(AbstractDataSource):
         """Issue the one combined GET and map the GeoJSON to a FeatureCollection.
 
         Widens the inherited `-> list[Path]` contract: a vector backend
-        returns in-memory :class:`FeatureCollection`s, not file paths.
-        An HTTP error propagates (it is not silently swallowed); an
-        empty feed yields a schema-correct empty FeatureCollection.
+        returns in-memory :class:`FeatureCollection`s, not file paths. A
+        service-availability failure (a connection/timeout error or a
+        retry-worthy status) that outlives the retries is re-raised as
+        `GdacsUnavailableError`; a genuine request error (`403` / `404`)
+        propagates as `requests.HTTPError`. Nothing is silently swallowed.
+        An empty feed yields a schema-correct empty FeatureCollection.
         Because GDACS SEARCH has no documented bbox filter, the mapped
         alerts are clipped to `self.space` client-side.
 

--- a/libs/providers/hazards/tests/gdacs/conftest.py
+++ b/libs/providers/hazards/tests/gdacs/conftest.py
@@ -99,7 +99,9 @@ class _FakeResponse:
         if self._status_error is not None:
             raise self._status_error
         if self.status_code >= 400:
-            raise requests.HTTPError(f"{self.status_code} Server Error", response=self)
+            # Neutral label (the response carries the real status_code, which is
+            # what gdacs_http_status reads first) so it is never mis-labelled.
+            raise requests.HTTPError(f"{self.status_code} HTTP Error", response=self)
 
     def json(self) -> dict[str, Any]:
         return self._payload

--- a/libs/providers/hazards/tests/gdacs/conftest.py
+++ b/libs/providers/hazards/tests/gdacs/conftest.py
@@ -12,6 +12,7 @@ from collections.abc import Iterator
 from typing import Any, Callable
 
 import pytest
+import requests
 
 
 def _make_feature(
@@ -83,15 +84,22 @@ def _make_payload(features: list[dict[str, Any]] | None = None) -> dict[str, Any
 class _FakeResponse:
     """Stand-in for a `requests.Response` returning a canned payload."""
 
-    def __init__(self, payload: dict[str, Any], status_error: Exception | None):
+    def __init__(
+        self,
+        payload: dict[str, Any],
+        status_error: Exception | None,
+        status_code: int = 200,
+    ):
         self._payload = payload
         self._status_error = status_error
-        self.status_code = 200
+        self.status_code = status_code
         self.headers: dict[str, str] = {}
 
     def raise_for_status(self) -> None:
         if self._status_error is not None:
             raise self._status_error
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Server Error", response=self)
 
     def json(self) -> dict[str, Any]:
         return self._payload
@@ -108,12 +116,13 @@ class _FakeGdacs:
         self.calls: list[dict[str, Any]] = []
         self.payload: dict[str, Any] = _make_payload()
         self.status_error: Exception | None = None
+        self.status_code: int = 200
 
     def __call__(self, url: str, **kwargs: Any) -> _FakeResponse:
         entry: dict[str, Any] = {"url": url}
         entry.update(kwargs)
         self.calls.append(entry)
-        return _FakeResponse(self.payload, self.status_error)
+        return _FakeResponse(self.payload, self.status_error, self.status_code)
 
     def set_payload(self, payload: dict[str, Any]) -> None:
         """Pin the payload the next SEARCH call returns."""
@@ -122,6 +131,16 @@ class _FakeGdacs:
     def set_status_error(self, error: Exception) -> None:
         """Make `raise_for_status` raise the given error (HTTP failure)."""
         self.status_error = error
+
+    def set_retry_status(self, code: int) -> None:
+        """Return this HTTP status on every call, so the client retry loop engages.
+
+        Unlike `set_status_error` (which raises only from `raise_for_status`, so
+        the response looks like a `200` to the client and is never retried), this
+        sets the real `status_code`, so a code in the client's `status_forcelist`
+        drives the actual retry path.
+        """
+        self.status_code = code
 
 
 @pytest.fixture

--- a/libs/providers/hazards/tests/gdacs/test_backend.py
+++ b/libs/providers/hazards/tests/gdacs/test_backend.py
@@ -170,8 +170,9 @@ class TestGDACSFetch:
         """A persistent 5xx surfaces as a typed GdacsUnavailableError."""
         fake_gdacs.set_status_error(requests.HTTPError("500 Server Error"))
         backend = _make_backend(tmp_path)
+        products = backend._search()
         with pytest.raises(GdacsUnavailableError) as excinfo:
-            backend._fetch(backend._search())
+            backend._fetch(products)
         assert excinfo.value.status_code == 500
 
     def test_persistent_400_becomes_unavailable(
@@ -185,16 +186,18 @@ class TestGDACSFetch:
         """
         fake_gdacs.set_status_error(requests.HTTPError("400 Client Error: Bad Request"))
         backend = _make_backend(tmp_path)
+        products = backend._search()
         with pytest.raises(GdacsUnavailableError) as excinfo:
-            backend._fetch(backend._search())
+            backend._fetch(products)
         assert excinfo.value.status_code == 400
 
     def test_non_service_error_propagates(self, tmp_path: Path, fake_gdacs: _FakeGdacs):
         """A genuine client error (404) fails hard instead of being masked."""
         fake_gdacs.set_status_error(requests.HTTPError("404 Client Error: Not Found"))
         backend = _make_backend(tmp_path)
+        products = backend._search()
         with pytest.raises(requests.HTTPError, match="404"):
-            backend._fetch(backend._search())
+            backend._fetch(products)
 
     def test_http_client_retries_configured(self, tmp_path: Path):
         """The SEARCH client retries the service-status family and transport errors."""

--- a/libs/providers/hazards/tests/gdacs/test_backend.py
+++ b/libs/providers/hazards/tests/gdacs/test_backend.py
@@ -136,7 +136,14 @@ class TestGDACSFetch:
         assert fake_gdacs.calls[0]["url"] == SEARCH_URL
 
     def test_forwards_params(self, tmp_path: Path, fake_gdacs: _FakeGdacs):
-        """Date window, hazard list, and alert levels reach the query params."""
+        """Date window, hazard list, and alert levels reach the query params.
+
+        This is the sole offline regression net for the SEARCH parameter
+        contract: because the backend treats a live 400 as availability (issue
+        #929) and skips rather than fails, a real query-shaping regression would
+        not redden the e2e lane — so keep these assertions exhaustive as new
+        params are added.
+        """
         backend = _make_backend(
             tmp_path, variables=["EQ", "TC"], alert_level=["Green", "Red"]
         )
@@ -197,6 +204,9 @@ class TestGDACSFetch:
         with pytest.raises(GdacsUnavailableError) as excinfo:
             backend._fetch(products)
         assert excinfo.value.status_code == 400
+        assert "SEARCH parameter contract" in str(excinfo.value), (
+            "a persistent 400 must flag a possible contract change in its reason"
+        )
 
     def test_non_service_error_propagates(self, tmp_path: Path, fake_gdacs: _FakeGdacs):
         """A genuine client error (404) fails hard instead of being masked."""

--- a/libs/providers/hazards/tests/gdacs/test_backend.py
+++ b/libs/providers/hazards/tests/gdacs/test_backend.py
@@ -11,6 +11,7 @@ from geopandas import GeoDataFrame
 
 from earthlens.base import RemoteProduct, SpatialExtent, TemporalExtent
 from earthlens.gdacs import GDACS, GdacsUnavailableError
+from earthlens.gdacs._helpers import GDACS_MAX_RETRIES
 from earthlens.gdacs.backend import SEARCH_URL
 
 from .conftest import _FakeGdacs
@@ -198,6 +199,37 @@ class TestGDACSFetch:
         products = backend._search()
         with pytest.raises(requests.HTTPError, match="404"):
             backend._fetch(products)
+
+    def test_transport_error_retries_then_wraps(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A read timeout is retried, then wrapped as a status-less unavailable error.
+
+        The second failure mode in issue #929. The transport raises on every
+        attempt, so the backend exhausts its retries (one initial call plus
+        GDACS_MAX_RETRIES) and re-raises a GdacsUnavailableError whose
+        status_code is None (a transport error carries no HTTP status).
+        """
+        import earthlens.base.http as http
+
+        monkeypatch.setattr(http.HttpClient, "_backoff_wait", lambda self, ra, at: 0.0)
+        calls = {"n": 0}
+
+        def boom(url: str, **kwargs: object) -> object:
+            calls["n"] += 1
+            raise requests.ReadTimeout("read timed out")
+
+        monkeypatch.setattr("earthlens.gdacs.backend.requests.get", boom)
+        backend = _make_backend(tmp_path)
+        products = backend._search()
+        with pytest.raises(GdacsUnavailableError) as excinfo:
+            backend._fetch(products)
+        assert excinfo.value.status_code is None, (
+            f"a transport error carries no status, got {excinfo.value.status_code}"
+        )
+        assert calls["n"] == 1 + GDACS_MAX_RETRIES, (
+            f"expected {1 + GDACS_MAX_RETRIES} attempts, got {calls['n']}"
+        )
 
     def test_http_client_retries_configured(self, tmp_path: Path):
         """The SEARCH client retries the service-status family and transport errors."""

--- a/libs/providers/hazards/tests/gdacs/test_backend.py
+++ b/libs/providers/hazards/tests/gdacs/test_backend.py
@@ -10,7 +10,7 @@ import requests
 from geopandas import GeoDataFrame
 
 from earthlens.base import RemoteProduct, SpatialExtent, TemporalExtent
-from earthlens.gdacs import GDACS
+from earthlens.gdacs import GDACS, GdacsUnavailableError
 from earthlens.gdacs.backend import SEARCH_URL
 
 from .conftest import _FakeGdacs
@@ -164,12 +164,46 @@ class TestGDACSFetch:
         results = backend._fetch(backend._search())
         assert len(results[0]) == 0, "empty feed should yield an empty FC"
 
-    def test_http_error_propagates(self, tmp_path: Path, fake_gdacs: _FakeGdacs):
-        """A non-2xx status propagates rather than being swallowed."""
+    def test_service_error_becomes_unavailable(
+        self, tmp_path: Path, fake_gdacs: _FakeGdacs
+    ):
+        """A persistent 5xx surfaces as a typed GdacsUnavailableError."""
         fake_gdacs.set_status_error(requests.HTTPError("500 Server Error"))
         backend = _make_backend(tmp_path)
-        with pytest.raises(requests.HTTPError, match="500"):
+        with pytest.raises(GdacsUnavailableError) as excinfo:
             backend._fetch(backend._search())
+        assert excinfo.value.status_code == 500
+
+    def test_persistent_400_becomes_unavailable(
+        self, tmp_path: Path, fake_gdacs: _FakeGdacs
+    ):
+        """A 400 that survives the retries is treated as an availability failure.
+
+        GDACS returns spurious 400s on well-formed queries (issue #929), so a
+        persistent 400 is wrapped like a 5xx rather than raised as a client
+        error — the query composition itself is guarded by test_forwards_params.
+        """
+        fake_gdacs.set_status_error(requests.HTTPError("400 Client Error: Bad Request"))
+        backend = _make_backend(tmp_path)
+        with pytest.raises(GdacsUnavailableError) as excinfo:
+            backend._fetch(backend._search())
+        assert excinfo.value.status_code == 400
+
+    def test_non_service_error_propagates(self, tmp_path: Path, fake_gdacs: _FakeGdacs):
+        """A genuine client error (404) fails hard instead of being masked."""
+        fake_gdacs.set_status_error(requests.HTTPError("404 Client Error: Not Found"))
+        backend = _make_backend(tmp_path)
+        with pytest.raises(requests.HTTPError, match="404"):
+            backend._fetch(backend._search())
+
+    def test_http_client_retries_configured(self, tmp_path: Path):
+        """The SEARCH client retries the service-status family and transport errors."""
+        client = _make_backend(tmp_path)._http_client()
+        assert client.max_retries >= 1, "retries must be enabled"
+        assert 400 in client.status_forcelist, "GDACS's spurious 400 must be retried"
+        assert 503 in client.status_forcelist, "the 5xx family must be retried"
+        assert requests.ConnectionError in client.retry_on_exceptions
+        assert requests.Timeout in client.retry_on_exceptions
 
     def test_cap_logs_truncation_warning(
         self,

--- a/libs/providers/hazards/tests/gdacs/test_backend.py
+++ b/libs/providers/hazards/tests/gdacs/test_backend.py
@@ -168,7 +168,11 @@ class TestGDACSFetch:
     def test_service_error_becomes_unavailable(
         self, tmp_path: Path, fake_gdacs: _FakeGdacs
     ):
-        """A persistent 5xx surfaces as a typed GdacsUnavailableError."""
+        """A 5xx is classified as an availability failure and wrapped, keeping its status.
+
+        Verifies the wrap classification only; the retry-count behaviour is
+        covered by test_status_failure_retries_then_wraps.
+        """
         fake_gdacs.set_status_error(requests.HTTPError("500 Server Error"))
         backend = _make_backend(tmp_path)
         products = backend._search()
@@ -176,14 +180,16 @@ class TestGDACSFetch:
             backend._fetch(products)
         assert excinfo.value.status_code == 500
 
-    def test_persistent_400_becomes_unavailable(
+    def test_400_classified_as_unavailable(
         self, tmp_path: Path, fake_gdacs: _FakeGdacs
     ):
-        """A 400 that survives the retries is treated as an availability failure.
+        """A 400 is classified as an availability failure, not a client error.
 
-        GDACS returns spurious 400s on well-formed queries (issue #929), so a
-        persistent 400 is wrapped like a 5xx rather than raised as a client
-        error — the query composition itself is guarded by test_forwards_params.
+        GDACS returns spurious 400s on well-formed queries (issue #929), so a 400
+        is wrapped like a 5xx rather than raised as a client error — the query
+        composition itself is guarded by test_forwards_params. Verifies the wrap
+        classification only; the retry-count behaviour is covered by
+        test_status_failure_retries_then_wraps.
         """
         fake_gdacs.set_status_error(requests.HTTPError("400 Client Error: Bad Request"))
         backend = _make_backend(tmp_path)
@@ -229,6 +235,29 @@ class TestGDACSFetch:
         )
         assert calls["n"] == 1 + GDACS_MAX_RETRIES, (
             f"expected {1 + GDACS_MAX_RETRIES} attempts, got {calls['n']}"
+        )
+
+    def test_status_failure_retries_then_wraps(
+        self, tmp_path: Path, fake_gdacs: _FakeGdacs, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A persistent forcelist status (500) is retried, then wrapped.
+
+        Unlike the classification tests, the fake returns a real 500 status, so
+        the client's status-forcelist retry path actually runs: the request is
+        attempted one initial time plus GDACS_MAX_RETRIES before the survivor is
+        wrapped as a GdacsUnavailableError.
+        """
+        import earthlens.base.http as http
+
+        monkeypatch.setattr(http.HttpClient, "_backoff_wait", lambda self, ra, at: 0.0)
+        fake_gdacs.set_retry_status(500)
+        backend = _make_backend(tmp_path)
+        products = backend._search()
+        with pytest.raises(GdacsUnavailableError) as excinfo:
+            backend._fetch(products)
+        assert excinfo.value.status_code == 500
+        assert len(fake_gdacs.calls) == 1 + GDACS_MAX_RETRIES, (
+            f"expected {1 + GDACS_MAX_RETRIES} attempts, got {len(fake_gdacs.calls)}"
         )
 
     def test_http_client_retries_configured(self, tmp_path: Path):

--- a/libs/providers/hazards/tests/gdacs/test_gdacs_e2e.py
+++ b/libs/providers/hazards/tests/gdacs/test_gdacs_e2e.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import datetime as dt
 from pathlib import Path
+from typing import NoReturn
 
 import pytest
 import requests
@@ -30,7 +31,7 @@ _RECENT_START = (_TODAY - dt.timedelta(days=30)).strftime("%Y-%m-%d")
 _TODAY_STR = _TODAY.strftime("%Y-%m-%d")
 
 
-def _skip_on_upstream(exc: Exception) -> None:
+def _skip_on_upstream(exc: Exception) -> NoReturn:
     """Skip (not fail) when GDACS SEARCH was unavailable, else re-raise.
 
     GDACS SEARCH answers a well-formed query with a spurious `400`, or times

--- a/libs/providers/hazards/tests/gdacs/test_gdacs_e2e.py
+++ b/libs/providers/hazards/tests/gdacs/test_gdacs_e2e.py
@@ -20,6 +20,7 @@ import requests
 from earthlens.earthlens import EarthLens
 from earthlens.gdacs import GDACS, GdacsUnavailableError
 from earthlens.gdacs.events import ATTRIBUTE_COLUMNS
+from earthlens.testing import skip_live_unavailable
 
 # A recent ~30-day window: GDACS is a live alert feed, so very old
 # windows can be sparse. Earthquakes are the most frequent hazard, so a
@@ -37,13 +38,18 @@ def _skip_on_upstream(exc: Exception) -> None:
     persist, raises the typed `GdacsUnavailableError`, which skips the lane
     rather than reddening it — the backend's retries already gave the service
     several chances, so a survivor is a real outage, not a regression (the query
-    composition is asserted offline by the unit tests). A bare transport error
-    escaping the retries skips too. Anything else re-raises and fails.
+    composition is asserted offline by the unit tests). The skip goes through
+    `skip_live_unavailable` so it carries the shared availability-skip prefix and
+    the repo-wide masked-lane guard still counts it (a wholly-skipped GDACS lane
+    never reports green). Anything else re-raises and fails.
     """
+    # `GdacsUnavailableError` is the live path — `_fetch` already wraps a SEARCH
+    # ConnectionError/Timeout into it. The bare transport arms are belt-and-braces
+    # for a transport error raised outside the SEARCH call (e.g. while writing).
     if isinstance(
         exc, (GdacsUnavailableError, requests.ConnectionError, requests.Timeout)
     ):
-        pytest.skip(f"GDACS SEARCH unavailable: {exc}")
+        skip_live_unavailable(f"GDACS SEARCH unavailable: {exc}")
     raise exc
 
 

--- a/libs/providers/hazards/tests/gdacs/test_gdacs_e2e.py
+++ b/libs/providers/hazards/tests/gdacs/test_gdacs_e2e.py
@@ -118,16 +118,19 @@ class TestSkipOnUpstream:
 
     def test_skips_on_typed_unavailable(self):
         """A GdacsUnavailableError becomes a prefixed skip, not a failure."""
+        exc = GdacsUnavailableError("down", status_code=503)
         with pytest.raises(pytest.skip.Exception) as excinfo:
-            _skip_on_upstream(GdacsUnavailableError("down", status_code=503))
+            _skip_on_upstream(exc)
         assert "GDACS SEARCH unavailable" in str(excinfo.value)
 
     def test_skips_on_transport_error(self):
         """A bare transport error also skips (belt-and-braces arm)."""
+        exc = requests.ConnectionError("dropped")
         with pytest.raises(pytest.skip.Exception):
-            _skip_on_upstream(requests.ConnectionError("dropped"))
+            _skip_on_upstream(exc)
 
     def test_reraises_other_errors(self):
         """A non-availability error re-raises unchanged so the test still fails."""
+        exc = ValueError("real bug")
         with pytest.raises(ValueError, match="real bug"):
-            _skip_on_upstream(ValueError("real bug"))
+            _skip_on_upstream(exc)

--- a/libs/providers/hazards/tests/gdacs/test_gdacs_e2e.py
+++ b/libs/providers/hazards/tests/gdacs/test_gdacs_e2e.py
@@ -110,3 +110,23 @@ class TestGdacsLiveQuery:
             "expected one combined query for all hazard types (no per-hazard "
             f"fan-out); saw eventlist params {eventlists}"
         )
+
+
+class TestSkipOnUpstream:
+    """The `_skip_on_upstream` triage runs offline (no e2e marker, no network)."""
+
+    def test_skips_on_typed_unavailable(self):
+        """A GdacsUnavailableError becomes a prefixed skip, not a failure."""
+        with pytest.raises(pytest.skip.Exception) as excinfo:
+            _skip_on_upstream(GdacsUnavailableError("down", status_code=503))
+        assert "GDACS SEARCH unavailable" in str(excinfo.value)
+
+    def test_skips_on_transport_error(self):
+        """A bare transport error also skips (belt-and-braces arm)."""
+        with pytest.raises(pytest.skip.Exception):
+            _skip_on_upstream(requests.ConnectionError("dropped"))
+
+    def test_reraises_other_errors(self):
+        """A non-availability error re-raises unchanged so the test still fails."""
+        with pytest.raises(ValueError, match="real bug"):
+            _skip_on_upstream(ValueError("real bug"))

--- a/libs/providers/hazards/tests/gdacs/test_gdacs_e2e.py
+++ b/libs/providers/hazards/tests/gdacs/test_gdacs_e2e.py
@@ -15,9 +15,10 @@ import datetime as dt
 from pathlib import Path
 
 import pytest
+import requests
 
 from earthlens.earthlens import EarthLens
-from earthlens.gdacs import GDACS
+from earthlens.gdacs import GDACS, GdacsUnavailableError
 from earthlens.gdacs.events import ATTRIBUTE_COLUMNS
 
 # A recent ~30-day window: GDACS is a live alert feed, so very old
@@ -28,6 +29,24 @@ _RECENT_START = (_TODAY - dt.timedelta(days=30)).strftime("%Y-%m-%d")
 _TODAY_STR = _TODAY.strftime("%Y-%m-%d")
 
 
+def _skip_on_upstream(exc: Exception) -> None:
+    """Skip (not fail) when GDACS SEARCH was unavailable, else re-raise.
+
+    GDACS SEARCH answers a well-formed query with a spurious `400`, or times
+    out, under load (issue #929). The backend retries those and, when they
+    persist, raises the typed `GdacsUnavailableError`, which skips the lane
+    rather than reddening it — the backend's retries already gave the service
+    several chances, so a survivor is a real outage, not a regression (the query
+    composition is asserted offline by the unit tests). A bare transport error
+    escaping the retries skips too. Anything else re-raises and fails.
+    """
+    if isinstance(
+        exc, (GdacsUnavailableError, requests.ConnectionError, requests.Timeout)
+    ):
+        pytest.skip(f"GDACS SEARCH unavailable: {exc}")
+    raise exc
+
+
 @pytest.mark.e2e
 @pytest.mark.gdacs
 class TestGdacsLiveQuery:
@@ -35,15 +54,18 @@ class TestGdacsLiveQuery:
 
     def test_recent_earthquakes(self, tmp_path: Path):
         """A recent global EQ window returns a schema-correct FeatureCollection."""
-        fc = EarthLens(
-            variables=["EQ"],
-            data_source="gdacs",
-            start=_RECENT_START,
-            end=_TODAY_STR,
-            lat_lim=[-90.0, 90.0],
-            lon_lim=[-180.0, 180.0],
-            path=str(tmp_path),
-        ).download(progress_bar=False)
+        try:
+            fc = EarthLens(
+                variables=["EQ"],
+                data_source="gdacs",
+                start=_RECENT_START,
+                end=_TODAY_STR,
+                lat_lim=[-90.0, 90.0],
+                lon_lim=[-180.0, 180.0],
+                path=str(tmp_path),
+            ).download(progress_bar=False)
+        except Exception as exc:  # noqa: BLE001 - upstream -> skip, else re-raise
+            _skip_on_upstream(exc)
 
         for column in ATTRIBUTE_COLUMNS:
             assert column in fc.columns, f"missing column {column!r}"
@@ -53,22 +75,32 @@ class TestGdacsLiveQuery:
             assert list(tmp_path.glob("gdacs_alerts_*.gpkg")), "GeoPackage written"
 
     def test_single_request(self, tmp_path: Path):
-        """A multi-hazard download issues exactly one HTTP request (no fan-out)."""
+        """A multi-hazard download issues one combined query (no per-hazard fan-out)."""
         from unittest import mock
 
         import earthlens.gdacs.backend as backend_module
 
-        with mock.patch.object(
-            backend_module.requests, "get", wraps=backend_module.requests.get
-        ) as spy:
-            GDACS(
-                start=_RECENT_START,
-                end=_TODAY_STR,
-                variables=["EQ", "TC", "FL", "VO", "WF", "DR"],
-                lat_lim=[-90.0, 90.0],
-                lon_lim=[-180.0, 180.0],
-                path=str(tmp_path),
-            ).download(progress_bar=False)
-        assert spy.call_count == 1, (
-            f"expected a single SEARCH request, got {spy.call_count}"
+        try:
+            with mock.patch.object(
+                backend_module.requests, "get", wraps=backend_module.requests.get
+            ) as spy:
+                GDACS(
+                    start=_RECENT_START,
+                    end=_TODAY_STR,
+                    variables=["EQ", "TC", "FL", "VO", "WF", "DR"],
+                    lat_lim=[-90.0, 90.0],
+                    lon_lim=[-180.0, 180.0],
+                    path=str(tmp_path),
+                ).download(progress_bar=False)
+        except Exception as exc:  # noqa: BLE001 - upstream -> skip, else re-raise
+            _skip_on_upstream(exc)
+        # Every call carries all six hazard types in one `eventlist`, so any
+        # repeat is a retry of the same combined query, not a per-hazard split.
+        # (A single transient burp now retries rather than fans out, so counting
+        # raw calls would false-fail; assert the query shape instead.)
+        assert spy.call_count >= 1, "expected at least one SEARCH request"
+        eventlists = {call.kwargs["params"]["eventlist"] for call in spy.call_args_list}
+        assert eventlists == {"EQ,TC,FL,VO,WF,DR"}, (
+            "expected one combined query for all hazard types (no per-hazard "
+            f"fan-out); saw eventlist params {eventlists}"
         )

--- a/libs/providers/hazards/tests/gdacs/test_helpers.py
+++ b/libs/providers/hazards/tests/gdacs/test_helpers.py
@@ -1,0 +1,81 @@
+"""Unit tests for the GDACS availability classifier (`earthlens.gdacs._helpers`)."""
+
+from __future__ import annotations
+
+import requests
+
+from earthlens.gdacs._helpers import (
+    GDACS_RETRY_STATUSES,
+    GdacsUnavailableError,
+    gdacs_http_status,
+    service_failure_reason,
+)
+
+
+class TestGdacsHttpStatus:
+    """`gdacs_http_status` recovers the status from either exception shape."""
+
+    def test_status_from_message(self):
+        """A bare raise_for_status message yields its leading status code."""
+        assert (
+            gdacs_http_status(requests.HTTPError("400 Client Error: Bad Request"))
+            == 400
+        )
+        assert gdacs_http_status(requests.HTTPError("503 Server Error")) == 503
+
+    def test_status_from_response(self):
+        """A status carried on `.response.status_code` is preferred."""
+        response = requests.Response()
+        response.status_code = 429
+        err = requests.HTTPError("rate limited", response=response)
+        assert gdacs_http_status(err) == 429
+
+    def test_no_status_for_transport_error(self):
+        """A connection/timeout error carries no status."""
+        assert gdacs_http_status(requests.ConnectionError("boom")) is None
+        assert gdacs_http_status(requests.ReadTimeout("read timed out")) is None
+
+    def test_walks_exception_chain(self):
+        """A wrapped error still yields the underlying status."""
+        try:
+            try:
+                raise requests.HTTPError("500 Server Error")
+            except requests.HTTPError as inner:
+                raise RuntimeError("wrapped") from inner
+        except RuntimeError as outer:
+            assert gdacs_http_status(outer) == 500
+
+
+class TestServiceFailureReason:
+    """`service_failure_reason` separates availability failures from real errors."""
+
+    def test_service_statuses_are_failures(self):
+        """Every retry-worthy status (incl. the spurious 400) is an availability failure."""
+        for status in GDACS_RETRY_STATUSES:
+            err = requests.HTTPError(f"{status} Server Error")
+            assert service_failure_reason(err) == f"HTTP {status}"
+
+    def test_transport_errors_are_failures(self):
+        """A connection or timeout error is an availability failure."""
+        assert "ConnectionError" in (
+            service_failure_reason(requests.ConnectionError("down")) or ""
+        )
+        assert "ReadTimeout" in (
+            service_failure_reason(requests.ReadTimeout("read timed out")) or ""
+        )
+
+    def test_authoritative_statuses_are_not_failures(self):
+        """A 403 / 404 is a genuine error, not an availability one."""
+        assert service_failure_reason(requests.HTTPError("403 Client Error")) is None
+        assert service_failure_reason(requests.HTTPError("404 Client Error")) is None
+
+    def test_unrelated_error_is_not_a_failure(self):
+        """A non-transport, non-HTTP error is not classified as unavailable."""
+        assert service_failure_reason(ValueError("bad json")) is None
+
+
+def test_unavailable_error_carries_status():
+    """The typed error stores the originating status for callers to branch on."""
+    err = GdacsUnavailableError("unavailable", status_code=400)
+    assert err.status_code == 400
+    assert isinstance(err, RuntimeError)

--- a/libs/providers/hazards/tests/gdacs/test_helpers.py
+++ b/libs/providers/hazards/tests/gdacs/test_helpers.py
@@ -36,7 +36,7 @@ class TestGdacsHttpStatus:
         assert gdacs_http_status(requests.ReadTimeout("read timed out")) is None
 
     def test_walks_exception_chain(self):
-        """A wrapped error still yields the underlying status."""
+        """An explicit `raise ... from` cause still yields the underlying status."""
         try:
             try:
                 raise requests.HTTPError("500 Server Error")
@@ -44,6 +44,26 @@ class TestGdacsHttpStatus:
                 raise RuntimeError("wrapped") from inner
         except RuntimeError as outer:
             assert gdacs_http_status(outer) == 500
+
+    def test_follows_implicit_context(self):
+        """A bare re-raise inside `except` exposes the status via `__context__`."""
+        try:
+            try:
+                raise requests.HTTPError("503 Server Error")
+            except requests.HTTPError:
+                raise RuntimeError("wrapped")
+        except RuntimeError as outer:
+            assert gdacs_http_status(outer) == 503
+
+    def test_suppressed_context_hides_the_status(self):
+        """`raise ... from None` suppresses the context, so no status is recovered."""
+        try:
+            try:
+                raise requests.HTTPError("500 Server Error")
+            except requests.HTTPError:
+                raise RuntimeError("wrapped") from None
+        except RuntimeError as outer:
+            assert gdacs_http_status(outer) is None
 
 
 class TestServiceFailureReason:


### PR DESCRIPTION
# Description

The GDACS live e2e lane reddened on transient upstream conditions (issue #929): a `400 Bad Request` on a query
the backend composes, and a read timeout. Reproducing the exact failing URL by hand returned `200` immediately
(6/6 on repeat), so both were transient GDACS burps on a **well-formed** query, not a contract change.

Root cause: the GDACS backend uniquely opted out of all retries (`max_retries=0, status_forcelist=()`), so a
single upstream hiccup failed the lane outright.

This implements "retry, then skip only on a *persistent* failure":

- **Retry** the one SEARCH GET through the shared `HttpClient` (new `_http_client()`) on the `429`/`5xx` family
  **plus GDACS's spurious `400`**, and on `ConnectionError`/`Timeout`.
- **Wrap** a failure that outlives the retries in a typed, exported `GdacsUnavailableError` carrying the
  originating HTTP status. A genuine `403`/`404` (and a JSON-decode error) still propagates and fails.
- The two live e2e tests **catch `GdacsUnavailableError`/transport and skip**, routing the skip through a new
  `earthlens.testing.skip_live_unavailable(reason)` helper so it carries the shared availability-skip prefix and
  the repo-wide masked-lane guard still counts it (a wholly-skipped GDACS lane can never report green). This
  mirrors the OSM `OhsomeUnavailableError` and EMODnet-WCS `WcsServiceUnavailableError` patterns.

A transient burp is absorbed by the retries and the test **passes**; only a persistent failure **skips**, and a
persistent `400` carries a "verify GDACS has not changed its SEARCH parameter contract" note so a real regression
is visible in skip logs. Query composition stays guarded offline by `test_forwards_params` — the sole regression
net once a `400` no longer fails the lane — so masking a persistent e2e `400` cannot hide a request-shaping
regression.

Scope: a new `earthlens.gdacs._helpers` module (typed error + classifier + retry constants), the `gdacs` backend
and package export, and a small additive `earthlens.testing.skip_live_unavailable` helper, plus tests.

# Issues

- Closes #929 — GDACS event-list API returns 400 for a query the backend composes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All green on the changed modules and their suites:

- [x] `pytest -m "not e2e"` over `libs/core` + `libs/providers/hazards` — **4054 passed, 14 skipped**
- [x] `pytest -m "e2e and gdacs"` (live GDACS) — **2 passed**
- [x] `earthlens.gdacs.backend` and `earthlens.gdacs._helpers` at **100% line + branch coverage**
- [x] `--doctest-modules` on `gdacs/_helpers.py` — passed; `ruff@0.15.22 check`/`format` clean; `mypy` clean on
      the changed source files
- [x] Retry paths asserted directly: a persistent 500 (status-forcelist) and a persistent `ReadTimeout`
      (transport) are each attempted `1 + GDACS_MAX_RETRIES` times, then wrapped; a genuine `404` propagates
- [x] SonarCloud on the PR HEAD — **0 issues, quality gate OK**

Reproduce:

```bash
uv run --locked pytest -m "e2e and gdacs" -v
```

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.