### PR TITLE
fix(osm): surface opaque ohsome failures as typed, logged errors

### DIFF
--- a/libs/providers/hazards/src/earthlens/osm/__init__.py
+++ b/libs/providers/hazards/src/earthlens/osm/__init__.py
@@ -40,9 +40,13 @@ Public surface (re-exported from this package):
 * `download_extract` / `read_pbf` / `geofabrik_url` / `GEOFABRIK_BASE_URL` —
   the `pbf` fetch-and-cache + layer-read helpers (`G13` / `G14`).
 * `LicenseWarning` — the ODbL share-alike warning (`G5`).
-* `OhsomeUnavailableError` / `ohsome_http_status` — the typed public-endpoint
-  throttle/block error the ohsome path raises on a `403` / `429`, and the
-  helper that recovers the HTTP status from the SDK's opaque failure.
+* `OhsomeResponseError` / `OhsomeUnavailableError` — the typed errors the ohsome
+  path raises instead of a raw `JSONDecodeError`: `OhsomeResponseError` for any
+  non-JSON body (carrying the status / `Content-Type` / body preview, `#930`),
+  and its `OhsomeUnavailableError` subtype for the `403` / `429` throttle/block.
+* `ohsome_http_status` / `ohsome_error_response` / `ohsome_response_is_non_json`
+  / `ohsome_body_preview` — the helpers that recover the HTTP status, response,
+  non-JSON verdict, and body preview from the SDK's opaque failure.
 * `CATALOG_PATH` — path to the bundled named-query YAML; monkey-patchable in
   tests.
 
@@ -62,11 +66,15 @@ from __future__ import annotations
 
 from earthlens.osm._helpers import (
     LicenseWarning,
+    OhsomeResponseError,
     OhsomeUnavailableError,
     bbox_swne,
     bbox_wsen,
     empty_fc,
+    ohsome_body_preview,
+    ohsome_error_response,
     ohsome_http_status,
+    ohsome_response_is_non_json,
     overpy_to_gdf,
     shapely_bbox,
     to_fc,
@@ -87,13 +95,17 @@ __all__ = [
     "Dataset",
     "LicenseWarning",
     "OSM",
+    "OhsomeResponseError",
     "OhsomeUnavailableError",
     "bbox_swne",
     "bbox_wsen",
     "download_extract",
     "empty_fc",
     "geofabrik_url",
+    "ohsome_body_preview",
+    "ohsome_error_response",
     "ohsome_http_status",
+    "ohsome_response_is_non_json",
     "overpy_to_gdf",
     "read_pbf",
     "shapely_bbox",

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -32,7 +32,6 @@ the shared biodiversity home so the backend imports the one warning class.
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, cast
 
@@ -224,10 +223,12 @@ def ohsome_response_is_non_json(exc: BaseException) -> bool:
     Returns:
         bool: `True` when a JSON-decode failure is in the chain.
     """
+    # Match by class name to catch the stdlib, `simplejson`, and `requests`
+    # variants without importing them, guarded by `ValueError` (every real
+    # variant subclasses it) so an unrelated same-named class is not a false
+    # positive.
     for node in _exception_chain(exc):
-        if isinstance(node, json.JSONDecodeError):
-            return True
-        if type(node).__name__ == "JSONDecodeError":
+        if isinstance(node, ValueError) and type(node).__name__ == "JSONDecodeError":
             return True
     return False
 

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -16,11 +16,13 @@ Three concerns are factored here so `osm/backend.py` only routes:
   `FeatureCollection` (`G7`), normalising the CRS to EPSG:4326. The ohsome
   path's `.as_dataframe()` is already a `GeoDataFrame`, so it goes straight to
   `to_fc`.
-* `OhsomeUnavailableError` / `ohsome_http_status` — turn the `ohsome` SDK's
-  opaque failure on a throttled/blocked public endpoint into a clear, typed,
-  actionable error. The SDK exposes the HTTP status inconsistently (see
-  `ohsome_http_status` for the two shapes), so the status is recovered from the
-  exception chain here.
+* `OhsomeResponseError` / `OhsomeUnavailableError` + `ohsome_http_status` /
+  `ohsome_error_response` / `ohsome_response_is_non_json` / `ohsome_body_preview`
+  — turn the `ohsome` SDK's opaque failure into a clear, typed, actionable error
+  carrying the evidence a raw `JSONDecodeError` discards (`#930`): the HTTP
+  status, the response `Content-Type`, and the first bytes of the body. The SDK
+  exposes those inconsistently (see `ohsome_http_status`), so they are recovered
+  from the exception chain here.
 
 All GIS containerisation stays inside the pyramids `FeatureCollection` per the
 repository's pyramids policy; earthlens only assembles the plain attribute rows
@@ -30,7 +32,9 @@ the shared biodiversity home so the backend imports the one warning class.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import json
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, cast
 
 import geopandas as gpd
 import pandas as pd
@@ -44,6 +48,8 @@ from shapely.geometry import LineString, Point, Polygon, box
 from earthlens.biodiversity import LicenseWarning  # noqa: F401
 
 if TYPE_CHECKING:
+    import requests
+
     from earthlens.base import SpatialExtent
 
 #: WGS84 — the CRS every OSM FeatureCollection is tagged with.
@@ -54,15 +60,55 @@ OSM_CRS = "EPSG:4326"
 _ID_COLUMNS = ["osm_id", "osm_type"]
 
 
-class OhsomeUnavailableError(RuntimeError):
+#: Characters of a non-JSON ohsome body to surface in the error / log line —
+#: enough to recognise an HTML rate-limit / maintenance / login page without
+#: dumping the whole thing.
+OHSOME_BODY_PREVIEW_CHARS = 200
+
+
+class OhsomeResponseError(RuntimeError):
+    """The ohsome endpoint returned a response earthlens could not use.
+
+    Raised in place of a raw `JSONDecodeError` when `api.ohsome.org` answers with
+    a body that is not the expected GeoJSON — a rate-limit / maintenance / error
+    page, an empty body, or a redirect followed to a landing page. Carries the
+    HTTP `status_code`, the response `content_type`, and a short `body_preview`
+    so a caller (and the logs) can tell those cases apart, instead of guessing
+    behind a decoder error (`#930`).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        content_type: str | None = None,
+        body_preview: str | None = None,
+    ) -> None:
+        """Store the readable message and the recovered response evidence.
+
+        Args:
+            message: Human-facing explanation — what happened and what to do.
+            status_code: The HTTP status of the offending response, or `None`
+                when it could not be recovered from the SDK error.
+            content_type: The response `Content-Type` header, or `None`.
+            body_preview: The first characters of the response body (decoded), or
+                `None` when no response object was recoverable.
+        """
+        super().__init__(message)
+        self.status_code = status_code
+        self.content_type = content_type
+        self.body_preview = body_preview
+
+
+class OhsomeUnavailableError(OhsomeResponseError):
     """The public ohsome endpoint refused a request with a retry-worthy status.
 
-    Raised by the OSM backend when `api.ohsome.org` answers a `403` (its front
-    proxy blocking / throttling this client — the endpoint is public and
-    keyless, so it is never a credential problem) or a `429` that outlived the
-    SDK's automatic retries. Carries the HTTP `status_code` so a caller can tell
-    a transient public-endpoint throttle apart from a genuine request error and
-    back off rather than fail hard.
+    A specialisation of `OhsomeResponseError` for the throttle/block case: raised
+    when `api.ohsome.org` answers a `403` (its front proxy blocking / throttling
+    this client — the endpoint is public and keyless, so it is never a credential
+    problem) or a `429` that outlived the SDK's automatic retries. Carries the
+    HTTP `status_code` so a caller can tell a transient public-endpoint throttle
+    apart from a genuine request error and back off rather than fail hard.
     """
 
     def __init__(self, message: str, status_code: int | None = None) -> None:
@@ -73,8 +119,28 @@ class OhsomeUnavailableError(RuntimeError):
             status_code: The HTTP status that triggered it (`403` / `429`), or
                 `None` when it could not be recovered from the SDK error.
         """
-        super().__init__(message)
-        self.status_code = status_code
+        super().__init__(message, status_code=status_code)
+
+
+def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
+    """Yield `exc` and its `__cause__` / `__context__` predecessors, once each.
+
+    Cycle-guarded (a self-referential `__context__` terminates instead of
+    looping), so callers can walk the whole chain the SDK may bury an HTTP status
+    or a `JSONDecodeError` in.
+
+    Args:
+        exc: The exception to walk from.
+
+    Yields:
+        BaseException: `exc`, then each predecessor, skipping any already seen.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
 
 
 def ohsome_http_status(exc: BaseException) -> int | None:
@@ -108,19 +174,89 @@ def ohsome_http_status(exc: BaseException) -> int | None:
 
             ```
     """
-    seen: set[int] = set()
-    current: BaseException | None = exc
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        error_code = getattr(current, "error_code", None)
+    for node in _exception_chain(exc):
+        error_code = getattr(node, "error_code", None)
         if _is_http_status(error_code):
             return error_code
-        response = getattr(current, "response", None)
-        status = getattr(response, "status_code", None)
+        status = getattr(getattr(node, "response", None), "status_code", None)
         if _is_http_status(status):
             return status
-        current = current.__cause__ or current.__context__
     return None
+
+
+def ohsome_error_response(exc: BaseException) -> requests.Response | None:
+    """Best-effort `requests.Response` behind an `ohsome` SDK failure.
+
+    The companion to `ohsome_http_status`: walks the same exception chain and
+    returns the first `response` object carrying a real HTTP status — the
+    `OhsomeException`'s `.response`, or the `requests.HTTPError.response` buried
+    in `__context__`. Hands the caller the status, `Content-Type`, and body the
+    raw decoder error discards (`#930`).
+
+    Args:
+        exc: The exception raised by an `ohsome` SDK call.
+
+    Returns:
+        requests.Response | None: The offending response, or `None` when none is
+            recoverable from the chain.
+    """
+    for node in _exception_chain(exc):
+        response = getattr(node, "response", None)
+        if response is not None and _is_http_status(
+            getattr(response, "status_code", None)
+        ):
+            return cast("requests.Response", response)
+    return None
+
+
+def ohsome_response_is_non_json(exc: BaseException) -> bool:
+    """Return whether the failure is a JSON-decode of the ohsome response body.
+
+    True when a `JSONDecodeError` (stdlib, `simplejson`, or the `requests`
+    variant) appears anywhere in the exception chain — the signature of "the body
+    was not JSON" (an HTML rate-limit / maintenance / error page, an empty body,
+    or a redirect to a landing page), as opposed to a genuine ohsome error served
+    *as* JSON.
+
+    Args:
+        exc: The exception raised by an `ohsome` SDK call.
+
+    Returns:
+        bool: `True` when a JSON-decode failure is in the chain.
+    """
+    for node in _exception_chain(exc):
+        if isinstance(node, json.JSONDecodeError):
+            return True
+        if type(node).__name__ == "JSONDecodeError":
+            return True
+    return False
+
+
+def ohsome_body_preview(
+    response: requests.Response | None,
+    limit: int = OHSOME_BODY_PREVIEW_CHARS,
+) -> str | None:
+    """Return the first `limit` characters of a response body, or `None`.
+
+    Reads `response.text` defensively (the SDK has already consumed the body, so
+    it is cached) and truncates it — the evidence `#930` asks to surface without
+    dumping a whole error page.
+
+    Args:
+        response: The offending response, or `None`.
+        limit: Maximum number of characters to return.
+
+    Returns:
+        str | None: The decoded body prefix, or `None` when there is no response
+            or its body could not be decoded.
+    """
+    if response is None:
+        return None
+    try:
+        text = response.text
+    except Exception:  # noqa: BLE001 - a body we cannot decode is simply no preview
+        return None
+    return text[:limit]
 
 
 def _is_http_status(value: object) -> bool:

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -122,8 +122,9 @@ class OhsomeUnavailableError(OhsomeResponseError):
 
         Args:
             message: Human-facing explanation — what happened and what to do.
-            status_code: The HTTP status that triggered it (`403` / `429`), or
-                `None` when it could not be recovered from the SDK error.
+            status_code: The HTTP status that triggered it (`403` / `429` /
+                `5xx`), or `None` when it could not be recovered from the SDK
+                error.
             content_type: The response `Content-Type` header, or `None`.
             body_preview: The first characters of the response body, or `None`.
         """

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -102,12 +102,13 @@ class OhsomeResponseError(RuntimeError):
 class OhsomeUnavailableError(OhsomeResponseError):
     """The public ohsome endpoint refused a request with a retry-worthy status.
 
-    A specialisation of `OhsomeResponseError` for the throttle/block case: raised
-    when `api.ohsome.org` answers a `403` (its front proxy blocking / throttling
-    this client — the endpoint is public and keyless, so it is never a credential
-    problem) or a `429` that outlived the SDK's automatic retries. Carries the
-    HTTP `status_code` so a caller can tell a transient public-endpoint throttle
-    apart from a genuine request error and back off rather than fail hard.
+    A specialisation of `OhsomeResponseError` for the throttle / block / outage
+    case: raised when `api.ohsome.org` answers a `403` (its front proxy blocking
+    / throttling this client — the endpoint is public and keyless, so it is never
+    a credential problem), a `429`, or a `5xx` server-side outage that outlived
+    the SDK's automatic retries. Carries the HTTP `status_code` so a caller can
+    tell a transient public-endpoint unavailability apart from a genuine request
+    error and back off rather than fail hard.
     """
 
     def __init__(

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -134,7 +134,7 @@ class OhsomeUnavailableError(OhsomeResponseError):
         )
 
 
