### PR TITLE
docs: refresh the WDPA and IUCN e2e test docstrings (uv command + token URL)

### DIFF
--- a/libs/providers/land/tests/iucn/test_iucn_e2e.py
+++ b/libs/providers/land/tests/iucn/test_iucn_e2e.py
@@ -2,7 +2,8 @@
 
 Hits the real IUCN Red List v4 API, which requires a Bearer token, so it is
 gated behind the `e2e` marker and a skip on a missing `IUCN_TOKEN`. A
-default `pytest` run skips it.
+default `pytest` run skips it. Request a token at
+`https://api.iucnredlist.org/users/sign_up`.
 
 Run with:
 

--- a/libs/providers/land/tests/iucn/test_iucn_e2e.py
+++ b/libs/providers/land/tests/iucn/test_iucn_e2e.py
@@ -6,7 +6,7 @@ default `pytest` run skips it.
 
 Run with:
 
-    pixi run -e dev pytest -m e2e tests/iucn
+    uv run --active pytest -m "e2e and iucn" libs/providers/land/tests/iucn
 """
 
 from __future__ import annotations

--- a/libs/providers/land/tests/wdpa/test_wdpa_e2e.py
+++ b/libs/providers/land/tests/wdpa/test_wdpa_e2e.py
@@ -6,7 +6,7 @@ default `pytest` run skips it.
 
 Run with:
 
-    pixi run -e dev pytest -m e2e tests/wdpa
+    uv run --active pytest -m "e2e and wdpa" libs/providers/land/tests/wdpa
 """
 
 from __future__ import annotations

--- a/libs/providers/land/tests/wdpa/test_wdpa_e2e.py
+++ b/libs/providers/land/tests/wdpa/test_wdpa_e2e.py
@@ -2,7 +2,8 @@
 
 Hits the real Protected Planet v4 API, which requires a personal token, so
 it is gated behind the `e2e` marker and a skip on a missing `WDPA_TOKEN`. A
-default `pytest` run skips it.
+default `pytest` run skips it. Request a token at
+`https://api.protectedplanet.net/request`.
 
 Run with:
 


### PR DESCRIPTION
# Description

The `land` provider's two biodiversity-cluster e2e test docstrings (`wdpa`, `iucn`) still told readers to run the
tests with the retired `pixi` command:

```
pixi run -e dev pytest -m e2e tests/wdpa
```

The repo migrated from pixi to uv, and the `tests/` path no longer matches the workspace layout, so that command
fails on a fresh checkout. This updates both docstrings to the current convention already used by the `isimip` and
`bathymetry` e2e tests:

```
uv run --active pytest -m "e2e and wdpa" libs/providers/land/tests/wdpa
uv run --active pytest -m "e2e and iucn" libs/providers/land/tests/iucn
```

While updating these docstrings, each also gained a one-line pointer to where a contributor requests the personal
API token the live test is gated on, matching the URL each backend's `auth.py` already names:

- WDPA → `https://api.protectedplanet.net/request`
- IUCN → `https://api.iucnredlist.org/users/sign_up`

Docstring-only change — no runtime behavior, imports, or test logic is touched.

# Issues
- Closes #1077 — refresh the WDPA and IUCN e2e test docstrings

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No test run required — the change is confined to module docstrings. Verification performed:

- Confirmed both edited files still collect cleanly (`pytest --collect-only`), with the two live e2e classes intact.
- Ran the doctest gate on both files (`python -m doctest`): 0 tests, 0 failures (no executable examples, as expected
  for token-gated live-API tests).
- The replacement command matches the phrasing of the existing `isimip` / `bathymetry` e2e docstrings (`uv run
  --active`, quoted compound marker, full `libs/providers/...` path); `e2e`, `wdpa`, and `iucn` are all registered
  pytest markers.
- Branch synced with `origin/main`; full CI is green on the merged HEAD.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
