### PR TITLE
refactor(auth): resolve single-secret credentials through a shared SingleSecretAuth

### DIFF
--- a/libs/core/src/earthlens/base/__init__.py
+++ b/libs/core/src/earthlens/base/__init__.py
@@ -26,7 +26,11 @@ from earthlens.base.abstractdatasource import (
     SpatialExtent,
     TemporalExtent,
 )
-from earthlens.base.auth import AbstractAuth, AuthenticationError
+from earthlens.base.auth import (
+    AbstractAuth,
+    AuthenticationError,
+    SingleSecretAuth,
+)
 from earthlens.base.cache import (
     aoi_tag,
     sidecar_is_fresh,
@@ -114,6 +118,7 @@ __all__ = [
     "S3Auth",
     "S3Credentials",
     "safe_filename",
+    "SingleSecretAuth",
     "sidecar_is_fresh",
     "sidecar_path",
     "SpatialExtent",

--- a/libs/core/src/earthlens/base/auth.py
+++ b/libs/core/src/earthlens/base/auth.py
@@ -34,6 +34,7 @@ teardown override `close`.
 
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 
@@ -241,3 +242,147 @@ class AbstractAuth(ABC, Generic[CredentialsT]):
         tb: object | None,
     ) -> None:
         self.close()
+
+
+class SingleSecretAuth(AbstractAuth[CredentialsT]):
+    """`AbstractAuth` for a backend authenticated by a single secret.
+
+    Many backends authenticate with one API key or token: resolve it from an
+    explicit argument, fall back to one or more environment variables, raise
+    `AuthenticationError` when none is found, then memoise so a second
+    `configure()` is a no-op. That ceremony is identical across those backends —
+    only *which* env var, *how* the explicit value is stored, and *what* to do
+    with the resolved secret differ. This class carries the ceremony so each
+    single-secret backend supplies only the parts that differ:
+
+    * set :attr:`ENV_VARS` and :attr:`PROVIDER` (and optionally
+      :attr:`CREDENTIAL_HINT` / :attr:`AUTH_ERROR`),
+    * override :meth:`_explicit_credential` to read the explicit secret off its
+      credentials value object,
+    * implement :meth:`_connect` to apply the resolved secret.
+
+    A multi-field / OAuth / username+password backend does not fit this shape and
+    should extend :class:`AbstractAuth` directly with its own `configure`.
+
+    Examples:
+        - A minimal single-secret auth resolving from the environment:
+            ```python
+            >>> import os
+            >>> from pydantic import BaseModel, SecretStr
+            >>> from earthlens.base import SingleSecretAuth
+            >>> class _Creds(BaseModel):
+            ...     token: SecretStr | None = None
+            >>> class _Auth(SingleSecretAuth[_Creds]):
+            ...     ENV_VARS = ("DEMO_TOKEN",)
+            ...     PROVIDER = "Demo"
+            ...     def _explicit_credential(self):
+            ...         tok = self._creds.token
+            ...         return tok.get_secret_value() if tok is not None else None
+            ...     def _connect(self, credential):
+            ...         self._token = credential
+            >>> os.environ["DEMO_TOKEN"] = "from-env"
+            >>> auth = _Auth(_Creds())
+            >>> auth.configure()
+            >>> auth._token
+            'from-env'
+            >>> del os.environ["DEMO_TOKEN"]
+
+            ```
+        - An explicit credential wins over the environment, and a missing one
+          raises a message naming the provider and the variable:
+            ```python
+            >>> from pydantic import BaseModel, SecretStr
+            >>> from earthlens.base import AuthenticationError, SingleSecretAuth
+            >>> class _Creds(BaseModel):
+            ...     token: SecretStr | None = None
+            >>> class _Auth(SingleSecretAuth[_Creds]):
+            ...     ENV_VARS = ("DEMO_TOKEN",)
+            ...     PROVIDER = "Demo"
+            ...     def _explicit_credential(self):
+            ...         tok = self._creds.token
+            ...         return tok.get_secret_value() if tok is not None else None
+            ...     def _connect(self, credential):
+            ...         self._token = credential
+            >>> _Auth(_Creds(token="explicit")).configure() or None
+            >>> try:
+            ...     _Auth(_Creds()).configure()
+            ... except AuthenticationError as exc:
+            ...     str(exc)
+            'no Demo credential available: pass it explicitly or set DEMO_TOKEN.'
+
+            ```
+    """
+
+    #: Environment variables consulted, in priority order, after the explicit
+    #: argument. The first one that is set (non-empty) supplies the secret.
+    ENV_VARS: tuple[str, ...] = ()
+
+    #: Human-readable provider name used in the missing-credential message.
+    PROVIDER: str = ""
+
+    #: Optional extra sentence appended to that message (e.g. a sign-up URL).
+    CREDENTIAL_HINT: str = ""
+
+    #: Exception type raised when no credential resolves. A subclass may point
+    #: this at its own `AuthenticationError` subclass so callers can catch it
+    #: narrowly while the message stays consistent across providers.
+    AUTH_ERROR: type[AuthenticationError] = AuthenticationError
+
+    def configure(self) -> None:
+        """Resolve and apply the secret once; idempotent.
+
+        Short-circuits when :meth:`is_authenticated` is already `True`; otherwise
+        resolves the credential (:meth:`_resolve_credential`), applies it
+        (:meth:`_connect`), and records success (:meth:`mark_configured`).
+
+        Raises:
+            AuthenticationError: When no credential can be resolved.
+        """
+        if self.is_authenticated():
+            return
+        self._connect(self._resolve_credential())
+        self.mark_configured()
+
+    def _resolve_credential(self) -> str:
+        """Return the secret: explicit argument, else :attr:`ENV_VARS`, else raise.
+
+        Returns:
+            The resolved secret string.
+
+        Raises:
+            AuthenticationError: When neither the explicit credential nor any of
+                :attr:`ENV_VARS` supplies a value. The message names
+                :attr:`PROVIDER` and the variables, plus :attr:`CREDENTIAL_HINT`.
+        """
+        explicit = self._explicit_credential()
+        if explicit:
+            return explicit
+        for variable in self.ENV_VARS:
+            value = os.environ.get(variable)
+            if value:
+                return value
+        names = " or ".join(self.ENV_VARS) or "a credential"
+        message = (
+            f"no {self.PROVIDER or type(self).__name__} credential available: "
+            f"pass it explicitly or set {names}."
+        )
+        if self.CREDENTIAL_HINT:
+            message = f"{message} {self.CREDENTIAL_HINT}"
+        raise self.AUTH_ERROR(message)
+
+    def _explicit_credential(self) -> str | None:
+        """Return the explicit secret off the bound credentials, or `None`.
+
+        Default: `None` (rely on :attr:`ENV_VARS`). A subclass whose credentials
+        carry an explicit secret overrides this to extract it — typically
+        unwrapping a `pydantic.SecretStr`.
+        """
+        return None
+
+    @abstractmethod
+    def _connect(self, credential: str) -> None:
+        """Apply the resolved secret (store it, build a client, …).
+
+        Args:
+            credential: The secret resolved by :meth:`_resolve_credential`.
+        """

--- a/libs/core/src/earthlens/base/auth.py
+++ b/libs/core/src/earthlens/base/auth.py
@@ -320,6 +320,12 @@ class SingleSecretAuth(AbstractAuth[CredentialsT]):
     #: Human-readable provider name used in the missing-credential message.
     PROVIDER: str = ""
 
+    #: Name of the constructor argument that carries the explicit secret (e.g.
+    #: `"api_key"` or `"token"`). Named in the missing-credential message so it
+    #: tells the caller exactly what to pass. Empty falls back to the generic
+    #: "pass it explicitly".
+    CREDENTIAL_ARG: str = ""
+
     #: Optional extra sentence appended to that message (e.g. a sign-up URL).
     CREDENTIAL_HINT: str = ""
 
@@ -372,9 +378,14 @@ class SingleSecretAuth(AbstractAuth[CredentialsT]):
                 if value:
                     return value
         names = " or ".join(self.ENV_VARS) or "a credential"
+        how = (
+            f"pass {self.CREDENTIAL_ARG}="
+            if self.CREDENTIAL_ARG
+            else "pass it explicitly"
+        )
         message = (
             f"no {self.PROVIDER or type(self).__name__} credential available: "
-            f"pass it explicitly or set {names}."
+            f"{how} or set {names}."
         )
         if self.CREDENTIAL_HINT:
             message = f"{message} {self.CREDENTIAL_HINT}"

--- a/libs/core/src/earthlens/base/auth.py
+++ b/libs/core/src/earthlens/base/auth.py
@@ -346,21 +346,31 @@ class SingleSecretAuth(AbstractAuth[CredentialsT]):
     def _resolve_credential(self) -> str:
         """Return the secret: explicit argument, else :attr:`ENV_VARS`, else raise.
 
+        The environment is consulted only when no explicit credential was
+        supplied — i.e. :meth:`_explicit_credential` returns `None`. An explicit
+        credential that is present but empty is treated as an error and does not
+        fall back to the environment, matching each backend's original behaviour.
+
         Returns:
             The resolved secret string.
 
         Raises:
-            AuthenticationError: When neither the explicit credential nor any of
-                :attr:`ENV_VARS` supplies a value. The message names
-                :attr:`PROVIDER` and the variables, plus :attr:`CREDENTIAL_HINT`.
+            AuthenticationError: When no explicit credential was supplied and
+                none of :attr:`ENV_VARS` is set, or when an explicit credential
+                was supplied but is empty. The message names :attr:`PROVIDER` and
+                the variables, plus :attr:`CREDENTIAL_HINT`.
         """
         explicit = self._explicit_credential()
         if explicit:
             return explicit
-        for variable in self.ENV_VARS:
-            value = os.environ.get(variable)
-            if value:
-                return value
+        # Only an *absent* explicit credential (None) falls back to the
+        # environment; a present-but-empty one is an error, so it skips the
+        # env lookup and drops straight to the raise below.
+        if explicit is None:
+            for variable in self.ENV_VARS:
+                value = os.environ.get(variable)
+                if value:
+                    return value
         names = " or ".join(self.ENV_VARS) or "a credential"
         message = (
             f"no {self.PROVIDER or type(self).__name__} credential available: "

--- a/libs/core/tests/test_abstract_auth.py
+++ b/libs/core/tests/test_abstract_auth.py
@@ -306,3 +306,41 @@ class TestSingleSecretAuth:
         auth.configure()
         assert auth.connected == 1, auth.connected
         assert auth.is_authenticated() is True
+
+
+class _EnvOnlyAuth(SingleSecretAuth[_SecretCreds]):
+    """A single-secret auth that keeps the base's default `_explicit_credential`.
+
+    It declares only an env var and provider name and no `CREDENTIAL_HINT`, so it
+    exercises the inherited `_explicit_credential` (always `None`, env-only) and
+    the missing-credential message with no trailing hint sentence.
+    """
+
+    ENV_VARS = ("ENVONLY_VAR",)
+    PROVIDER = "EnvOnly"
+
+    def _connect(self, credential: str) -> None:
+        """Record the resolved secret."""
+        self.secret = credential
+
+
+class TestSingleSecretAuthDefaults:
+    """The base defaults: env-only resolution and the hint-free error message."""
+
+    def test_env_resolution_uses_the_inherited_explicit_credential(self, monkeypatch):
+        """With no `_explicit_credential` override, the env var supplies the secret."""
+        monkeypatch.setenv("ENVONLY_VAR", "from-env")
+        auth = _EnvOnlyAuth(_SecretCreds(token="ignored-because-not-read"))
+        auth.configure()
+        assert auth.secret == "from-env", auth.secret
+
+    def test_missing_credential_without_hint_omits_the_hint_sentence(self, monkeypatch):
+        """A backend with no CREDENTIAL_HINT raises the bare provider-named message."""
+        monkeypatch.delenv("ENVONLY_VAR", raising=False)
+        with pytest.raises(AuthenticationError) as exc_info:
+            _EnvOnlyAuth(_SecretCreds()).configure()
+        message = str(exc_info.value)
+        assert (
+            message == "no EnvOnly credential available: pass it explicitly or set "
+            "ENVONLY_VAR."
+        ), message

--- a/libs/core/tests/test_abstract_auth.py
+++ b/libs/core/tests/test_abstract_auth.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import pytest
 from pydantic import BaseModel, ConfigDict, SecretStr
 
-from earthlens.base import AbstractAuth, AuthenticationError
+from earthlens.base import AbstractAuth, AuthenticationError, SingleSecretAuth
 
 
 class _Creds(BaseModel):
@@ -221,3 +221,88 @@ class TestProviderErrorHierarchy:
         assert len(set(classes.values())) == len(classes), (
             f"two providers share an error class: {sorted(classes)}"
         )
+
+
+class _SecretCreds(BaseModel):
+    """Credentials value object carrying one optional secret."""
+
+    model_config = ConfigDict(frozen=True)
+
+    token: SecretStr | None = None
+
+
+class _DemoError(AuthenticationError):
+    """A provider-specific error so the raised type can be asserted."""
+
+
+class _DemoAuth(SingleSecretAuth[_SecretCreds]):
+    """Minimal single-secret auth resolving `DEMO_A` then `DEMO_B`."""
+
+    ENV_VARS = ("DEMO_A", "DEMO_B")
+    PROVIDER = "Demo"
+    CREDENTIAL_HINT = "Get one at example.test."
+    AUTH_ERROR = _DemoError
+
+    def _explicit_credential(self) -> str | None:
+        """Unwrap the explicit token off the credentials, if present."""
+        token = self._creds.token
+        return token.get_secret_value() if token is not None else None
+
+    def _connect(self, credential: str) -> None:
+        """Record the resolved secret and count the calls."""
+        self.connected = getattr(self, "connected", 0) + 1
+        self.secret = credential
+
+
+class TestSingleSecretAuth:
+    """The shared explicit -> env -> raise -> memoise ceremony."""
+
+    def test_explicit_credential_wins(self, monkeypatch):
+        """An explicit credential is used even when an env var is also set."""
+        monkeypatch.setenv("DEMO_A", "from-env")
+        auth = _DemoAuth(_SecretCreds(token="explicit"))
+        auth.configure()
+        assert auth.secret == "explicit", auth.secret
+
+    def test_env_fallback_in_priority_order(self, monkeypatch):
+        """With no explicit value, the first set ENV_VAR (in order) wins."""
+        monkeypatch.delenv("DEMO_A", raising=False)
+        monkeypatch.setenv("DEMO_B", "second")
+        auth = _DemoAuth(_SecretCreds())
+        auth.configure()
+        assert auth.secret == "second", auth.secret
+
+    def test_first_env_var_takes_priority(self, monkeypatch):
+        """DEMO_A is preferred over DEMO_B when both are set."""
+        monkeypatch.setenv("DEMO_A", "first")
+        monkeypatch.setenv("DEMO_B", "second")
+        auth = _DemoAuth(_SecretCreds())
+        auth.configure()
+        assert auth.secret == "first", auth.secret
+
+    def test_missing_raises_provider_error_with_consistent_message(self, monkeypatch):
+        """No credential raises the provider's error type, naming provider+vars+hint."""
+        monkeypatch.delenv("DEMO_A", raising=False)
+        monkeypatch.delenv("DEMO_B", raising=False)
+        with pytest.raises(_DemoError) as exc_info:
+            _DemoAuth(_SecretCreds()).configure()
+        message = str(exc_info.value)
+        assert "Demo" in message, message
+        assert "DEMO_A or DEMO_B" in message, message
+        assert "Get one at example.test." in message, message
+
+    def test_missing_error_is_catchable_as_base(self, monkeypatch):
+        """The provider error is still a base AuthenticationError for the broad catch."""
+        monkeypatch.delenv("DEMO_A", raising=False)
+        monkeypatch.delenv("DEMO_B", raising=False)
+        with pytest.raises(AuthenticationError):
+            _DemoAuth(_SecretCreds()).configure()
+
+    def test_configure_is_idempotent(self, monkeypatch):
+        """A second configure() after success does not re-connect."""
+        monkeypatch.setenv("DEMO_A", "x")
+        auth = _DemoAuth(_SecretCreds())
+        auth.configure()
+        auth.configure()
+        assert auth.connected == 1, auth.connected
+        assert auth.is_authenticated() is True

--- a/libs/core/tests/test_abstract_auth.py
+++ b/libs/core/tests/test_abstract_auth.py
@@ -307,6 +307,19 @@ class TestSingleSecretAuth:
         assert auth.connected == 1, auth.connected
         assert auth.is_authenticated() is True
 
+    def test_empty_explicit_credential_raises_without_env_fallback(self, monkeypatch):
+        """A present-but-empty explicit secret raises and never consults the env.
+
+        Only an absent (None) explicit credential falls back to ENV_VARS; an
+        empty one is an error, matching each backend's original behaviour.
+        """
+        monkeypatch.setenv("DEMO_A", "from-env")
+        auth = _DemoAuth(_SecretCreds(token=""))
+        with pytest.raises(_DemoError) as exc_info:
+            auth.configure()
+        assert "no Demo credential available" in str(exc_info.value), exc_info.value
+        assert getattr(auth, "connected", 0) == 0, "must not connect on empty secret"
+
 
 class _EnvOnlyAuth(SingleSecretAuth[_SecretCreds]):
     """A single-secret auth that keeps the base's default `_explicit_credential`.

--- a/libs/core/tests/test_abstract_auth.py
+++ b/libs/core/tests/test_abstract_auth.py
@@ -285,8 +285,9 @@ class TestSingleSecretAuth:
         """No credential raises the provider's error type, naming provider+vars+hint."""
         monkeypatch.delenv("DEMO_A", raising=False)
         monkeypatch.delenv("DEMO_B", raising=False)
+        auth = _DemoAuth(_SecretCreds())
         with pytest.raises(_DemoError) as exc_info:
-            _DemoAuth(_SecretCreds()).configure()
+            auth.configure()
         message = str(exc_info.value)
         assert "Demo" in message, message
         assert "pass demo_key=" in message, message
@@ -297,8 +298,9 @@ class TestSingleSecretAuth:
         """The provider error is still a base AuthenticationError for the broad catch."""
         monkeypatch.delenv("DEMO_A", raising=False)
         monkeypatch.delenv("DEMO_B", raising=False)
+        auth = _DemoAuth(_SecretCreds())
         with pytest.raises(AuthenticationError):
-            _DemoAuth(_SecretCreds()).configure()
+            auth.configure()
 
     def test_configure_is_idempotent(self, monkeypatch):
         """A second configure() after success does not re-connect."""
@@ -352,8 +354,9 @@ class TestSingleSecretAuthDefaults:
     def test_missing_credential_without_hint_omits_the_hint_sentence(self, monkeypatch):
         """A backend with no CREDENTIAL_HINT raises the bare provider-named message."""
         monkeypatch.delenv("ENVONLY_VAR", raising=False)
+        auth = _EnvOnlyAuth(_SecretCreds())
         with pytest.raises(AuthenticationError) as exc_info:
-            _EnvOnlyAuth(_SecretCreds()).configure()
+            auth.configure()
         message = str(exc_info.value)
         assert (
             message == "no EnvOnly credential available: pass it explicitly or set "

--- a/libs/core/tests/test_abstract_auth.py
+++ b/libs/core/tests/test_abstract_auth.py
@@ -240,6 +240,7 @@ class _DemoAuth(SingleSecretAuth[_SecretCreds]):
 
     ENV_VARS = ("DEMO_A", "DEMO_B")
     PROVIDER = "Demo"
+    CREDENTIAL_ARG = "demo_key"
     CREDENTIAL_HINT = "Get one at example.test."
     AUTH_ERROR = _DemoError
 
@@ -288,6 +289,7 @@ class TestSingleSecretAuth:
             _DemoAuth(_SecretCreds()).configure()
         message = str(exc_info.value)
         assert "Demo" in message, message
+        assert "pass demo_key=" in message, message
         assert "DEMO_A or DEMO_B" in message, message
         assert "Get one at example.test." in message, message
 

--- a/libs/core/tests/test_distribution_boundaries.py
+++ b/libs/core/tests/test_distribution_boundaries.py
@@ -1422,3 +1422,87 @@ class TestCliIsBackendAgnostic:
             f"missing={sorted(self.PENDING_IMPORTS - imported)}. Move the handler "
             "into the provider and update PENDING_IMPORTS (empty = #863 closed)."
         )
+
+
+class TestSingleSecretAuthAdoption:
+    """#833: the single-secret credential ceremony lives once, in the base.
+
+    Six backends authenticate with a single *mandatory* API key / token and each
+    used to carry the same ceremony by hand: resolve an explicit argument, fall
+    back to an environment variable, raise `AuthenticationError` when neither is
+    present, then memoise. That ceremony now lives in
+    `earthlens.base.SingleSecretAuth`; each backend supplies only its `ENV_VARS`
+    / `PROVIDER` and the `_explicit_credential` / `_connect` hooks. This guard
+    keeps them on the shared base and off a re-grown `os.environ` fallback.
+
+    The exclusions are deliberate, not omissions:
+
+    * `usgs_water` has the same single-secret *shape* but its token is optional —
+      a missing one falls back to anonymous access rather than raising, so it does
+      not fit the always-raise `SingleSecretAuth` contract and keeps its own
+      `configure`.
+    * the multi-field / OAuth backends (`nrel`, `cmems`, `earthdata`, `emdat`,
+      `eumetsat`, `jaxa`, `openeo`, `sentinel_hub`, `gee`) resolve more than one
+      field and extend `AbstractAuth` directly by design.
+    """
+
+    #: Backends whose single mandatory secret must resolve through the base.
+    SINGLE_SECRET = frozenset(
+        {"airnow", "firms", "iucn", "openaq", "risk_indicators", "wdpa"}
+    )
+
+    def _auth_path(self, backend: str) -> Path:
+        """Return the one `auth.py` for `backend`, asserting it is unique."""
+        matches = sorted(
+            _ROOT.glob(f"libs/providers/*/src/earthlens/{backend}/auth.py")
+        )
+        assert len(matches) == 1, f"expected one auth.py for {backend}, got {matches}"
+        return matches[0]
+
+    def test_single_secret_backends_were_found(self):
+        """Guard the guard: every named backend resolves to exactly one auth.py."""
+        for backend in sorted(self.SINGLE_SECRET):
+            assert self._auth_path(backend).exists()
+
+    def test_single_secret_backends_extend_the_shared_base(self):
+        """Each single-secret `Auth` subclasses `SingleSecretAuth`, not `AbstractAuth`."""
+        offenders = []
+        for backend in sorted(self.SINGLE_SECRET):
+            tree = ast.parse(self._auth_path(backend).read_text(encoding="utf-8"))
+            bases = {
+                ast.unparse(base)
+                for node in ast.walk(tree)
+                if isinstance(node, ast.ClassDef)
+                for base in node.bases
+            }
+            if not any(base.startswith("SingleSecretAuth[") for base in bases):
+                offenders.append(backend)
+        assert offenders == [], (
+            f"these single-secret backends do not extend SingleSecretAuth, so "
+            f"they carry their own credential ceremony: {offenders}"
+        )
+
+    def test_single_secret_backends_do_not_reimplement_the_env_fallback(self):
+        """None of them still reads `os.environ` — the fallback lives in the base.
+
+        The explicit-or-`os.environ.get` chain that raises when the secret is
+        absent now lives once in `SingleSecretAuth._resolve_credential`. A read of
+        `os.environ` in one of these modules means a hand-rolled copy has crept
+        back in.
+        """
+        offenders = []
+        for backend in sorted(self.SINGLE_SECRET):
+            source = self._auth_path(backend).read_text(encoding="utf-8")
+            for node in ast.walk(ast.parse(source)):
+                if (
+                    isinstance(node, ast.Attribute)
+                    and node.attr == "environ"
+                    and isinstance(node.value, ast.Name)
+                    and node.value.id == "os"
+                ):
+                    offenders.append(backend)
+                    break
+        assert offenders == [], (
+            f"these single-secret backends still read os.environ instead of "
+            f"delegating the fallback to SingleSecretAuth: {offenders}"
+        )

--- a/libs/providers/atmosphere/src/earthlens/airnow/auth.py
+++ b/libs/providers/atmosphere/src/earthlens/airnow/auth.py
@@ -122,6 +122,7 @@ class AirnowAuth(SingleSecretAuth[AirnowCredentials]):
 
     ENV_VARS = ("AIRNOW_API_KEY",)
     PROVIDER = "AirNow"
+    CREDENTIAL_ARG = "api_key"
     CREDENTIAL_HINT = f"Register a free key at {_REGISTER_URL}."
     AUTH_ERROR = AuthenticationError
 

--- a/libs/providers/atmosphere/src/earthlens/airnow/auth.py
+++ b/libs/providers/atmosphere/src/earthlens/airnow/auth.py
@@ -1,6 +1,6 @@
 """Credentials and API-key resolution for the AirNow backend.
 
-Hosts `AirnowAuth`, an `earthlens.base.AbstractAuth` subclass that
+Hosts `AirnowAuth`, an `earthlens.base.SingleSecretAuth` subclass that
 resolves a single AirNow API key from, in priority order, an explicit
 `api_key=` argument or the `AIRNOW_API_KEY` environment variable. The
 AirNow `/aq/data/` service requires a free key (registered at
@@ -12,10 +12,11 @@ The shape:
 
 * `AirnowCredentials` is a frozen pydantic value object carrying the
   optional API key as a `pydantic.SecretStr`.
-* `AirnowAuth` binds those credentials and resolves the key in
-  `AirnowAuth.configure` — explicit key first, then the
-  `AIRNOW_API_KEY` env var, then a clear `AuthenticationError` naming
-  the free-registration URL (never an interactive prompt).
+* `AirnowAuth` binds those credentials and lets the shared
+  `earthlens.base.SingleSecretAuth.configure` resolve the key — explicit
+  key first, then the `AIRNOW_API_KEY` env var, then a clear
+  `AuthenticationError` naming the free-registration URL (never an
+  interactive prompt).
 * `configure()` is idempotent — a second call after
   `AirnowAuth.is_authenticated` returns `True` short-circuits.
 
@@ -26,12 +27,10 @@ and attached as the `API_KEY` query argument by
 
 from __future__ import annotations
 
-import os
-
 from pydantic import BaseModel, ConfigDict, SecretStr
 
-from earthlens.base.auth import AbstractAuth
 from earthlens.base.auth import AuthenticationError as _BaseAuthenticationError
+from earthlens.base.auth import SingleSecretAuth
 
 #: Where a user registers for a free AirNow API key.
 _REGISTER_URL = "https://docs.airnowapi.org/account/request/"
@@ -86,15 +85,16 @@ class AirnowCredentials(BaseModel):
     api_key: SecretStr | None = None
 
 
-class AirnowAuth(AbstractAuth[AirnowCredentials]):
+class AirnowAuth(SingleSecretAuth[AirnowCredentials]):
     """Resolve and hold the AirNow API key.
 
-    Implements the `earthlens.base.AbstractAuth` contract for a
-    single-secret backend. Construction does not touch the environment;
-    `configure` performs the resolution and is idempotent. After a
-    successful `configure()`, the key is available via the `api_key`
-    property for the HTTP client to attach as the `API_KEY` query
-    argument.
+    Implements the `earthlens.base.SingleSecretAuth` contract for a
+    single-secret backend: it declares its env var and provider name and
+    supplies `_explicit_credential` / `_connect`, while the inherited
+    `configure` performs the explicit → env → raise → memoise resolution.
+    Construction does not touch the environment; `configure` is idempotent.
+    After a successful `configure()`, the key is available via the `api_key`
+    property for the HTTP client to attach as the `API_KEY` query argument.
 
     The class is a context manager (inherited from `AbstractAuth`):
     `with AirnowAuth(creds) as auth: ...` calls `configure()` on enter
@@ -120,46 +120,22 @@ class AirnowAuth(AbstractAuth[AirnowCredentials]):
             ```
     """
 
-    def __init__(self, credentials: AirnowCredentials) -> None:
-        """Store credentials; does not resolve the key yet.
+    ENV_VARS = ("AIRNOW_API_KEY",)
+    PROVIDER = "AirNow"
+    CREDENTIAL_HINT = f"Register a free key at {_REGISTER_URL}."
+    AUTH_ERROR = AuthenticationError
 
-        Args:
-            credentials: The `AirnowCredentials` value object carrying
-                the optional API key.
-        """
-        super().__init__(credentials)
-        self._configured = False
-        self._key: str | None = None
+    #: The resolved key, set by `_connect`; `None` until `configure` runs.
+    _key: str | None = None
 
-    def configure(self) -> None:
-        """Resolve the API key so subsequent requests can authenticate.
+    def _explicit_credential(self) -> str | None:
+        """Return the explicit `api_key` off the credentials, if any."""
+        api_key = self._creds.api_key
+        return api_key.get_secret_value() if api_key is not None else None
 
-        Idempotent — short-circuits when `is_authenticated` already
-        returns `True`. On the first call, resolves the key in this
-        order: the explicit `api_key` on the credentials, then the
-        `AIRNOW_API_KEY` environment variable.
-
-        Raises:
-            AuthenticationError: When neither source supplies a key. The
-                message names the `api_key=` argument, the
-                `AIRNOW_API_KEY` env var, and the free-registration URL —
-                it never blocks on an interactive prompt.
-        """
-        if self.is_authenticated():
-            return
-        key = (
-            self._creds.api_key.get_secret_value()
-            if self._creds.api_key is not None
-            else os.environ.get("AIRNOW_API_KEY")
-        )
-        if not key:
-            raise AuthenticationError(
-                "no AirNow API key available: pass api_key= to AirNow(...) "
-                "or set the AIRNOW_API_KEY environment variable. Register a "
-                f"free key at {_REGISTER_URL}."
-            )
-        self._key = key
-        self.mark_configured()
+    def _connect(self, credential: str) -> None:
+        """Store the resolved key for the `api_key` property to read back."""
+        self._key = credential
 
     @property
     def api_key(self) -> str:

--- a/libs/providers/atmosphere/src/earthlens/openaq/auth.py
+++ b/libs/providers/atmosphere/src/earthlens/openaq/auth.py
@@ -1,6 +1,6 @@
 """Credentials and API-key resolution for the OpenAQ backend.
 
-Hosts :class:`OpenaqAuth`, an :class:`earthlens.base.AbstractAuth`
+Hosts :class:`OpenaqAuth`, an :class:`earthlens.base.SingleSecretAuth`
 subclass that resolves a single OpenAQ **`X-API-Key`** from, in
 priority order, an explicit `api_key=` argument or the
 `OPENAQ_API_KEY` environment variable. OpenAQ v3 requires a (free)
@@ -13,10 +13,11 @@ The shape:
 
 * :class:`OpenaqCredentials` is a frozen pydantic value object
   carrying the optional API key as a :class:`pydantic.SecretStr`.
-* :class:`OpenaqAuth` binds those credentials and resolves the key in
-  :meth:`OpenaqAuth.configure` — explicit key first, then the
-  `OPENAQ_API_KEY` env var, then a clear :class:`AuthenticationError`
-  naming the free-registration URL (never an interactive prompt).
+* :class:`OpenaqAuth` binds those credentials and lets the shared
+  :meth:`earthlens.base.SingleSecretAuth.configure` resolve the key —
+  explicit key first, then the `OPENAQ_API_KEY` env var, then a clear
+  :class:`AuthenticationError` naming the free-registration URL (never
+  an interactive prompt).
 * `configure()` is idempotent — a second call after
   :meth:`OpenaqAuth.is_authenticated` returns `True` short-circuits,
   so it is safe to call from long-lived workers.
@@ -28,12 +29,10 @@ property and attached as the `X-API-Key` header by
 
 from __future__ import annotations
 
-import os
-
 from pydantic import BaseModel, ConfigDict, SecretStr
 
-from earthlens.base.auth import AbstractAuth
 from earthlens.base.auth import AuthenticationError as _BaseAuthenticationError
+from earthlens.base.auth import SingleSecretAuth
 
 #: Where a user registers for a free OpenAQ API key.
 _REGISTER_URL = "https://explore.openaq.org/register"
@@ -90,12 +89,13 @@ class OpenaqCredentials(BaseModel):
     api_key: SecretStr | None = None
 
 
-class OpenaqAuth(AbstractAuth[OpenaqCredentials]):
+class OpenaqAuth(SingleSecretAuth[OpenaqCredentials]):
     """Resolve and hold the OpenAQ API key.
 
-    Implements the :class:`earthlens.base.AbstractAuth` contract for a
-    single-secret backend. Construction does not touch the
-    environment; :meth:`configure` performs the resolution and is
+    Implements the :class:`earthlens.base.SingleSecretAuth` contract
+    for a single-secret backend: it declares its env var and provider
+    name and supplies `_explicit_credential` / `_connect`, while the
+    inherited :meth:`configure` performs the resolution and is
     idempotent. After a successful `configure()`, the key is available
     via the :attr:`api_key` property for the HTTP client to attach as
     the `X-API-Key` header.
@@ -124,46 +124,22 @@ class OpenaqAuth(AbstractAuth[OpenaqCredentials]):
             ```
     """
 
-    def __init__(self, credentials: OpenaqCredentials) -> None:
-        """Store credentials; does not resolve the key yet.
+    ENV_VARS = ("OPENAQ_API_KEY",)
+    PROVIDER = "OpenAQ"
+    CREDENTIAL_HINT = f"Register a free key at {_REGISTER_URL}."
+    AUTH_ERROR = AuthenticationError
 
-        Args:
-            credentials: The :class:`OpenaqCredentials` value object
-                carrying the optional API key.
-        """
-        super().__init__(credentials)
-        self._configured = False
-        self._key: str | None = None
+    #: The resolved key, set by `_connect`; `None` until `configure` runs.
+    _key: str | None = None
 
-    def configure(self) -> None:
-        """Resolve the API key so subsequent requests can authenticate.
+    def _explicit_credential(self) -> str | None:
+        """Return the explicit `api_key` off the credentials, if any."""
+        api_key = self._creds.api_key
+        return api_key.get_secret_value() if api_key is not None else None
 
-        Idempotent — short-circuits when :meth:`is_authenticated`
-        already returns `True`. On the first call, resolves the key
-        in this order: the explicit `api_key` on the credentials, then
-        the `OPENAQ_API_KEY` environment variable.
-
-        Raises:
-            AuthenticationError: When neither source supplies a key.
-                The message names the `api_key=` argument, the
-                `OPENAQ_API_KEY` env var, and the free-registration
-                URL — it never blocks on an interactive prompt.
-        """
-        if self.is_authenticated():
-            return
-        key = (
-            self._creds.api_key.get_secret_value()
-            if self._creds.api_key is not None
-            else os.environ.get("OPENAQ_API_KEY")
-        )
-        if not key:
-            raise AuthenticationError(
-                "no OpenAQ API key available: pass api_key= to OpenAQ(...) "
-                "or set the OPENAQ_API_KEY environment variable. Register a "
-                f"free key at {_REGISTER_URL}."
-            )
-        self._key = key
-        self.mark_configured()
+    def _connect(self, credential: str) -> None:
+        """Store the resolved key for the `api_key` property to read back."""
+        self._key = credential
 
     @property
     def api_key(self) -> str:

--- a/libs/providers/atmosphere/src/earthlens/openaq/auth.py
+++ b/libs/providers/atmosphere/src/earthlens/openaq/auth.py
@@ -126,6 +126,7 @@ class OpenaqAuth(SingleSecretAuth[OpenaqCredentials]):
 
     ENV_VARS = ("OPENAQ_API_KEY",)
     PROVIDER = "OpenAQ"
+    CREDENTIAL_ARG = "api_key"
     CREDENTIAL_HINT = f"Register a free key at {_REGISTER_URL}."
     AUTH_ERROR = AuthenticationError
 

--- a/libs/providers/atmosphere/tests/airnow/test_auth.py
+++ b/libs/providers/atmosphere/tests/airnow/test_auth.py
@@ -52,6 +52,7 @@ class TestAirnowAuth:
         with pytest.raises(AuthenticationError) as exc:
             auth.configure()
         assert "AIRNOW_API_KEY" in str(exc.value)
+        assert "api_key=" in str(exc.value), str(exc.value)
 
     def test_configure_idempotent(self, monkeypatch: pytest.MonkeyPatch):
         """A second `configure` after success short-circuits."""

--- a/libs/providers/hazards/src/earthlens/firms/auth.py
+++ b/libs/providers/hazards/src/earthlens/firms/auth.py
@@ -128,6 +128,7 @@ class FirmsAuth(SingleSecretAuth[FirmsCredentials]):
 
     ENV_VARS = ("FIRMS_MAP_KEY",)
     PROVIDER = "FIRMS"
+    CREDENTIAL_ARG = "api_key"
     CREDENTIAL_HINT = f"Request a free key at {_MAP_KEY_URL}."
     AUTH_ERROR = AuthenticationError
 

--- a/libs/providers/hazards/src/earthlens/firms/auth.py
+++ b/libs/providers/hazards/src/earthlens/firms/auth.py
@@ -1,6 +1,6 @@
 """Credentials and `MAP_KEY` resolution for the NASA FIRMS backend.
 
-Hosts :class:`FirmsAuth`, an :class:`earthlens.base.AbstractAuth`
+Hosts :class:`FirmsAuth`, an :class:`earthlens.base.SingleSecretAuth`
 subclass that resolves a single FIRMS **`MAP_KEY`** from, in priority
 order, an explicit `api_key=` argument or the `FIRMS_MAP_KEY`
 environment variable. FIRMS requires a (free) key on every request;
@@ -19,10 +19,11 @@ The shape:
 
 * :class:`FirmsCredentials` is a frozen pydantic value object carrying
   the optional key as a :class:`pydantic.SecretStr`.
-* :class:`FirmsAuth` binds those credentials and resolves the key in
-  :meth:`FirmsAuth.configure` — explicit key first, then the
-  `FIRMS_MAP_KEY` env var, then a clear :class:`AuthenticationError`
-  naming the free-registration URL (never an interactive prompt).
+* :class:`FirmsAuth` binds those credentials and lets the shared
+  :meth:`earthlens.base.SingleSecretAuth.configure` resolve the key —
+  explicit key first, then the `FIRMS_MAP_KEY` env var, then a clear
+  :class:`AuthenticationError` naming the free-registration URL (never
+  an interactive prompt).
 * `configure()` is idempotent — a second call after
   :meth:`FirmsAuth.is_authenticated` returns `True` short-circuits, so
   it is safe to call from long-lived workers.
@@ -30,12 +31,10 @@ The shape:
 
 from __future__ import annotations
 
-import os
-
 from pydantic import BaseModel, ConfigDict, SecretStr
 
-from earthlens.base.auth import AbstractAuth
 from earthlens.base.auth import AuthenticationError as _BaseAuthenticationError
+from earthlens.base.auth import SingleSecretAuth
 
 #: Where a user requests a free FIRMS MAP_KEY.
 _MAP_KEY_URL = "https://firms.modaps.eosdis.nasa.gov/api/map_key/"
@@ -92,11 +91,12 @@ class FirmsCredentials(BaseModel):
     api_key: SecretStr | None = None
 
 
-class FirmsAuth(AbstractAuth[FirmsCredentials]):
+class FirmsAuth(SingleSecretAuth[FirmsCredentials]):
     """Resolve and hold the FIRMS `MAP_KEY`.
 
-    Implements the :class:`earthlens.base.AbstractAuth` contract for a
-    single-secret backend. Construction does not touch the environment;
+    Implements the :class:`earthlens.base.SingleSecretAuth` contract for
+    a single-secret backend: it declares its env var and provider name
+    and supplies `_explicit_credential` / `_connect`, while the inherited
     :meth:`configure` performs the resolution and is idempotent. After a
     successful `configure()`, the key is available via the
     :attr:`api_key` property for the backend to drop into the request
@@ -126,46 +126,22 @@ class FirmsAuth(AbstractAuth[FirmsCredentials]):
             ```
     """
 
-    def __init__(self, credentials: FirmsCredentials) -> None:
-        """Store credentials; does not resolve the key yet.
+    ENV_VARS = ("FIRMS_MAP_KEY",)
+    PROVIDER = "FIRMS"
+    CREDENTIAL_HINT = f"Request a free key at {_MAP_KEY_URL}."
+    AUTH_ERROR = AuthenticationError
 
-        Args:
-            credentials: The :class:`FirmsCredentials` value object
-                carrying the optional `MAP_KEY`.
-        """
-        super().__init__(credentials)
-        self._configured = False
-        self._key: str | None = None
+    #: The resolved MAP_KEY, set by `_connect`; `None` until `configure` runs.
+    _key: str | None = None
 
-    def configure(self) -> None:
-        """Resolve the `MAP_KEY` so subsequent requests can authenticate.
+    def _explicit_credential(self) -> str | None:
+        """Return the explicit `api_key` off the credentials, if any."""
+        api_key = self._creds.api_key
+        return api_key.get_secret_value() if api_key is not None else None
 
-        Idempotent — short-circuits when :meth:`is_authenticated`
-        already returns `True`. On the first call, resolves the key in
-        this order: the explicit `api_key` on the credentials, then the
-        `FIRMS_MAP_KEY` environment variable.
-
-        Raises:
-            AuthenticationError: When neither source supplies a key. The
-                message names the `api_key=` argument, the
-                `FIRMS_MAP_KEY` env var, and the free-registration URL —
-                it never blocks on an interactive prompt.
-        """
-        if self.is_authenticated():
-            return
-        key = (
-            self._creds.api_key.get_secret_value()
-            if self._creds.api_key is not None
-            else os.environ.get("FIRMS_MAP_KEY")
-        )
-        if not key:
-            raise AuthenticationError(
-                "no FIRMS MAP_KEY available: pass api_key= to "
-                "EarthLens(...).authenticate() or set the FIRMS_MAP_KEY "
-                f"environment variable. Request a free key at {_MAP_KEY_URL}."
-            )
-        self._key = key
-        self.mark_configured()
+    def _connect(self, credential: str) -> None:
+        """Store the resolved MAP_KEY for the `api_key` property to read back."""
+        self._key = credential
 
     @property
     def api_key(self) -> str:

--- a/libs/providers/hazards/src/earthlens/risk_indicators/auth.py
+++ b/libs/providers/hazards/src/earthlens/risk_indicators/auth.py
@@ -128,6 +128,7 @@ class GfwAuth(SingleSecretAuth[GfwCredentials]):
 
     ENV_VARS = ("GFW_API_KEY",)
     PROVIDER = "GFW"
+    CREDENTIAL_ARG = "api_key"
     CREDENTIAL_HINT = f"Create a free key with a MyGFW account: {_CREATE_KEY_URL}."
     AUTH_ERROR = AuthenticationError
 

--- a/libs/providers/hazards/src/earthlens/risk_indicators/auth.py
+++ b/libs/providers/hazards/src/earthlens/risk_indicators/auth.py
@@ -1,6 +1,6 @@
 """Credentials and API-key resolution for the GFW datasets of the risk backend.
 
-Hosts :class:`GfwAuth`, an :class:`earthlens.base.AbstractAuth` subclass that
+Hosts :class:`GfwAuth`, an :class:`earthlens.base.SingleSecretAuth` subclass that
 resolves a single Global Forest Watch **`x-api-key`** from, in priority order,
 an explicit `api_key=` argument or the `GFW_API_KEY` environment variable. The
 GFW Data API requires a key on every `query/json` and geostore request; there
@@ -16,10 +16,11 @@ The shape:
 
 * :class:`GfwCredentials` is a frozen pydantic value object carrying the
   optional API key as a :class:`pydantic.SecretStr`.
-* :class:`GfwAuth` binds those credentials and resolves the key in
-  :meth:`GfwAuth.configure` — explicit key first, then the `GFW_API_KEY`
-  environment variable, then a clear :class:`AuthenticationError` naming how to
-  create a key (never an interactive prompt).
+* :class:`GfwAuth` binds those credentials and lets the shared
+  :meth:`earthlens.base.SingleSecretAuth.configure` resolve the key — explicit
+  key first, then the `GFW_API_KEY` environment variable, then a clear
+  :class:`AuthenticationError` naming how to create a key (never an interactive
+  prompt).
 * `configure()` is idempotent — a second call after
   :meth:`GfwAuth.is_authenticated` returns `True` short-circuits.
 
@@ -30,12 +31,10 @@ attached as the `x-api-key` header by
 
 from __future__ import annotations
 
-import os
-
 from pydantic import BaseModel, ConfigDict, SecretStr
 
-from earthlens.base.auth import AbstractAuth
 from earthlens.base.auth import AuthenticationError as _BaseAuthenticationError
+from earthlens.base.auth import SingleSecretAuth
 
 #: Where a user creates a free GFW API key (MyGFW account -> token -> key).
 _CREATE_KEY_URL = (
@@ -93,11 +92,12 @@ class GfwCredentials(BaseModel):
     api_key: SecretStr | None = None
 
 
-class GfwAuth(AbstractAuth[GfwCredentials]):
+class GfwAuth(SingleSecretAuth[GfwCredentials]):
     """Resolve and hold the Global Forest Watch API key.
 
-    Implements the :class:`earthlens.base.AbstractAuth` contract for a
-    single-secret source. Construction does not touch the environment;
+    Implements the :class:`earthlens.base.SingleSecretAuth` contract for a
+    single-secret source: it declares its env var and provider name and
+    supplies `_explicit_credential` / `_connect`, while the inherited
     :meth:`configure` performs the resolution and is idempotent. After a
     successful `configure()`, the key is available via the :attr:`api_key`
     property for the HTTP helpers to attach as the `x-api-key` header.
@@ -126,46 +126,22 @@ class GfwAuth(AbstractAuth[GfwCredentials]):
             ```
     """
 
-    def __init__(self, credentials: GfwCredentials) -> None:
-        """Store credentials; does not resolve the key yet.
+    ENV_VARS = ("GFW_API_KEY",)
+    PROVIDER = "GFW"
+    CREDENTIAL_HINT = f"Create a free key with a MyGFW account: {_CREATE_KEY_URL}."
+    AUTH_ERROR = AuthenticationError
 
-        Args:
-            credentials: The :class:`GfwCredentials` value object carrying the
-                optional API key.
-        """
-        super().__init__(credentials)
-        self._configured = False
-        self._key: str | None = None
+    #: The resolved key, set by `_connect`; `None` until `configure` runs.
+    _key: str | None = None
 
-    def configure(self) -> None:
-        """Resolve the API key so subsequent requests can authenticate.
+    def _explicit_credential(self) -> str | None:
+        """Return the explicit `api_key` off the credentials, if any."""
+        api_key = self._creds.api_key
+        return api_key.get_secret_value() if api_key is not None else None
 
-        Idempotent — short-circuits when :meth:`is_authenticated` already
-        returns `True`. On the first call, resolves the key in this order: the
-        explicit `api_key` on the credentials, then the `GFW_API_KEY`
-        environment variable.
-
-        Raises:
-            AuthenticationError: When neither source supplies a key. The
-                message names the `api_key=` argument, the `GFW_API_KEY` env
-                var, and the key-creation URL — it never blocks on an
-                interactive prompt.
-        """
-        if self.is_authenticated():
-            return
-        key = (
-            self._creds.api_key.get_secret_value()
-            if self._creds.api_key is not None
-            else os.environ.get("GFW_API_KEY")
-        )
-        if not key:
-            raise AuthenticationError(
-                "no GFW API key available: pass api_key= to EarthLens(...) for "
-                "a gfw dataset, or set the GFW_API_KEY environment variable. "
-                f"Create a free key with a MyGFW account: {_CREATE_KEY_URL}."
-            )
-        self._key = key
-        self.mark_configured()
+    def _connect(self, credential: str) -> None:
+        """Store the resolved key for the `api_key` property to read back."""
+        self._key = credential
 
     @property
     def api_key(self) -> str:

--- a/libs/providers/hazards/tests/firms/test_auth.py
+++ b/libs/providers/hazards/tests/firms/test_auth.py
@@ -46,12 +46,16 @@ def test_explicit_key_beats_env(monkeypatch: pytest.MonkeyPatch):
     assert auth.api_key == "explicit"
 
 
-def test_missing_key_raises_naming_url(monkeypatch: pytest.MonkeyPatch):
-    """No key anywhere raises AuthenticationError naming the map_key URL."""
+def test_missing_key_raises_naming_arg_env_and_url(monkeypatch: pytest.MonkeyPatch):
+    """No key anywhere raises AuthenticationError naming the arg, env var, and URL."""
     monkeypatch.delenv("FIRMS_MAP_KEY", raising=False)
     auth = FirmsAuth(FirmsCredentials())
-    with pytest.raises(AuthenticationError, match="map_key"):
+    with pytest.raises(AuthenticationError) as exc:
         auth.configure()
+    message = str(exc.value)
+    assert "api_key=" in message, message
+    assert "FIRMS_MAP_KEY" in message, message
+    assert "firms.modaps.eosdis.nasa.gov" in message, message
 
 
 def test_configure_is_idempotent():

--- a/libs/providers/hazards/tests/firms/test_auth.py
+++ b/libs/providers/hazards/tests/firms/test_auth.py
@@ -10,6 +10,7 @@ from earthlens.firms import (
     FirmsAuth,
     FirmsCredentials,
 )
+from earthlens.firms.auth import _MAP_KEY_URL
 
 pytestmark = pytest.mark.firms
 
@@ -55,7 +56,7 @@ def test_missing_key_raises_naming_arg_env_and_url(monkeypatch: pytest.MonkeyPat
     message = str(exc.value)
     assert "api_key=" in message, message
     assert "FIRMS_MAP_KEY" in message, message
-    assert "firms.modaps.eosdis.nasa.gov" in message, message
+    assert _MAP_KEY_URL in message, message
 
 
 def test_configure_is_idempotent():

--- a/libs/providers/hazards/tests/firms/test_backend.py
+++ b/libs/providers/hazards/tests/firms/test_backend.py
@@ -80,7 +80,7 @@ class TestAuthenticate:
         """No api_key= and no env var raises AuthenticationError."""
         monkeypatch.delenv("FIRMS_MAP_KEY", raising=False)
         backend = _unauthed_backend(tmp_path)
-        with pytest.raises(AuthenticationError, match="api_key="):
+        with pytest.raises(AuthenticationError, match="no FIRMS credential"):
             backend.authenticate()
 
     def test_download_lazily_authenticates_from_env(

--- a/libs/providers/land/src/earthlens/iucn/auth.py
+++ b/libs/providers/land/src/earthlens/iucn/auth.py
@@ -1,6 +1,6 @@
 """Credentials and token resolution for the IUCN Red List backend.
 
-Hosts :class:`IucnAuth`, an :class:`earthlens.base.AbstractAuth` subclass
+Hosts :class:`IucnAuth`, an :class:`earthlens.base.SingleSecretAuth` subclass
 that resolves the IUCN Red List **v4 API token** from, in priority order, an
 explicit `token=` argument or the `IUCN_TOKEN` environment variable. The v4
 API (`api.iucnredlist.org/api/v4`) requires a token on every request, sent
@@ -10,20 +10,19 @@ can be resolved.
 
 The shape mirrors `WdpaAuth` / `OpenaqAuth`: a frozen
 :class:`IucnCredentials` value object holding the optional token as a
-:class:`pydantic.SecretStr`, and :class:`IucnAuth` resolving it in
-:meth:`IucnAuth.configure`. The resolved token is read back via the
+:class:`pydantic.SecretStr`, and :class:`IucnAuth` resolving it via the shared
+:meth:`earthlens.base.SingleSecretAuth.configure`. The resolved token is read
+back via the
 :attr:`IucnAuth.token` property and attached as the Bearer header by
 `earthlens.iucn._rest`.
 """
 
 from __future__ import annotations
 
-import os
-
 from pydantic import BaseModel, ConfigDict, SecretStr
 
-from earthlens.base.auth import AbstractAuth
 from earthlens.base.auth import AuthenticationError as _BaseAuthenticationError
+from earthlens.base.auth import SingleSecretAuth
 
 #: Where a user signs up for a free IUCN Red List v4 API token.
 _TOKEN_URL = "https://api.iucnredlist.org/users/sign_up"  # nosec B105 - not a secret (public URL / identifier)
@@ -72,11 +71,12 @@ class IucnCredentials(BaseModel):
     token: SecretStr | None = None
 
 
-class IucnAuth(AbstractAuth[IucnCredentials]):
+class IucnAuth(SingleSecretAuth[IucnCredentials]):
     """Resolve and hold the IUCN Red List v4 API token (mandatory).
 
-    Implements the :class:`earthlens.base.AbstractAuth` contract for a
-    single-secret backend. Construction does not touch the environment;
+    Implements the :class:`earthlens.base.SingleSecretAuth` contract for a
+    single-secret backend: it declares its env var and provider name and
+    supplies `_explicit_credential` / `_connect`, while the inherited
     :meth:`configure` performs the resolution and is idempotent. After a
     successful `configure()`, the token is available via the :attr:`token`
     property for `_rest` to attach as the `Authorization: Bearer` header.
@@ -98,46 +98,22 @@ class IucnAuth(AbstractAuth[IucnCredentials]):
             ```
     """
 
-    def __init__(self, credentials: IucnCredentials) -> None:
-        """Store credentials; does not resolve the token yet.
+    ENV_VARS = ("IUCN_TOKEN",)
+    PROVIDER = "IUCN Red List"
+    CREDENTIAL_HINT = f"Sign up for a free token at {_TOKEN_URL}."
+    AUTH_ERROR = AuthenticationError
 
-        Args:
-            credentials: The :class:`IucnCredentials` value object carrying
-                the optional token.
-        """
-        super().__init__(credentials)
-        self._configured = False
-        self._token: str | None = None
+    #: The resolved token, set by `_connect`; `None` until `configure` runs.
+    _token: str | None = None
 
-    def configure(self) -> None:
-        """Resolve the token so subsequent requests can authenticate.
+    def _explicit_credential(self) -> str | None:
+        """Return the explicit `token` off the credentials, if any."""
+        token = self._creds.token
+        return token.get_secret_value() if token is not None else None
 
-        Idempotent — short-circuits when :meth:`is_authenticated` already
-        returns `True`. On the first call, resolves the token in this order:
-        the explicit `token` on the credentials, then the `IUCN_TOKEN`
-        environment variable.
-
-        Raises:
-            AuthenticationError: When neither source supplies a token. The
-                message names the `token=` argument, the `IUCN_TOKEN` env
-                var, and the sign-up URL — it never blocks on an interactive
-                prompt.
-        """
-        if self.is_authenticated():
-            return
-        token = (
-            self._creds.token.get_secret_value()
-            if self._creds.token is not None
-            else os.environ.get("IUCN_TOKEN")
-        )
-        if not token:
-            raise AuthenticationError(
-                "no IUCN Red List token available: pass token= to IUCN(...) or "
-                "set the IUCN_TOKEN environment variable. Sign up for a free "
-                f"token at {_TOKEN_URL}."
-            )
-        self._token = token
-        self.mark_configured()
+    def _connect(self, credential: str) -> None:
+        """Store the resolved token for the `token` property to read back."""
+        self._token = credential
 
     @property
     def token(self) -> str:

--- a/libs/providers/land/src/earthlens/iucn/auth.py
+++ b/libs/providers/land/src/earthlens/iucn/auth.py
@@ -100,6 +100,7 @@ class IucnAuth(SingleSecretAuth[IucnCredentials]):
 
     ENV_VARS = ("IUCN_TOKEN",)
     PROVIDER = "IUCN Red List"
+    CREDENTIAL_ARG = "token"
     CREDENTIAL_HINT = f"Sign up for a free token at {_TOKEN_URL}."
     AUTH_ERROR = AuthenticationError
 

--- a/libs/providers/land/src/earthlens/wdpa/auth.py
+++ b/libs/providers/land/src/earthlens/wdpa/auth.py
@@ -107,6 +107,7 @@ class WdpaAuth(SingleSecretAuth[WdpaCredentials]):
 
     ENV_VARS = ("WDPA_TOKEN",)
     PROVIDER = "Protected Planet"
+    CREDENTIAL_ARG = "token"
     CREDENTIAL_HINT = f"Request a token at {_TOKEN_URL}."
     AUTH_ERROR = AuthenticationError
 

--- a/libs/providers/land/src/earthlens/wdpa/auth.py
+++ b/libs/providers/land/src/earthlens/wdpa/auth.py
@@ -1,6 +1,6 @@
 """Credentials and token resolution for the WDPA / Protected Planet backend.
 
-Hosts :class:`WdpaAuth`, an :class:`earthlens.base.AbstractAuth` subclass
+Hosts :class:`WdpaAuth`, an :class:`earthlens.base.SingleSecretAuth` subclass
 that resolves the Protected Planet **personal API token** from, in priority
 order, an explicit `token=` argument or the `WDPA_TOKEN` environment
 variable. The Protected Planet v4 API requires a token on every request,
@@ -13,10 +13,11 @@ The shape:
 
 * :class:`WdpaCredentials` is a frozen pydantic value object carrying the
   optional token as a :class:`pydantic.SecretStr`.
-* :class:`WdpaAuth` binds those credentials and resolves the token in
-  :meth:`WdpaAuth.configure` — explicit token first, then the `WDPA_TOKEN`
-  env var, then a clear :class:`AuthenticationError` naming the
-  token-request URL (never an interactive prompt).
+* :class:`WdpaAuth` binds those credentials and lets the shared
+  :meth:`earthlens.base.SingleSecretAuth.configure` resolve the token —
+  explicit token first, then the `WDPA_TOKEN` env var, then a clear
+  :class:`AuthenticationError` naming the token-request URL (never an
+  interactive prompt).
 
 The resolved token is read back via the :attr:`WdpaAuth.token` property and
 attached as the `token=` query parameter by `earthlens.wdpa._rest`.
@@ -24,12 +25,10 @@ attached as the `token=` query parameter by `earthlens.wdpa._rest`.
 
 from __future__ import annotations
 
-import os
-
 from pydantic import BaseModel, ConfigDict, SecretStr
 
-from earthlens.base.auth import AbstractAuth
 from earthlens.base.auth import AuthenticationError as _BaseAuthenticationError
+from earthlens.base.auth import SingleSecretAuth
 
 #: Where a user requests a personal Protected Planet API token.
 _TOKEN_URL = "https://api.protectedplanet.net/request"  # nosec B105 - not a secret (public URL / identifier)
@@ -78,11 +77,12 @@ class WdpaCredentials(BaseModel):
     token: SecretStr | None = None
 
 
-class WdpaAuth(AbstractAuth[WdpaCredentials]):
+class WdpaAuth(SingleSecretAuth[WdpaCredentials]):
     """Resolve and hold the Protected Planet API token (mandatory).
 
-    Implements the :class:`earthlens.base.AbstractAuth` contract for a
-    single-secret backend. Construction does not touch the environment;
+    Implements the :class:`earthlens.base.SingleSecretAuth` contract for a
+    single-secret backend: it declares its env var and provider name and
+    supplies `_explicit_credential` / `_connect`, while the inherited
     :meth:`configure` performs the resolution and is idempotent. After a
     successful `configure()`, the token is available via the
     :attr:`token` property for `_rest` to attach as the `token=` query
@@ -105,46 +105,22 @@ class WdpaAuth(AbstractAuth[WdpaCredentials]):
             ```
     """
 
-    def __init__(self, credentials: WdpaCredentials) -> None:
-        """Store credentials; does not resolve the token yet.
+    ENV_VARS = ("WDPA_TOKEN",)
+    PROVIDER = "Protected Planet"
+    CREDENTIAL_HINT = f"Request a token at {_TOKEN_URL}."
+    AUTH_ERROR = AuthenticationError
 
-        Args:
-            credentials: The :class:`WdpaCredentials` value object
-                carrying the optional token.
-        """
-        super().__init__(credentials)
-        self._configured = False
-        self._token: str | None = None
+    #: The resolved token, set by `_connect`; `None` until `configure` runs.
+    _token: str | None = None
 
-    def configure(self) -> None:
-        """Resolve the token so subsequent requests can authenticate.
+    def _explicit_credential(self) -> str | None:
+        """Return the explicit `token` off the credentials, if any."""
+        token = self._creds.token
+        return token.get_secret_value() if token is not None else None
 
-        Idempotent — short-circuits when :meth:`is_authenticated` already
-        returns `True`. On the first call, resolves the token in this
-        order: the explicit `token` on the credentials, then the
-        `WDPA_TOKEN` environment variable.
-
-        Raises:
-            AuthenticationError: When neither source supplies a token. The
-                message names the `token=` argument, the `WDPA_TOKEN` env
-                var, and the token-request URL — it never blocks on an
-                interactive prompt.
-        """
-        if self.is_authenticated():
-            return
-        token = (
-            self._creds.token.get_secret_value()
-            if self._creds.token is not None
-            else os.environ.get("WDPA_TOKEN")
-        )
-        if not token:
-            raise AuthenticationError(
-                "no Protected Planet token available: pass token= to WDPA(...) "
-                "or set the WDPA_TOKEN environment variable. Request a token at "
-                f"{_TOKEN_URL}."
-            )
-        self._token = token
-        self.mark_configured()
+    def _connect(self, credential: str) -> None:
+        """Store the resolved token for the `token` property to read back."""
+        self._token = credential
 
     @property
     def token(self) -> str:


### PR DESCRIPTION
# Description

Every single-secret backend (one API key or token) repeated the same `configure()` ceremony by hand:
resolve an explicit constructor argument, fall back to an environment variable, raise `AuthenticationError`
when neither is present, then memoise so a second `configure()` is a no-op. The same ~40 lines lived in six
`auth.py` modules, drifting apart in wording and structure.

This hoists that ceremony into one place. A new `earthlens.base.SingleSecretAuth` (an `AbstractAuth`
subclass) carries `configure()` / the explicit → env → raise → memoise resolution; each single-secret
backend now supplies only the parts that differ:

- `ENV_VARS` / `PROVIDER` (and optional `CREDENTIAL_ARG` / `CREDENTIAL_HINT` / `AUTH_ERROR`),
- `_explicit_credential()` — read the explicit secret off its credentials value object,
- `_connect()` — apply the resolved secret.

Six backends were migrated onto it — **airnow**, **firms**, **iucn**, **openaq**, **risk_indicators** (GFW),
**wdpa** — for a net reduction of roughly 230 lines. Their distinct `AuthenticationError` subclasses and
their `api_key` / `token` properties are unchanged; `AUTH_ERROR` lets the shared base raise each provider's
own subclass (so `except earthlens.<provider>.AuthenticationError` still singles one out) while the
missing-credential message is built consistently as
`no <Provider> credential available: pass <arg>= or set <VARS>. <hint>` — naming the constructor argument,
the environment variables, and the sign-up URL.

`AbstractAuth` itself is untouched, so the other auth classes are unaffected. The sanctioned exceptions stay
as they are: `usgs_water` (its token is optional — a missing one falls back to anonymous access rather than
raising, so it does not fit the always-raise contract), the multi-field / OAuth backends (`nrel`, `cmems`,
`earthdata`, `emdat`, `eumetsat`, `jaxa`, `openeo`, `sentinel_hub`, `gee`), and the SDK-owned auth (`ecmwf`
via `~/.cdsapirc`, `stac` signer model).

No new runtime dependencies.

## Review follow-ups (resolved)

A review round on the diff surfaced three items; all are fixed in this PR:

- **Empty explicit secret** — the first cut gated the env fallback on the explicit value's *truthiness*, so a
  present-but-empty explicit secret (`api_key=""`) fell through to the environment. The original per-backend
  code gated on *presence* (`is not None`): an explicit-but-empty secret raised immediately and never consulted
  the environment. Restored — `_resolve_credential` consults `ENV_VARS` only when `_explicit_credential()`
  returns `None`; a present-but-empty value raises. Pinned by a regression test.
- **Actionable message** — the consolidated message named no constructor argument ("pass it explicitly"). Added
  a `CREDENTIAL_ARG` class attribute rendered as `pass <arg>=`, set to `api_key` on
  airnow/firms/openaq/risk_indicators and `token` on iucn/wdpa, so the message again tells the caller exactly
  what to pass.
- **Test tightening** — the firms missing-key test matched `"map_key"`, which passed only because the
  registration URL contains `/api/map_key/`. It now asserts the message's real content (the `api_key=`
  argument, the `FIRMS_MAP_KEY` env var, and the registration host).

# Issues

- Closes #833 — hoist the repeated single-secret `configure()` ceremony into a shared base

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Full non-e2e suite (`pytest -m "not e2e"`) run per distribution against the workspace venv, plus `mypy` and
`ruff` (check + format) over the branch diff.

- [x] Unit tests — `TestSingleSecretAuth` / `TestSingleSecretAuthDefaults` cover: explicit wins, env fallback in
      priority order, missing raises the consistent provider-named message (naming the argument + env vars +
      hint), the hint-free and env-only default paths, empty-explicit raises without env fallback, idempotence,
      and the `AUTH_ERROR` subclass being raised. The six backends' own `auth.py` tests continue to pass.
- [x] Boundary test — `TestSingleSecretAuthAdoption` asserts the six single-secret backends extend
      `SingleSecretAuth` and carry no `os.environ` fallback of their own; the existing
      `TestProviderErrorHierarchy` still pins the distinct per-provider error subclasses.
- [x] `earthlens.base.auth` at 100% line + branch coverage; all doctests on the changed production files pass.
- [x] Full suites green: core 2460, atmosphere 2465, hazards 1632, land 917, imagery+ocean 1946 — 0 failures.
      `mypy` clean (403 files); `ruff` check + format clean on all changed files.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