-def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
+def _exception_chain(exc: Exception) -> Iterator[Exception]:
     """Yield `exc` and its `__cause__` / `__context__` predecessors, once each.
 
     Cycle-guarded (a self-referential `__context__` terminates instead of
@@ -145,17 +145,21 @@ def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
         exc: The exception to walk from.
 
     Yields:
-        BaseException: `exc`, then each predecessor, skipping any already seen.
+        Exception: `exc`, then each predecessor, skipping any already seen.
     """
     seen: set[int] = set()
-    current: BaseException | None = exc
+    current: Exception | None = exc
     while current is not None and id(current) not in seen:
         seen.add(id(current))
         yield current
-        current = current.__cause__ or current.__context__
+        # `__cause__` / `__context__` are `BaseException | None`; keep walking only
+        # while the predecessor is an ordinary `Exception` (a `KeyboardInterrupt`
+        # or `SystemExit` in the chain is never an ohsome response failure).
+        predecessor = current.__cause__ or current.__context__
+        current = predecessor if isinstance(predecessor, Exception) else None
 
 
-def ohsome_http_status(exc: BaseException) -> int | None:
+def ohsome_http_status(exc: Exception) -> int | None:
     """Best-effort HTTP status behind an `ohsome` SDK failure.
 
     The SDK exposes the status inconsistently. Usually it wraps the failure into
@@ -196,7 +200,7 @@ def ohsome_http_status(exc: BaseException) -> int | None:
     return None
 
 
-def ohsome_error_response(exc: BaseException) -> requests.Response | None:
+def ohsome_error_response(exc: Exception) -> requests.Response | None:
     """Best-effort `requests.Response` behind an `ohsome` SDK failure.
 
     The companion to `ohsome_http_status`: walks the same exception chain and
@@ -221,7 +225,7 @@ def ohsome_error_response(exc: BaseException) -> requests.Response | None:
     return None
 
 
-def ohsome_response_is_non_json(exc: BaseException) -> bool:
+def ohsome_response_is_non_json(exc: Exception) -> bool:
     """Return whether the failure is a JSON-decode of the ohsome response body.
 
     True when a `JSONDecodeError` (stdlib, `simplejson`, or the `requests`

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -110,15 +110,28 @@ class OhsomeUnavailableError(OhsomeResponseError):
     apart from a genuine request error and back off rather than fail hard.
     """
 
