### PR TITLE
ci(e2e): key non-PR concurrency per run so every merge to main completes

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -8,14 +8,13 @@ name: Tests - E2E (live CDS + GEE + STAC)
 permissions:
   contents: read
 
-# Each non-PR run (a merge to `main`, the cron, a dispatch) gets its own group
-# keyed on the run id, so every merge runs to the end and a later merge never
-# cancels an earlier one. A PR still supersedes its own in-flight run.
+# No pull_request trigger here, so key the group on the run id: every run (a
+# merge to `main`, the cron, a dispatch) gets its own group and runs to the end -
+# a later merge never cancels an earlier one. Overlapping live runs are the
+# accepted cost of never dropping a merge's run.
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event_name == 'pull_request'
-    && github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
 
 on:
   push:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -8,11 +8,13 @@ name: Tests - E2E (live CDS + GEE + STAC)
 permissions:
   contents: read
 
-# Serialise non-PR runs (a merge, the cron, a dispatch on `main` share one group)
-# so two full live runs never overlap; cancel-in-progress applies to PRs only.
-# See tests.yml for the pending-run-cancellation trade-off.
+# Each non-PR run (a merge to `main`, the cron, a dispatch) gets its own group
+# keyed on the run id, so every merge runs to the end and a later merge never
+# cancels an earlier one. A PR still supersedes its own in-flight run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name == 'pull_request'
+    && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:


### PR DESCRIPTION
# Description

The live e2e workflow put every non-PR run into **one** concurrency group keyed on `github.ref`
(`Tests-E2E…-refs/heads/main`), with `cancel-in-progress` disabled for pushes. So when several merges landed on
`main` close together, their runs serialised into that single group and GitHub cancelled the **queued** runs
before any job started — the full e2e suite silently never ran for the superseded merges.

Observed on the last few merges: the run for the #1078 merge (`5fdac965`) was created but ended `cancelled` with
**0 jobs started**, queued behind an earlier merge's run; the same `cancelled`/0-jobs fingerprint repeats across a
whole string of prior main merges.

This keys the group on `github.run_id` for non-PR events — matching `tests.yml` and `lint.yml` — so each merge,
cron, and dispatch gets its **own** group and always runs to completion. A pull request still supersedes its own
in-flight run (group stays keyed on the PR ref, `cancel-in-progress` stays true for PRs).

```yaml
concurrency:
  group: >-
    ${{ github.workflow }}-${{ github.event_name == 'pull_request'
    && github.ref || github.run_id }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Trade-off: two full live e2e runs can now overlap if two merges land close together (more simultaneous load on the
rate/quota-limited services), which is the intended cost of guaranteeing every merge runs.

# Issues
- Closes #1087

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `yaml.safe_load` parses the workflow; the folded `group` resolves to
      `${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}`.
- [x] Confirmed the same formula is already in use by `tests.yml` and `lint.yml`, where every merge to `main` runs
      to completion.
- Behaviour is exercised by the next merges to `main` (GitHub Actions concurrency cannot be run locally).

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.

