### PR TITLE
ci(e2e): run the full suite on every non-docs merge to main (include CI changes)

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -1,48 +1,16 @@
 name: Tests - E2E (live CDS + GEE + STAC)
 
-# Live end-to-end suites against external services (Copernicus Climate
-# Data Store; Google Earth Engine). These hit real servers / queue
-# server-side, so running on every push to any branch or every PR would burn
-# quota and slow CI. So the triggers are deliberately scoped:
-#
-#   * push to `main`: every merge to the default branch runs the FULL live e2e
-#     suite, EXCEPT a merge that changes only documentation. Any code or CI /
-#     workflow change (including this workflow itself) is validated end-to-end
-#     on its own merge. (The per-provider `tests-e2e-<theme>.yml` gates only run
-#     the affected lane on a PR; this is the complete post-merge check.)
-#   * schedule: weekly on Sunday at 04:00 UTC
-#   * workflow_dispatch: manual trigger from the Actions tab
-#
-# Forks cannot read repo secrets, so a fork-PR run would fail at auth.
-# The jobs below only run on the main repo, and each suite skips its
-# tests when its credentials are absent.
+# Live e2e against external, rate/quota-limited services (CDS, GEE, EUMETSAT,
+# STAC, …). Triggers: every non-docs merge to `main` (docs-only merges skipped
+# below), the weekly cron, and manual dispatch. Jobs run only on the main repo
+# (forks have no secrets) and self-skip when a credential is absent.
 
 permissions:
   contents: read
 
-# There is no `pull_request` trigger, so the expression is always false and
-# `cancel-in-progress: false` protects a live run that is already IN PROGRESS —
-# an active suite is never cancelled mid-flight against rate/quota-limited
-# services, which is the point.
-#
-# The one shared `github.ref` group is deliberate: the non-PR events that run as
-# `refs/heads/main` — a merge to `main`, the weekly cron, and a dispatch from
-# `main` — serialise, so two full live runs never overlap. (A dispatch launched
-# from another branch runs as that ref, a separate group, and would not
-# serialise against a `main` run — an accepted edge for a manual action.) The cost is that it does NOT
-# guarantee a run per merge: GitHub cancels a *pending* run when a newer one
-# queues in the same group (see tests.yml for the full note), so during a burst
-# — merge A in progress, B pending, C queued — B is superseded before it starts,
-# and any non-PR event (a dispatch/cron, not just a later merge) can drop a
-# pending run this way. This is quota-first by choice: run the latest main state,
-# not every intermediate; the weekly cron backstops. Guaranteeing a run per merge
-# needs a run_id-keyed group (as tests.yml uses), which runs collisions in
-# PARALLEL and doubles the live-quota spend — exactly what this suite avoids.
-#
-# The expression is kept rather than hard-coded `false` so the PR-cancel half
-# switches on by itself if a `pull_request` trigger is ever added - at which
-# point re-read it, because cancelling a half-finished live run mid-flight is
-# not obviously right for this suite.
+# Serialise non-PR runs (a merge, the cron, a dispatch on `main` share one group)
+# so two full live runs never overlap; cancel-in-progress applies to PRs only.
+# See tests.yml for the pending-run-cancellation trade-off.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -50,11 +18,7 @@ concurrency:
 on:
   push:
     branches: [main]
-    # Skip ONLY pure-documentation merges (they cannot change an e2e result).
-    # `.github/**` is intentionally NOT ignored, so a CI / workflow change runs
-    # the suite on its own merge. `paths-ignore` skips a push only when EVERY
-    # changed path matches, so a mixed docs+code merge still runs.
-    paths-ignore:
+    paths-ignore:  # docs-only merges skip; code and CI changes run
       - 'docs/**'
       - '**/*.md'
       - 'mkdocs.yml'

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -5,11 +5,11 @@ name: Tests - E2E (live CDS + GEE + STAC)
 # server-side, so running on every push to any branch or every PR would burn
 # quota and slow CI. So the triggers are deliberately scoped:
 #
-#   * push to `main`: every non-docs/non-CI merge to the default branch runs
-#     the FULL live e2e suite, so what actually landed is validated end-to-end (the
-#     per-provider `tests-e2e-<theme>.yml` gates only run the affected lane on
-#     a PR; this is the complete post-merge check). Docs-/markdown-/CI-only
-#     merges are skipped via `paths-ignore` on the trigger below.
+#   * push to `main`: every merge to the default branch runs the FULL live e2e
+#     suite, EXCEPT a merge that changes only documentation. Any code or CI /
+#     workflow change (including this workflow itself) is validated end-to-end
+#     on its own merge. (The per-provider `tests-e2e-<theme>.yml` gates only run
+#     the affected lane on a PR; this is the complete post-merge check.)
 #   * schedule: weekly on Sunday at 04:00 UTC
 #   * workflow_dispatch: manual trigger from the Actions tab
 #
@@ -50,21 +50,14 @@ concurrency:
 on:
   push:
     branches: [main]
-    # A merge that changes only docs / markdown / mkdocs config / CI workflow
-    # files cannot affect an e2e result, so it skips the full live suite (which
-    # burns rate/quota-limited services). `paths-ignore` skips only when EVERY
-    # changed path matches, so a mixed merge (docs + code) still runs.
-    #
-    # Trade-off: a merge touching ONLY `.github/**` — including this workflow
-    # itself — is not re-run on the merge push; a CI-config change is validated
-    # only by the next weekly cron or a manual dispatch, never by its own merge.
-    # Acceptable: a workflow-YAML change cannot alter the shipped code's e2e
-    # result, and the e2e jobs use no local composite actions under `.github/`.
+    # Skip ONLY pure-documentation merges (they cannot change an e2e result).
+    # `.github/**` is intentionally NOT ignored, so a CI / workflow change runs
+    # the suite on its own merge. `paths-ignore` skips a push only when EVERY
+    # changed path matches, so a mixed docs+code merge still runs.
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
       - 'mkdocs.yml'
-      - '.github/**'
   schedule:
     - cron: '0 4 * * 0'
   workflow_dispatch:


### PR DESCRIPTION
# Description

Follow-up to #1036. The on-merge full-suite trigger on `tests-e2e.yml` had `.github/**` in its `paths-ignore`, so a
merge that changed only CI/workflow files skipped the live suite — including the very merge that introduced the
trigger (it was workflow-only), which is why no e2e ran on `main` after that merge.

Intent: run the full live e2e suite on **every code (and CI) merge to `main`, skipping only pure documentation**.
So drop `.github/**` from `paths-ignore`, leaving just the documentation patterns:

```yaml
push:
  branches: [main]
  paths-ignore:
    - 'docs/**'
    - '**/*.md'
    - 'mkdocs.yml'
```

Now:
- a **code** merge runs the full suite;
- a **CI / workflow** merge (including a change to this workflow itself) runs it too;
- a **pure-documentation** merge is skipped;
- `paths-ignore` skips only when *every* changed path matches, so a mixed docs+code merge still runs.

No source/test/dependency changes. Concurrency and fork-safety unchanged.

# Issues
- Closes #1079 — run the full live e2e suite on every non-docs merge to main (include CI merges)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- `tests-e2e.yml` validated as parseable YAML; `push.paths-ignore` resolves to the three documentation patterns
  with `.github/**` removed; all 12 jobs intact; no line exceeds 120 chars.
- The live suite runs on merge/cron, not in this PR's checks. Because this PR touches only `.github/**`, its own
  merge will exercise the new behaviour (the suite will run on it).

- [x] Workflow YAML validated; trigger + job set confirmed

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.