-    def __init__(self, message: str, status_code: int | None = None) -> None:
-        """Store the actionable message and the originating HTTP status.
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        content_type: str | None = None,
+        body_preview: str | None = None,
+    ) -> None:
+        """Store the actionable message and the recovered response evidence.
 
         Args:
             message: Human-facing explanation — what happened and what to do.
             status_code: The HTTP status that triggered it (`403` / `429`), or
                 `None` when it could not be recovered from the SDK error.
+            content_type: The response `Content-Type` header, or `None`.
+            body_preview: The first characters of the response body, or `None`.
         """
-        super().__init__(message, status_code=status_code)
+        super().__init__(
+            message,
+            status_code=status_code,
+            content_type=content_type,
+            body_preview=body_preview,
+        )
 
 
 def _exception_chain(exc: BaseException) -> Iterator[BaseException]:

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -775,7 +775,8 @@ class OSM(AbstractDataSource):
                 f"ohsome could not serve the elements/geometry request: HTTP "
                 f"{status_shown} after automatic retries. api.ohsome.org is a "
                 "public endpoint that load-sheds its compute-heavy extraction "
-                "path under load; this is a transient server-side outage, not a "
+                "path under load, so a 5xx is usually a transient server-side "
+                "condition (load-shedding or a gateway error), not typically a "
                 "problem with the request. Retry later, or check the ohsome "
                 "service status.",
                 status_code=status,

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -624,8 +624,9 @@ class OSM(AbstractDataSource):
         Raises:
             ImportError: If `ohsome` is not installed (`earthlens[osm]`).
             OhsomeUnavailableError: If `api.ohsome.org` blocks/throttles the
-                request with a `403` (or a `429` outlasting the retries) — a
-                public-endpoint denial, not a credential error.
+                request with a `403` / `429`, or is unavailable with a `5xx`
+                outlasting the retries — a public-endpoint denial/outage, not a
+                credential error.
             OhsomeResponseError: If `api.ohsome.org` returns any other non-JSON
                 body (a rate-limit / maintenance / error page or a redirect).
             ValueError: If no `start` (and `time`) was supplied — ohsome
@@ -694,6 +695,9 @@ class OSM(AbstractDataSource):
 
         * a `403`, or a `429` that outlived the retries, becomes an
           `OhsomeUnavailableError` (a public-endpoint throttle/block);
+        * a `5xx` that outlived the retries becomes an `OhsomeUnavailableError`
+          too — a transient server-side outage; the SDK can otherwise die with a
+          raw `KeyError: 'message'` on a `5xx` body (`#790`);
         * any other non-JSON body — a rate-limit / maintenance / error page, an
           empty body, or a redirect to a landing page — becomes an
           `OhsomeResponseError` carrying the recovered evidence.
@@ -708,13 +712,14 @@ class OSM(AbstractDataSource):
 
         Raises:
             OhsomeUnavailableError: On a public-endpoint throttle/block (`403` /
-                `429`).
+                `429`) or a transient server-side outage (`5xx`).
             OhsomeResponseError: On any other non-JSON response body.
         """
         status = ohsome_http_status(exc)
         non_json = ohsome_response_is_non_json(exc)
         is_throttle = status in (403, 429)
-        if not is_throttle and not non_json:
+        is_server_error = status is not None and 500 <= status < 600
+        if not is_throttle and not is_server_error and not non_json:
             # A transport error (no status), or a genuine ohsome error already
             # served as readable JSON (including a JSON `401`) — nothing to add;
             # let the caller re-raise the original, as quietly as before.
@@ -761,7 +766,24 @@ class OSM(AbstractDataSource):
                 content_type=content_type,
                 body_preview=body_preview,
             ) from exc
-        # Not a throttle, so — given the guard above — the body was not JSON.
+        if is_server_error:
+            # A 5xx that outlived the retries — a server-side outage. The SDK can
+            # die with a raw `KeyError: 'message'` here (its error handler assumes
+            # a `"message"` field the 5xx body lacks, `#790`), so surface a clear
+            # service-unavailable error carrying the status instead.
+            raise OhsomeUnavailableError(
+                f"ohsome could not serve the elements/geometry request: HTTP "
+                f"{status_shown} after automatic retries. api.ohsome.org is a "
+                "public endpoint that load-sheds its compute-heavy extraction "
+                "path under load; this is a transient server-side outage, not a "
+                "problem with the request. Retry later, or check the ohsome "
+                "service status.",
+                status_code=status,
+                content_type=content_type,
+                body_preview=body_preview,
+            ) from exc
+        # Not a throttle or a server error, so — given the guard above — the body
+        # was not JSON.
         raise OhsomeResponseError(
             "ohsome returned a non-JSON response for the elements/geometry "
             f"request (HTTP {status_shown}, Content-Type {content_type!r}); "

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -748,6 +748,8 @@ class OSM(AbstractDataSource):
                 "later, shrink the bbox or time window, or try from a different "
                 "network.",
                 status_code=status,
+                content_type=content_type,
+                body_preview=body_preview,
             ) from exc
         if status == 429:
             raise OhsomeUnavailableError(
@@ -756,6 +758,8 @@ class OSM(AbstractDataSource):
                 "rate-limiting this client; wait before retrying, or reduce the "
                 "request frequency and size.",
                 status_code=status,
+                content_type=content_type,
+                body_preview=body_preview,
             ) from exc
         # Not a throttle, so — given the guard above — the body was not JSON.
         raise OhsomeResponseError(

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -702,10 +702,10 @@ class OSM(AbstractDataSource):
           empty body, or a redirect to a landing page — becomes an
           `OhsomeResponseError` carrying the recovered evidence.
 
-        Anything else (a transport error, or a genuine ohsome error served *as*
-        JSON — including a `401`, which on this keyless endpoint signals a real
-        auth-contract change, not a throttle) is left for the caller to re-raise
-        unchanged, so a genuine regression still surfaces loudly.
+        Anything else (a transport error, or a non-`5xx` ohsome error served
+        *as* JSON — including a `401`, which on this keyless endpoint signals a
+        real auth-contract change, not a throttle) is left for the caller to
+        re-raise unchanged, so a genuine regression still surfaces loudly.
 
         Args:
             exc: The exception raised by the ohsome SDK call.
@@ -772,7 +772,7 @@ class OSM(AbstractDataSource):
             # a `"message"` field the 5xx body lacks, `#790`), so surface a clear
             # service-unavailable error carrying the status instead.
             raise OhsomeUnavailableError(
-                f"ohsome could not serve the elements/geometry request: HTTP "
+                "ohsome could not serve the elements/geometry request: HTTP "
                 f"{status_shown} after automatic retries. api.ohsome.org is a "
                 "public endpoint that load-sheds its compute-heavy extraction "
                 "path under load, so a 5xx is usually a transient server-side "

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -713,22 +713,30 @@ class OSM(AbstractDataSource):
         """
         status = ohsome_http_status(exc)
         non_json = ohsome_response_is_non_json(exc)
-        if status is None and not non_json:
-            # Not an HTTP / response failure (e.g. a transport error) — nothing to
-            # add; let the caller re-raise the original.
+        is_throttle = status in (403, 429)
+        if not is_throttle and not non_json:
+            # A transport error (no status), or a genuine ohsome error already
+            # served as readable JSON (including a JSON `401`) — nothing to add;
+            # let the caller re-raise the original, as quietly as before.
             return
 
         response = ohsome_error_response(exc)
         headers = getattr(response, "headers", None)
         content_type = headers.get("Content-Type") if headers is not None else None
         body_preview = ohsome_body_preview(response)
+        status_shown = status if status is not None else "unknown"
+        body_note = (
+            f"first {len(body_preview)} body chars: {body_preview!r}"
+            if body_preview is not None
+            else "no body captured"
+        )
         # Log the evidence the raw decoder error discards, at the point of failure
-        # — visible even when the caller skips the throttle case (`#930`).
+        # — visible even when the caller skips the throttle case (`#930`). Only the
+        # converted (throttle / non-JSON) branches reach here, so a JSON-served
+        # error propagates without a stray warning.
         logger.warning(
             "ohsome elements/geometry request failed: "
-            f"HTTP {status if status is not None else 'unknown'}, "
-            f"Content-Type {content_type!r}, "
-            f"first {len(body_preview or '')} body chars: {body_preview!r}"
+            f"HTTP {status_shown}, Content-Type {content_type!r}, {body_note}"
         )
 
         if status == 403:
@@ -749,23 +757,18 @@ class OSM(AbstractDataSource):
                 "request frequency and size.",
                 status_code=status,
             ) from exc
-        if non_json:
-            shown_status = status if status is not None else "an unknown status"
-            raise OhsomeResponseError(
-                "ohsome returned a non-JSON response for the elements/geometry "
-                f"request (HTTP {shown_status}, Content-Type {content_type!r}); "
-                f"the first {len(body_preview or '')} characters were "
-                f"{body_preview!r}. api.ohsome.org served an unparseable body — "
-                "typically a rate-limit, maintenance, or error page, or a "
-                "redirect to a landing page — rather than the expected GeoJSON. "
-                "Retry later, or check the ohsome service status.",
-                status_code=status,
-                content_type=content_type,
-                body_preview=body_preview,
-            ) from exc
-        # A recovered HTTP status that is neither a throttle nor a non-JSON body
-        # (e.g. a genuine ohsome error already served as readable JSON) — let the
-        # caller re-raise the SDK's own error unchanged.
+        # Not a throttle, so — given the guard above — the body was not JSON.
+        raise OhsomeResponseError(
+            "ohsome returned a non-JSON response for the elements/geometry "
+            f"request (HTTP {status_shown}, Content-Type {content_type!r}); "
+            f"{body_note}. api.ohsome.org served an unparseable body — typically "
+            "a rate-limit, maintenance, or error page, or a redirect to a landing "
+            "page — rather than the expected GeoJSON. Retry later, or check the "
+            "ohsome service status.",
+            status_code=status,
+            content_type=content_type,
+            body_preview=body_preview,
+        ) from exc
 
     def _fetch_pbf(self, query_id: str, dataset: Dataset) -> FeatureCollection:
         """Fetch one `pbf` layer: resolve region, fetch-cache, read, bbox-clip.

--- a/libs/providers/hazards/src/earthlens/osm/backend.py
+++ b/libs/providers/hazards/src/earthlens/osm/backend.py
@@ -62,11 +62,15 @@ from earthlens.base import (
 from earthlens.base.http import DEFAULT_TIMEOUT, HttpClient
 from earthlens.osm._helpers import (
     LicenseWarning,
+    OhsomeResponseError,
     OhsomeUnavailableError,
     bbox_swne,
     bbox_wsen,
     empty_fc,
+    ohsome_body_preview,
+    ohsome_error_response,
     ohsome_http_status,
+    ohsome_response_is_non_json,
     overpy_to_gdf,
     to_fc,
 )
@@ -601,12 +605,13 @@ class OSM(AbstractDataSource):
         gives the SDK's session a urllib3 `Retry` (`MAX_OHSOME_RETRIES` retries,
         exponential `OHSOME_BACKOFF_FACTOR` growth, `Retry-After` honoured) so a
         `429`/`5xx` throttle is retried with backoff — matching the repo-wide
-        `HttpClient`. A `403` (and any leftover `429` after the retries) is *not*
-        a transient error on this public, keyless endpoint, so it is turned into
-        a clear, typed `OhsomeUnavailableError` (via `_raise_ohsome_unavailable`)
-        instead of the SDK's opaque failure — which exposes the status
-        inconsistently, sometimes as an `OhsomeException` and sometimes as a bare
-        leaked `JSONDecodeError`.
+        `HttpClient`. Any remaining failure is turned into a clear, typed error
+        (via `_reraise_ohsome_error`, which logs the recovered status /
+        `Content-Type` / body preview) instead of the SDK's opaque failure: a
+        `403` / `429` throttle becomes an `OhsomeUnavailableError`, and any other
+        non-JSON body (a rate-limit / maintenance / error page or a redirect)
+        becomes an `OhsomeResponseError` — so a decoder error never stands in for
+        "the server said no" (`#930`).
 
         Args:
             query_id: The named-query id (for logging).
@@ -621,6 +626,8 @@ class OSM(AbstractDataSource):
             OhsomeUnavailableError: If `api.ohsome.org` blocks/throttles the
                 request with a `403` (or a `429` outlasting the retries) — a
                 public-endpoint denial, not a credential error.
+            OhsomeResponseError: If `api.ohsome.org` returns any other non-JSON
+                body (a rate-limit / maintenance / error page or a redirect).
             ValueError: If no `start` (and `time`) was supplied — ohsome
                 requires a time.
         """
@@ -663,10 +670,11 @@ class OSM(AbstractDataSource):
                 endpoint="elements/geometry",
             )
             gdf = response.as_dataframe()
-        # Broad by design: classify a throttle/block into a typed error, else
-        # re-raise the original failure unchanged.
+        # Broad by design: convert a throttle/block or a non-JSON response into a
+        # clear typed error (logging the recovered evidence), else re-raise the
+        # original failure unchanged.
         except Exception as exc:  # noqa: BLE001
-            self._raise_ohsome_unavailable(exc)
+            self._reraise_ohsome_error(exc)
             raise
         # `as_dataframe()` carries a (@osmId, @snapshotTimestamp) MultiIndex;
         # reset it so the history fields become ordinary columns on the FC.
@@ -674,26 +682,55 @@ class OSM(AbstractDataSource):
             gdf = gdf.reset_index()
         return to_fc(gdf)
 
-    def _raise_ohsome_unavailable(self, exc: Exception) -> None:
-        """Re-raise an ohsome throttle/block as a typed `OhsomeUnavailableError`.
+    def _reraise_ohsome_error(self, exc: Exception) -> None:
+        """Convert an ohsome SDK failure into a clear, typed, logged error.
 
-        Inspects the SDK failure for an HTTP status (`ohsome_http_status`
-        recovers it whether the SDK wrapped the failure into an `OhsomeException`
-        or leaked a bare `JSONDecodeError`). A `403`, or a `429`
-        that outlived the retries, becomes a clear, actionable
-        `OhsomeUnavailableError`; any other failure — including a `401`, which on
-        this keyless endpoint signals a real auth-contract change, not a
-        throttle — is left for the caller to re-raise unchanged so a genuine
-        regression still surfaces loudly.
+        The raw SDK failure discards what the server actually said — a decoder
+        error is the wrong abstraction for "the response was not JSON" (`#930`).
+        This recovers the HTTP status, `Content-Type`, and first bytes of the
+        body from the exception chain (whether the SDK wrapped the failure into
+        an `OhsomeException` or leaked a bare `JSONDecodeError`), logs them at the
+        point of failure, and then raises the right typed error:
+
+        * a `403`, or a `429` that outlived the retries, becomes an
+          `OhsomeUnavailableError` (a public-endpoint throttle/block);
+        * any other non-JSON body — a rate-limit / maintenance / error page, an
+          empty body, or a redirect to a landing page — becomes an
+          `OhsomeResponseError` carrying the recovered evidence.
+
+        Anything else (a transport error, or a genuine ohsome error served *as*
+        JSON — including a `401`, which on this keyless endpoint signals a real
+        auth-contract change, not a throttle) is left for the caller to re-raise
+        unchanged, so a genuine regression still surfaces loudly.
 
         Args:
             exc: The exception raised by the ohsome SDK call.
 
         Raises:
-            OhsomeUnavailableError: When the status is a public-endpoint
-                throttle/block (`403` / `429`).
+            OhsomeUnavailableError: On a public-endpoint throttle/block (`403` /
+                `429`).
+            OhsomeResponseError: On any other non-JSON response body.
         """
         status = ohsome_http_status(exc)
+        non_json = ohsome_response_is_non_json(exc)
+        if status is None and not non_json:
+            # Not an HTTP / response failure (e.g. a transport error) — nothing to
+            # add; let the caller re-raise the original.
+            return
+
+        response = ohsome_error_response(exc)
+        headers = getattr(response, "headers", None)
+        content_type = headers.get("Content-Type") if headers is not None else None
+        body_preview = ohsome_body_preview(response)
+        # Log the evidence the raw decoder error discards, at the point of failure
+        # — visible even when the caller skips the throttle case (`#930`).
+        logger.warning(
+            "ohsome elements/geometry request failed: "
+            f"HTTP {status if status is not None else 'unknown'}, "
+            f"Content-Type {content_type!r}, "
+            f"first {len(body_preview or '')} body chars: {body_preview!r}"
+        )
+
         if status == 403:
             raise OhsomeUnavailableError(
                 "ohsome refused the elements/geometry request with HTTP 403. "
@@ -712,6 +749,23 @@ class OSM(AbstractDataSource):
                 "request frequency and size.",
                 status_code=status,
             ) from exc
+        if non_json:
+            shown_status = status if status is not None else "an unknown status"
+            raise OhsomeResponseError(
+                "ohsome returned a non-JSON response for the elements/geometry "
+                f"request (HTTP {shown_status}, Content-Type {content_type!r}); "
+                f"the first {len(body_preview or '')} characters were "
+                f"{body_preview!r}. api.ohsome.org served an unparseable body — "
+                "typically a rate-limit, maintenance, or error page, or a "
+                "redirect to a landing page — rather than the expected GeoJSON. "
+                "Retry later, or check the ohsome service status.",
+                status_code=status,
+                content_type=content_type,
+                body_preview=body_preview,
+            ) from exc
+        # A recovered HTTP status that is neither a throttle nor a non-JSON body
+        # (e.g. a genuine ohsome error already served as readable JSON) — let the
+        # caller re-raise the SDK's own error unchanged.
 
     def _fetch_pbf(self, query_id: str, dataset: Dataset) -> FeatureCollection:
         """Fetch one `pbf` layer: resolve region, fetch-cache, read, bbox-clip.

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -471,6 +471,65 @@ class TestOhsomeRoute:
             logger.remove(sink_id)
         assert messages == [], f"expected no warning on pass-through, got: {messages}"
 
+    def test_server_error_becomes_unavailable(self, osm_kwargs, fake_ohsome):
+        """A 503 (the SDK's KeyError on a 5xx body) surfaces as unavailable (#790)."""
+        import requests
+
+        from earthlens.osm import OhsomeUnavailableError
+
+        # The ohsome SDK does e.response.json()["message"] on the 503 body, which
+        # lacks a "message" key, dying with a raw KeyError whose originating
+        # HTTPError (status 503) is only in the __context__ chain.
+        http_error = requests.HTTPError("503 Service Unavailable")
+        http_error.response = types.SimpleNamespace(
+            status_code=503, headers={}, text=""
+        )
+        key_error = KeyError("message")
+        key_error.__context__ = http_error
+        fake_ohsome.error = key_error
+
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
+        with pytest.raises(OhsomeUnavailableError) as excinfo:
+            backend.download()
+        assert excinfo.value.status_code == 503
+        assert "503" in str(excinfo.value)
+        assert excinfo.value.__cause__ is key_error
+
+
+class TestE2ESkipHelper:
+    """The e2e `_skip_on_network` decides skip-vs-fail from the typed error."""
+
+    def test_skips_on_server_error(self):
+        """A 5xx OhsomeUnavailableError skips the lane rather than failing (#790)."""
+        from _pytest.outcomes import Skipped
+
+        from earthlens.osm import OhsomeUnavailableError
+
+        from .test_osm_e2e import _skip_on_network
+
+        with pytest.raises(Skipped):
+            _skip_on_network(OhsomeUnavailableError("outage", status_code=503))
+
+    def test_skips_on_throttle(self):
+        """A 403 OhsomeUnavailableError still skips (issue #1025 behaviour)."""
+        from _pytest.outcomes import Skipped
+
+        from earthlens.osm import OhsomeUnavailableError
+
+        from .test_osm_e2e import _skip_on_network
+
+        with pytest.raises(Skipped):
+            _skip_on_network(OhsomeUnavailableError("throttled", status_code=403))
+
+    def test_reraises_a_genuine_error(self):
+        """A non-throttle, non-outage error re-raises and fails the lane."""
+        from .test_osm_e2e import _skip_on_network
+
+        with pytest.raises(ValueError, match="boom"):
+            _skip_on_network(ValueError("boom"))
+
 
 class TestDownloadContract:
     """Cross-cutting download() behaviour."""

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -497,24 +497,20 @@ class TestOhsomeRoute:
         assert "503" in str(excinfo.value)
         assert excinfo.value.__cause__ is key_error
 
-    @pytest.mark.parametrize("status", [500, 502, 504])
+    @pytest.mark.parametrize("status", [500, 502, 504, 599])
     def test_server_error_variants_become_unavailable(
         self, osm_kwargs, fake_ohsome, status
     ):
-        """Each 5xx wrapped as OhsomeException(error_code=5xx) becomes unavailable.
-
-        Args:
-            status: The 5xx server-error status the SDK reports via error_code.
-
-        Test scenario:
-            A 5xx whose body does carry a "message" surfaces from the SDK as an
-            OhsomeException-like error (error_code set, no KeyError); the backend
-            still converts it to a status-carrying OhsomeUnavailableError.
-        """
+        """A 5xx wrapped as OhsomeException(error_code=5xx) becomes unavailable."""
         from earthlens.osm import OhsomeUnavailableError
 
         ohsome_error = RuntimeError("server error")
         ohsome_error.error_code = status
+        ohsome_error.response = types.SimpleNamespace(
+            status_code=status,
+            headers={"Content-Type": "text/html"},
+            text="<html>server error</html>",
+        )
         fake_ohsome.error = ohsome_error
 
         backend = OSM(
@@ -522,21 +518,15 @@ class TestOhsomeRoute:
         )
         with pytest.raises(OhsomeUnavailableError) as excinfo:
             backend.download()
-        assert excinfo.value.status_code == status, (
-            f"expected status {status}, got {excinfo.value.status_code}"
-        )
+        err = excinfo.value
+        assert err.status_code == status, f"expected {status}, got {err.status_code}"
+        assert err.content_type == "text/html", f"got {err.content_type}"
+        assert err.body_preview.startswith("<html>"), f"got {err.body_preview!r}"
 
     def test_server_error_with_html_body_prefers_unavailable(
         self, osm_kwargs, fake_ohsome
     ):
-        """A 5xx with a non-JSON HTML body is unavailable, not a response error.
-
-        Test scenario:
-            A 503 served as HTML leaves a JSONDecodeError in the chain, but the
-            server-error branch takes precedence over the generic non-JSON one,
-            so it becomes an OhsomeUnavailableError (a subtype of
-            OhsomeResponseError) carrying the recovered content type and body.
-        """
+        """A 5xx served as HTML is unavailable, not a response error (5xx wins)."""
         import json
 
         from earthlens.osm import OhsomeResponseError, OhsomeUnavailableError
@@ -598,13 +588,7 @@ class TestE2ESkipHelper:
             _skip_on_network(genuine)
 
     def test_does_not_skip_on_non_transient_status(self):
-        """A non-403/429/5xx OhsomeUnavailableError re-raises, not skipped.
-
-        Test scenario:
-            The skip helper treats only 403/429 throttles and 5xx outages as
-            transient (`500 <= status < 600`); any other status re-raises, so a
-            genuine failure still fails the lane rather than skipping silently.
-        """
+        """A non-transient-status OhsomeUnavailableError re-raises, not skipped."""
         from earthlens.osm import OhsomeUnavailableError
 
         from .test_osm_e2e import _skip_on_network

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -407,6 +407,30 @@ class TestOhsomeRoute:
         assert "text/html" in logged
         assert "rate limited" in logged
 
+    def test_json_error_pass_through_does_not_log(self, osm_kwargs, fake_ohsome):
+        """A JSON-served ohsome error is re-raised quietly, with no stray warning."""
+        from loguru import logger
+
+        ohsome_error = RuntimeError("bad request")
+        ohsome_error.error_code = 400  # recovered status, but served AS JSON
+        fake_ohsome.error = ohsome_error
+
+        messages: list[str] = []
+        sink_id = logger.add(messages.append, level="WARNING", format="{message}")
+        try:
+            backend = OSM(
+                **{
+                    **osm_kwargs(),
+                    "variables": ["ohsome:buildings"],
+                    "start": "2020-01-01",
+                }
+            )
+            with pytest.raises(RuntimeError, match="bad request"):
+                backend.download()
+        finally:
+            logger.remove(sink_id)
+        assert messages == [], f"expected no warning on pass-through, got: {messages}"
+
 
 class TestDownloadContract:
     """Cross-cutting download() behaviour."""

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -497,6 +497,70 @@ class TestOhsomeRoute:
         assert "503" in str(excinfo.value)
         assert excinfo.value.__cause__ is key_error
 
+    @pytest.mark.parametrize("status", [500, 502, 504])
+    def test_server_error_variants_become_unavailable(
+        self, osm_kwargs, fake_ohsome, status
+    ):
+        """Each 5xx wrapped as OhsomeException(error_code=5xx) becomes unavailable.
+
+        Args:
+            status: The 5xx server-error status the SDK reports via error_code.
+
+        Test scenario:
+            A 5xx whose body does carry a "message" surfaces from the SDK as an
+            OhsomeException-like error (error_code set, no KeyError); the backend
+            still converts it to a status-carrying OhsomeUnavailableError.
+        """
+        from earthlens.osm import OhsomeUnavailableError
+
+        ohsome_error = RuntimeError("server error")
+        ohsome_error.error_code = status
+        fake_ohsome.error = ohsome_error
+
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
+        with pytest.raises(OhsomeUnavailableError) as excinfo:
+            backend.download()
+        assert excinfo.value.status_code == status, (
+            f"expected status {status}, got {excinfo.value.status_code}"
+        )
+
+    def test_server_error_with_html_body_prefers_unavailable(
+        self, osm_kwargs, fake_ohsome
+    ):
+        """A 5xx with a non-JSON HTML body is unavailable, not a response error.
+
+        Test scenario:
+            A 503 served as HTML leaves a JSONDecodeError in the chain, but the
+            server-error branch takes precedence over the generic non-JSON one,
+            so it becomes an OhsomeUnavailableError (a subtype of
+            OhsomeResponseError) carrying the recovered content type and body.
+        """
+        import json
+
+        from earthlens.osm import OhsomeResponseError, OhsomeUnavailableError
+
+        response = types.SimpleNamespace(
+            status_code=503,
+            headers={"Content-Type": "text/html"},
+            text="<html>Service Unavailable</html>",
+        )
+        decode_error = json.JSONDecodeError("Expecting value", "<html>", 0)
+        decode_error.response = response
+        fake_ohsome.error = decode_error
+
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
+        with pytest.raises(OhsomeUnavailableError) as excinfo:
+            backend.download()
+        err = excinfo.value
+        assert isinstance(err, OhsomeResponseError), "subtype should keep the base"
+        assert err.status_code == 503, f"expected 503, got {err.status_code}"
+        assert err.content_type == "text/html", f"got {err.content_type}"
+        assert err.body_preview.startswith("<html>"), f"got {err.body_preview!r}"
+
 
 class TestE2ESkipHelper:
     """The e2e `_skip_on_network` decides skip-vs-fail from the typed error."""
@@ -532,6 +596,22 @@ class TestE2ESkipHelper:
         genuine = ValueError("boom")
         with pytest.raises(ValueError, match="boom"):
             _skip_on_network(genuine)
+
+    def test_does_not_skip_on_non_transient_status(self):
+        """A non-403/429/5xx OhsomeUnavailableError re-raises, not skipped.
+
+        Test scenario:
+            The skip helper treats only 403/429 throttles and 5xx outages as
+            transient (`500 <= status < 600`); any other status re-raises, so a
+            genuine failure still fails the lane rather than skipping silently.
+        """
+        from earthlens.osm import OhsomeUnavailableError
+
+        from .test_osm_e2e import _skip_on_network
+
+        unexpected = OhsomeUnavailableError("odd", status_code=404)
+        with pytest.raises(OhsomeUnavailableError):
+            _skip_on_network(unexpected)
 
 
 class TestDownloadContract:

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -597,6 +597,28 @@ class TestE2ESkipHelper:
         with pytest.raises(OhsomeUnavailableError):
             _skip_on_network(unexpected)
 
+    def test_skips_at_upper_5xx_boundary(self):
+        """The top of the 5xx range (599) still skips."""
+        from _pytest.outcomes import Skipped
+
+        from earthlens.osm import OhsomeUnavailableError
+
+        from .test_osm_e2e import _skip_on_network
+
+        top = OhsomeUnavailableError("outage", status_code=599)
+        with pytest.raises(Skipped):
+            _skip_on_network(top)
+
+    def test_does_not_skip_at_600(self):
+        """Just past the 5xx range (600) re-raises, not skipped."""
+        from earthlens.osm import OhsomeUnavailableError
+
+        from .test_osm_e2e import _skip_on_network
+
+        past = OhsomeUnavailableError("odd", status_code=600)
+        with pytest.raises(OhsomeUnavailableError):
+            _skip_on_network(past)
+
 
 class TestDownloadContract:
     """Cross-cutting download() behaviour."""

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -407,6 +407,44 @@ class TestOhsomeRoute:
         assert "text/html" in logged
         assert "rate limited" in logged
 
+    def test_forbidden_carries_and_logs_evidence(self, osm_kwargs, fake_ohsome):
+        """A 403 throttle carries the recovered content-type/body and logs them."""
+        import json
+
+        from loguru import logger
+
+        from earthlens.osm import OhsomeUnavailableError
+
+        response = types.SimpleNamespace(
+            status_code=403,
+            headers={"Content-Type": "text/html"},
+            text="<html>Forbidden</html>",
+        )
+        decode_error = json.JSONDecodeError("Expecting value", "<html>", 0)
+        decode_error.response = response
+        fake_ohsome.error = decode_error
+
+        messages: list[str] = []
+        sink_id = logger.add(messages.append, level="WARNING", format="{message}")
+        try:
+            backend = OSM(
+                **{
+                    **osm_kwargs(),
+                    "variables": ["ohsome:buildings"],
+                    "start": "2020-01-01",
+                }
+            )
+            with pytest.raises(OhsomeUnavailableError) as excinfo:
+                backend.download()
+        finally:
+            logger.remove(sink_id)
+        err = excinfo.value
+        assert err.status_code == 403
+        assert err.content_type == "text/html"
+        assert err.body_preview.startswith("<html>")
+        logged = "".join(str(message) for message in messages)
+        assert "403" in logged and "text/html" in logged
+
     def test_json_error_pass_through_does_not_log(self, osm_kwargs, fake_ohsome):
         """A JSON-served ohsome error is re-raised quietly, with no stray warning."""
         from loguru import logger

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -318,7 +318,8 @@ class TestOhsomeRoute:
         assert err.status_code == 200
         assert err.content_type == "text/html"
         assert err.body_preview.startswith("<html>")
-        assert "non-JSON" in str(err) and "text/html" in str(err)
+        assert "non-JSON" in str(err)
+        assert "text/html" in str(err)
         # a 200 body is not a throttle, so it is the base error, not the subtype
         assert not isinstance(err, OhsomeUnavailableError)
 
@@ -443,7 +444,8 @@ class TestOhsomeRoute:
         assert err.content_type == "text/html"
         assert err.body_preview.startswith("<html>")
         logged = "".join(str(message) for message in messages)
-        assert "403" in logged and "text/html" in logged
+        assert "403" in logged
+        assert "text/html" in logged
 
     def test_json_error_pass_through_does_not_log(self, osm_kwargs, fake_ohsome):
         """A JSON-served ohsome error is re-raised quietly, with no stray warning."""

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -509,8 +509,9 @@ class TestE2ESkipHelper:
 
         from .test_osm_e2e import _skip_on_network
 
+        outage = OhsomeUnavailableError("outage", status_code=503)
         with pytest.raises(Skipped):
-            _skip_on_network(OhsomeUnavailableError("outage", status_code=503))
+            _skip_on_network(outage)
 
     def test_skips_on_throttle(self):
         """A 403 OhsomeUnavailableError still skips (issue #1025 behaviour)."""
@@ -520,15 +521,17 @@ class TestE2ESkipHelper:
 
         from .test_osm_e2e import _skip_on_network
 
+        throttled = OhsomeUnavailableError("throttled", status_code=403)
         with pytest.raises(Skipped):
-            _skip_on_network(OhsomeUnavailableError("throttled", status_code=403))
+            _skip_on_network(throttled)
 
     def test_reraises_a_genuine_error(self):
         """A non-throttle, non-outage error re-raises and fails the lane."""
         from .test_osm_e2e import _skip_on_network
 
+        genuine = ValueError("boom")
         with pytest.raises(ValueError, match="boom"):
-            _skip_on_network(ValueError("boom"))
+            _skip_on_network(genuine)
 
 
 class TestDownloadContract:

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -294,6 +294,119 @@ class TestOhsomeRoute:
         with pytest.raises(RuntimeError, match="some genuine bug"):
             backend.download()
 
+    def test_non_json_body_becomes_response_error(self, osm_kwargs, fake_ohsome):
+        """A non-JSON body (an HTML page) surfaces as a typed OhsomeResponseError."""
+        import json
+
+        from earthlens.osm import OhsomeResponseError, OhsomeUnavailableError
+
+        response = types.SimpleNamespace(
+            status_code=200,
+            headers={"Content-Type": "text/html"},
+            text="<html><body>Service under maintenance</body></html>",
+        )
+        decode_error = json.JSONDecodeError("Expecting value", "<html>", 0)
+        decode_error.response = response
+        fake_ohsome.error = decode_error
+
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
+        with pytest.raises(OhsomeResponseError) as excinfo:
+            backend.download()
+        err = excinfo.value
+        assert err.status_code == 200
+        assert err.content_type == "text/html"
+        assert err.body_preview.startswith("<html>")
+        assert "non-JSON" in str(err) and "text/html" in str(err)
+        # a 200 body is not a throttle, so it is the base error, not the subtype
+        assert not isinstance(err, OhsomeUnavailableError)
+
+    def test_non_json_body_without_status_still_typed(self, osm_kwargs, fake_ohsome):
+        """A non-JSON failure with no recoverable status still yields the typed error."""
+        import json
+
+        from earthlens.osm import OhsomeResponseError
+
+        fake_ohsome.error = json.JSONDecodeError("Expecting value", "", 0)
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
+        with pytest.raises(OhsomeResponseError) as excinfo:
+            backend.download()
+        err = excinfo.value
+        assert err.status_code is None
+        assert err.content_type is None
+        assert err.body_preview is None
+
+    def test_json_error_response_propagates_unchanged(self, osm_kwargs, fake_ohsome):
+        """A genuine ohsome error served AS JSON is not masked as a response error."""
+        from earthlens.osm import OhsomeResponseError
+
+        ohsome_error = RuntimeError("bad request")
+        ohsome_error.error_code = 400  # recovered status, but no JSONDecodeError
+        fake_ohsome.error = ohsome_error
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
+        with pytest.raises(RuntimeError, match="bad request") as excinfo:
+            backend.download()
+        assert not isinstance(excinfo.value, OhsomeResponseError)
+
+    def test_transport_error_propagates_unchanged(self, osm_kwargs, fake_ohsome):
+        """A transport error (no status, not non-JSON) propagates untouched."""
+        import requests
+
+        from earthlens.osm import OhsomeResponseError
+
+        fake_ohsome.error = requests.ConnectionError("connection reset")
+        backend = OSM(
+            **{**osm_kwargs(), "variables": ["ohsome:buildings"], "start": "2020-01-01"}
+        )
+        with pytest.raises(
+            requests.ConnectionError, match="connection reset"
+        ) as excinfo:
+            backend.download()
+        assert not isinstance(excinfo.value, OhsomeResponseError)
+
+    def test_failure_logs_status_content_type_and_body_preview(
+        self, osm_kwargs, fake_ohsome
+    ):
+        """The recovered status, content-type and body preview are logged (#930)."""
+        import json
+
+        from loguru import logger
+
+        from earthlens.osm import OhsomeResponseError
+
+        response = types.SimpleNamespace(
+            status_code=503,
+            headers={"Content-Type": "text/html; charset=utf-8"},
+            text="<html>rate limited</html>",
+        )
+        decode_error = json.JSONDecodeError("Expecting value", "<html>", 0)
+        decode_error.response = response
+        fake_ohsome.error = decode_error
+
+        messages: list[str] = []
+        sink_id = logger.add(messages.append, level="WARNING", format="{message}")
+        try:
+            backend = OSM(
+                **{
+                    **osm_kwargs(),
+                    "variables": ["ohsome:buildings"],
+                    "start": "2020-01-01",
+                }
+            )
+            with pytest.raises(OhsomeResponseError):
+                backend.download()
+        finally:
+            logger.remove(sink_id)
+        logged = "".join(str(message) for message in messages)
+        assert "503" in logged
+        assert "text/html" in logged
+        assert "rate limited" in logged
+
 
 class TestDownloadContract:
     """Cross-cutting download() behaviour."""

--- a/libs/providers/hazards/tests/osm/test_helpers.py
+++ b/libs/providers/hazards/tests/osm/test_helpers.py
@@ -12,7 +12,10 @@ from earthlens.osm._helpers import (
     bbox_swne,
     bbox_wsen,
     empty_fc,
+    ohsome_body_preview,
+    ohsome_error_response,
     ohsome_http_status,
+    ohsome_response_is_non_json,
     overpy_to_gdf,
     shapely_bbox,
     to_fc,
@@ -185,6 +188,74 @@ class TestOhsomeHttpStatus:
         first.__context__ = second
         second.__context__ = first
         assert ohsome_http_status(first) is None
+
+
+class TestOhsomeResponseRecovery:
+    """Recovering the response, non-JSON verdict, and body preview (#930)."""
+
+    def test_error_response_from_chain(self):
+        """The response object is dug out of the __context__ chain."""
+        import types
+
+        response = types.SimpleNamespace(status_code=200, headers={}, text="x")
+        http_error = RuntimeError("boom")
+        http_error.response = response
+        leaked = ValueError("Expecting value")
+        leaked.__context__ = http_error
+        assert ohsome_error_response(leaked) is response
+
+    def test_error_response_none_when_absent(self):
+        """No response anywhere yields None."""
+        assert ohsome_error_response(RuntimeError("no response")) is None
+
+    def test_error_response_ignores_response_without_status(self):
+        """A response object with no integer status_code is not returned."""
+        import types
+
+        exc = RuntimeError("x")
+        exc.response = types.SimpleNamespace(status_code=None)
+        assert ohsome_error_response(exc) is None
+
+    def test_non_json_detects_stdlib_json_decode_error(self):
+        """A stdlib json.JSONDecodeError anywhere in the chain reads as non-JSON."""
+        import json
+
+        outer = RuntimeError("wrapped")
+        outer.__context__ = json.JSONDecodeError("Expecting value", "<html>", 0)
+        assert ohsome_response_is_non_json(outer) is True
+
+    def test_non_json_detects_by_class_name(self):
+        """A JSONDecodeError variant (by class name) also reads as non-JSON."""
+
+        class JSONDecodeError(ValueError):
+            pass
+
+        assert ohsome_response_is_non_json(JSONDecodeError("bad")) is True
+
+    def test_non_json_false_for_plain_error(self):
+        """A plain error (a JSON error served as JSON) is not a non-JSON body."""
+        assert ohsome_response_is_non_json(RuntimeError("bad request")) is False
+
+    def test_body_preview_truncates(self):
+        """The body preview is truncated to the requested limit."""
+        import types
+
+        response = types.SimpleNamespace(text="abcdefghij")
+        assert ohsome_body_preview(response, limit=4) == "abcd"
+
+    def test_body_preview_none_for_none(self):
+        """No response yields no preview."""
+        assert ohsome_body_preview(None) is None
+
+    def test_body_preview_none_when_text_unreadable(self):
+        """A body that cannot be decoded yields None rather than raising."""
+
+        class _BadBody:
+            @property
+            def text(self):
+                raise UnicodeDecodeError("utf-8", b"", 0, 1, "boom")
+
+        assert ohsome_body_preview(_BadBody()) is None
 
 
 class TestWayGeometry:

--- a/libs/providers/hazards/tests/osm/test_helpers.py
+++ b/libs/providers/hazards/tests/osm/test_helpers.py
@@ -236,6 +236,14 @@ class TestOhsomeResponseRecovery:
         """A plain error (a JSON error served as JSON) is not a non-JSON body."""
         assert ohsome_response_is_non_json(RuntimeError("bad request")) is False
 
+    def test_non_json_false_for_non_valueerror_named_class(self):
+        """A class named JSONDecodeError that is not a ValueError is excluded."""
+
+        class JSONDecodeError(RuntimeError):
+            pass
+
+        assert ohsome_response_is_non_json(JSONDecodeError("x")) is False
+
     def test_body_preview_truncates(self):
         """The body preview is truncated to the requested limit."""
         import types

--- a/libs/providers/hazards/tests/osm/test_osm_e2e.py
+++ b/libs/providers/hazards/tests/osm/test_osm_e2e.py
@@ -7,7 +7,7 @@ failure (offline / a throttled mirror) skips rather than fails.
 
 Run with:
 
-    pixi run -e dev pytest -m "osm and e2e" tests/osm
+    uv run pytest -m "osm and e2e" tests/osm
 """
 
 from __future__ import annotations
@@ -33,15 +33,21 @@ def _skip_on_network(exc: Exception) -> None:
     """Skip (not fail) when the failure is a transport problem, else re-raise.
 
     Transport dropouts (offline / a throttled mirror) skip, and so does a
-    public-endpoint throttle/block: a `403` / `429` from `api.ohsome.org` (a
-    keyless service) is the CI runner's IP being rate-limited, not a regression,
-    so the backend's typed `OhsomeUnavailableError` skips the lane rather than
-    reddening it (issue #1025). Anything else re-raises and fails.
+    public-endpoint unavailability: a `403` / `429` throttle (issue #1025) or a
+    `5xx` outage (issue #790) from `api.ohsome.org` (a keyless service) is a
+    transient upstream condition, not a regression, so the backend's typed
+    `OhsomeUnavailableError` skips the lane rather than reddening it. Anything
+    else re-raises and fails.
     """
     if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
         pytest.skip(f"OSM service unreachable: {exc}")
-    if isinstance(exc, OhsomeUnavailableError) and exc.status_code in (403, 429):
-        pytest.skip(f"ohsome public endpoint throttled/blocked this runner: {exc}")
+    status = getattr(exc, "status_code", None)
+    if (
+        isinstance(exc, OhsomeUnavailableError)
+        and status is not None
+        and (status in (403, 429) or 500 <= status < 600)
+    ):
+        pytest.skip(f"ohsome public endpoint unavailable (HTTP {status}): {exc}")
     raise exc
 
 

--- a/libs/providers/hazards/tests/osm/test_osm_e2e.py
+++ b/libs/providers/hazards/tests/osm/test_osm_e2e.py
@@ -42,6 +42,11 @@ def _skip_on_network(exc: Exception) -> None:
     if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
         pytest.skip(f"OSM service unreachable: {exc}")
     status = getattr(exc, "status_code", None)
+    # A 5xx on this tiny smoke bbox is only ever an upstream outage, never
+    # something the request shape provoked (ohsome answers 4xx for a bad
+    # filter/bbox/time), so skipping it here does not mask an earthlens defect —
+    # the offline TestOhsomeRoute suite is the real guardrail for the 5xx
+    # classification logic.
     if (
         isinstance(exc, OhsomeUnavailableError)
         and status is not None


### PR DESCRIPTION
# Description

When `api.ohsome.org` returns a body that is not the expected GeoJSON — a rate-limit / maintenance / error page,
an empty body, a redirect to a landing page, or a `5xx` outage — the `ohsome` SDK surfaced a raw error
(`JSONDecodeError: Expecting value…`, or a `KeyError: 'message'` on a `5xx` body), discarding the status code,
content type, and body that tell those cases apart. A decoder / `KeyError` is the wrong abstraction for "the server
said no".

The earlier throttle fix (#1027, which closed #1025) only typed the `403` / `429` case. This PR finishes #930 and
also closes #790 by handling every remaining opaque ohsome failure through one place:

- **Recovers the response evidence** from the SDK's opaque failure via new helpers (`ohsome_error_response`,
  `ohsome_response_is_non_json`, `ohsome_body_preview`), sharing one cycle-safe exception-chain walk with
  `ohsome_http_status`.
- **Logs the recovered HTTP status, `Content-Type`, and first 200 body bytes** at the point of failure — only on the
  branches that convert to a typed error, so a genuine ohsome error served *as* JSON is re-raised quietly.
- **Raises a typed `OhsomeResponseError`** (carrying `status_code` / `content_type` / `body_preview`) for any
  non-JSON body. `OhsomeUnavailableError` (a subclass) covers the `403` / `429` throttle **and** a `5xx` server-side
  outage — the latter is where the SDK otherwise dies with a raw `KeyError: 'message'` (#790) — so both carry the
  recovered evidence and a clear, status-bearing message.
- **Skips the live ohsome e2e** on an `OhsomeUnavailableError` whose status is `403` / `429` (#1025) or a `5xx`
  (#790), so a transient upstream throttle/outage no longer reds the weekly lane.
- **Leaves a transport error, and a genuine ohsome error served *as* JSON (including a JSON `401`), untouched**, so a
  real regression still surfaces loudly.

The non-JSON detection is guarded by `isinstance(node, ValueError)` so an unrelated same-named class is not a false
positive, and the exception-inspection helpers accept `Exception` (the type the backend catches). No dependency or
lockfile change (only stdlib + the already-core `requests` are imported).

# Issues

- Closes #930
- Closes #790
- Related: #1080 — the `e2e / e2e (rest-of-hazards)` red on this PR's CI is the **unrelated** INFORM live-e2e
  empty-result failure (`risk_indicators` backend), not caused by this branch; `rest-of-hazards` only ran because
  this PR touches the `hazards` provider, and this PR's own `e2e / e2e (osm)` lane is green.

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run against a per-worktree env; all offline (the `ohsome` SDK is faked, so no live network).

- [x] **Unit suite** — `pytest -m "not e2e" tests/osm` → 177 passed. Coverage spans: a non-JSON body (with and
  without a recoverable status) becomes `OhsomeResponseError`; a `403` throttle and a `5xx` outage become
  `OhsomeUnavailableError` carrying the status / content-type / body — across both SDK shapes (the
  `KeyError`-on-`5xx`-body of #790 and an `OhsomeException(error_code=5xx)`), the `500`/`502`/`504`/`599` variants,
  and a `5xx` served as HTML (server-error branch taking precedence over the non-JSON one); a genuine JSON error and a
  transport error propagate unchanged and without a stray warning; the e2e `_skip_on_network` skips on `403` / `429`
  / `5xx` (with the `599`/`600` boundary pinned) and re-raises anything else; plus the `ValueError`-guard exclusion
  and the `ohsome_error_response` / `ohsome_response_is_non_json` / `ohsome_body_preview` helpers.
- [x] **Coverage** — `_helpers.py` 100%, `backend.py` 99% (line + branch); the changed code is fully covered (the 2
  misses are pre-existing, out-of-scope lines).
- [x] **Review** — the #930 and #790 changes each went through two adversarial review rounds; all findings resolved
  or justified.
- [x] **SonarCloud** — 0 open issues, 0 security hotspots.
- [x] **CI e2e** — `e2e / e2e (osm)` (the lane this PR changes) is green. The `e2e / e2e (rest-of-hazards)` red is the
  unrelated #1080 (INFORM empty upstream), see Issues above.
- [x] **Lint gate** — `ruff check` + `ruff format --check` clean; `mypy` clean (402 source files);
  `--doctest-modules` on the changed source passes.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
