### PR TITLE
feat(gee): add cloud_mask and filters hooks for pre-reducer cloud masking

### DIFF
--- a/libs/core/src/earthlens/earthlens.py
+++ b/libs/core/src/earthlens/earthlens.py
@@ -794,7 +794,8 @@ class EarthLens:
                 backend-specific options the facade does not name
                 explicitly (e.g. ECMWF's `skip_constraints`, or GEE's
                 `scale` / `crs` / `reducer` / `export_via` /
-                `drive_folder` / `gcs_bucket` / `region`). Credentials are
+                `drive_folder` / `gcs_bucket` / `region` / `cloud_mask` /
+                `filters`). Credentials are
                 not constructor kwargs: backends that defer auth take them
                 on `authenticate()` instead (e.g. GEE's `service_account`
                 / `service_key` / `project`), so forwarding those through

--- a/libs/providers/imagery/src/earthlens/gee/__init__.py
+++ b/libs/providers/imagery/src/earthlens/gee/__init__.py
@@ -19,6 +19,10 @@ Public surface (re-exported from this package):
   call :meth:`GEE.download`.
 * :class:`AuthenticationError` — raised when Earth Engine cannot be
   initialised (missing/invalid key, unregistered project, missing IAM role).
+* :data:`CloudMask` / :data:`CollectionFilter` — the callable type
+  aliases for the `GEE(cloud_mask=..., filters=...)` hooks
+  (`ee.Image -> ee.Image` and `ee.ImageCollection -> ee.ImageCollection`);
+  handy for annotating your own masks / filters.
 * :class:`Catalog` — pydantic-backed loader for the bundled per-category
   catalog under `src/earthlens/gee/catalog/`, exposing
   `available_datasets`, `datasets`, `providers`, and
@@ -103,7 +107,7 @@ Examples:
 from __future__ import annotations
 
 from earthlens.gee.auth import AuthenticationError, EarthEngineAuth
-from earthlens.gee.backend import GEE
+from earthlens.gee.backend import GEE, CloudMask, CollectionFilter
 from earthlens.gee.catalog import (
     CATALOG_PATH,
     PROVIDERS_PATH,
@@ -133,6 +137,8 @@ from earthlens.gee.sampling import sample_points, sample_points_to_gdf
 __all__ = [
     "GEE",
     "AuthenticationError",
+    "CloudMask",
+    "CollectionFilter",
     "Catalog",
     "Dataset",
     "Band",

--- a/libs/providers/imagery/src/earthlens/gee/__init__.py
+++ b/libs/providers/imagery/src/earthlens/gee/__init__.py
@@ -43,10 +43,15 @@ Public surface (re-exported from this package):
   small-FC `getInfo()` paths).
 
 Two submodules ship more specialised helpers and are intentionally
-**not** re-exported at this top level — import them directly:
+**not** re-exported at this top level — import them directly. Both
+feed the `GEE` backend's `cloud_mask=` / `filters=` constructor hooks
+(`.map`-applied / composed before the reducer), so a cloud-masked
+median composite is a facade call rather than raw `ee`:
 
-* `earthlens.gee.cloud_masks` — `landsat_sr(image, sensor=...)` for
-  Landsat C2-L2 QA_PIXEL Clear-bit masking.
+* `earthlens.gee.cloud_masks` — per-image `ee.Image -> ee.Image`
+  masks: `landsat_sr(image, sensor=...)` (Landsat C2-L2 QA_PIXEL
+  Clear-bit) and `sentinel2_scl(image)` (Sentinel-2 L2A SCL —
+  drops cloud shadow / cloud / cirrus).
 * `earthlens.gee.filters` — `by_year` / `by_bounds` /
   `by_property_in` / `by_cloud_cover_lte` / `by_year_and_bounds`
   for `ee.ImageCollection.filter*` composition.

--- a/libs/providers/imagery/src/earthlens/gee/backend.py
+++ b/libs/providers/imagery/src/earthlens/gee/backend.py
@@ -807,10 +807,11 @@ class GEE(LazyClientMixin, AbstractDataSource):
 
         `filters` and `cloud_mask` are meant for image collections. On a
         static `ee_type="image"` dataset they are still applied verbatim
-        (and a `logger.warning` is emitted): a metadata filter, or a mask
-        reading a band the asset lacks, empties the one-image collection
-        and surfaces later as an opaque Earth Engine error at download
-        time rather than here.
+        (and a `logger.warning` is emitted): a metadata filter can drop
+        the single wrapped image and empty the collection, while a mask
+        reading a band the asset lacks fails when the graph is computed —
+        either way it surfaces later as an opaque Earth Engine error at
+        download time rather than here.
 
         Args:
             var_info: The catalog entry.
@@ -833,9 +834,10 @@ class GEE(LazyClientMixin, AbstractDataSource):
                 logger.warning(
                     f"filters / cloud_mask were set but {var_info.id!r} is a "
                     "static single-image dataset (ee_type='image'); they are "
-                    "applied verbatim, and a metadata filter or a mask reading "
-                    "a band the asset lacks will empty the collection and fail "
-                    "server-side at download time."
+                    "applied verbatim — a metadata filter can empty the "
+                    "collection, and a mask reading an absent band fails when "
+                    "the graph is computed; either way it surfaces as an opaque "
+                    "Earth Engine error at download time."
                 )
         collection = collection.filterBounds(self._ee_region())
         for image_filter in self.filters:

--- a/libs/providers/imagery/src/earthlens/gee/backend.py
+++ b/libs/providers/imagery/src/earthlens/gee/backend.py
@@ -181,12 +181,15 @@ def _validate_filters(
         The filters as a tuple (empty when `filters is None`).
 
     Raises:
-        TypeError: If `filters` is a `str` / `bytes` / mapping, is not
-            iterable, or contains a non-callable entry.
+        TypeError: If `filters` is a `str`, a bytes-like object
+            (`bytes` / `bytearray` / `memoryview`), or a mapping; is not
+            iterable; or contains a non-callable entry.
     """
     if filters is None:
         return ()
-    if isinstance(filters, (str, bytes, Mapping)) or not isinstance(filters, Iterable):
+    if isinstance(
+        filters, (str, bytes, bytearray, memoryview, Mapping)
+    ) or not isinstance(filters, Iterable):
         raise TypeError(
             "filters must be an iterable of callables "
             "(ee.ImageCollection -> ee.ImageCollection) or None, got "
@@ -315,7 +318,7 @@ class GEE(LazyClientMixin, AbstractDataSource):
             or an oversized `"url"` request (unless `auto_split=True`);
             from :meth:`_download_dataset` on an unknown asset id or band.
         TypeError: At construction when `cloud_mask` is not callable, or
-            `filters` is a `str` / `bytes` / mapping / non-iterable or
+            `filters` is a `str` / bytes-like / mapping / non-iterable or
             contains a non-callable entry.
         NotImplementedError: From :meth:`download` when `aggregate=` is
             passed (not yet supported).

--- a/libs/providers/imagery/src/earthlens/gee/backend.py
+++ b/libs/providers/imagery/src/earthlens/gee/backend.py
@@ -310,6 +310,9 @@ class GEE(LazyClientMixin, AbstractDataSource):
             `temporal_resolution`; from :meth:`_api` on a missing scale
             or an oversized `"url"` request (unless `auto_split=True`);
             from :meth:`_download_dataset` on an unknown asset id or band.
+        TypeError: At construction when `cloud_mask` is not callable, or
+            `filters` is a `str` / `bytes` / mapping / non-iterable or
+            contains a non-callable entry.
         NotImplementedError: From :meth:`download` when `aggregate=` is
             passed (not yet supported).
         RuntimeError: From :meth:`_api` if a `"drive"` / `"gcs"` export

--- a/libs/providers/imagery/src/earthlens/gee/backend.py
+++ b/libs/providers/imagery/src/earthlens/gee/backend.py
@@ -270,22 +270,27 @@ class GEE(LazyClientMixin, AbstractDataSource):
             which is always synchronous.
         cloud_mask: Optional per-image mask `.map`-applied to every image
             in the stack *before* the reducer, so the composite is built
-            from cloud-screened pixels — the standard way to get a clean
+            from cloud-screened pixels — the usual way to get a clean
             optical mosaic. A callable `ee.Image -> ee.Image`; see
             :mod:`earthlens.gee.cloud_masks` (`landsat_sr` /
             `sentinel2_scl`). It runs before the band `select`, so it may
             read quality bands (`QA_PIXEL` / `SCL`) that are not listed in
-            `variables`. Defaults to `None` (no masking).
-        filters: Optional sequence of `ee.ImageCollection ->
-            ee.ImageCollection` filters applied to the stack after
-            `filterDate` / `filterBounds` and before the `cloud_mask` and
+            `variables`. Meant for image collections; on a static
+            `ee_type="image"` dataset it is applied verbatim and a warning
+            is logged (see :meth:`_build_collection`). Defaults to `None`
+            (no masking).
+        filters: Optional iterable of `ee.ImageCollection ->
+            ee.ImageCollection` filters applied to the stack after the
+            spatial / temporal filters (`filterBounds`, and `filterDate`
+            for image collections) and before the `cloud_mask` and
             reducer — e.g. a metadata cloud-cover cap. Each entry takes
             the collection and returns it; wrap the
             :mod:`earthlens.gee.filters` helpers (`by_cloud_cover_lte` /
             `by_property_in` / ...), whose first argument is the
             collection, with `functools.partial` or a lambda —
             `partial(by_cloud_cover_lte, max_pct=60)`. Applied left to
-            right. Defaults to `None` (no extra filters).
+            right; like `cloud_mask`, meant for image collections.
+            Defaults to `None` (no extra filters).
 
     Credentials are not constructor arguments — the constructor describes
     only what to fetch. Supply them at the authentication step:
@@ -783,12 +788,20 @@ class GEE(LazyClientMixin, AbstractDataSource):
         bumped by one day by :meth:`_clamp_window_to_extent` so the
         user's inclusive end date is covered.
 
-        The pipeline is `filterDate` → `filterBounds` → the constructor
-        `filters` (left to right) → the per-image `cloud_mask` (`.map`) →
-        `select(bands)`. The `cloud_mask` runs *before* `select` on
-        purpose: an optical mask reads a quality band (`QA_PIXEL` /
-        `SCL`) that the user's `bands` usually omit, so selecting the
-        requested bands first would strip it.
+        The pipeline is `filterDate` (image collections only) →
+        `filterBounds` → the constructor `filters` (left to right) → the
+        per-image `cloud_mask` (`.map`) → `select(bands)`. The
+        `cloud_mask` runs *before* `select` on purpose: an optical mask
+        reads a quality band (`QA_PIXEL` / `SCL`) that the user's `bands`
+        usually omit, so selecting the requested bands first would strip
+        it.
+
+        `filters` and `cloud_mask` are meant for image collections. On a
+        static `ee_type="image"` dataset they are still applied verbatim
+        (and a `logger.warning` is emitted): a metadata filter, or a mask
+        reading a band the asset lacks, empties the one-image collection
+        and surfaces later as an opaque Earth Engine error at download
+        time rather than here.
 
         Args:
             var_info: The catalog entry.
@@ -807,6 +820,14 @@ class GEE(LazyClientMixin, AbstractDataSource):
             # A static image: no temporal filtering (the asset may not
             # carry a `system:time_start` inside the request window).
             collection = ee.ImageCollection([ee.Image(var_info.id)])
+            if self.filters or self.cloud_mask is not None:
+                logger.warning(
+                    f"filters / cloud_mask were set but {var_info.id!r} is a "
+                    "static single-image dataset (ee_type='image'); they are "
+                    "applied verbatim, and a metadata filter or a mask reading "
+                    "a band the asset lacks will empty the collection and fail "
+                    "server-side at download time."
+                )
         collection = collection.filterBounds(self._ee_region())
         for image_filter in self.filters:
             collection = image_filter(collection)

--- a/libs/providers/imagery/src/earthlens/gee/backend.py
+++ b/libs/providers/imagery/src/earthlens/gee/backend.py
@@ -13,7 +13,9 @@ Per `(asset, band-set, time-bucket)` the pipeline is:
 
 * :meth:`_build_collection` — `ee.ImageCollection(asset_id)` (or the
   single `ee.Image` wrapped in one), `.filterDate(...)`,
-  `.filterBounds(region)`, `.select(bands)`. Pure: no I/O.
+  `.filterBounds(region)`, then any constructor `filters` and the
+  per-image `cloud_mask` (`.map`-applied), and finally `.select(bands)`.
+  Pure: no I/O.
 * :meth:`_composite` — split the request window into buckets at the
   requested cadence and collapse each with the dataset's
   `default_reducer` (or the constructor `reducer` override) — `mean`
@@ -46,7 +48,7 @@ from __future__ import annotations
 
 import datetime as dt
 import os
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -92,6 +94,14 @@ _RESOLUTION_FREQ: dict[str, str] = {"daily": "D", "monthly": "MS", "yearly": "YS
 
 _DEFAULT_HTTP_TIMEOUT_S: float = 300.0
 _ZIP_MAGIC: bytes = b"PK\x03\x04"
+
+#: A per-image cloud/quality mask — `ee.Image -> ee.Image` — `.map`-applied
+#: to the collection before the reducer (see `earthlens.gee.cloud_masks`).
+CloudMask = Callable[[ee.Image], ee.Image]
+
+#: An `ee.ImageCollection` filter — collection in, filtered collection out —
+#: applied after `filterDate` / `filterBounds` (see `earthlens.gee.filters`).
+CollectionFilter = Callable[[ee.ImageCollection], ee.ImageCollection]
 
 # Cache of EE-discovered temporal extents per asset id, shared across
 # all `GEE` instances in this process. `_discover_ee_extent` issues an
@@ -153,6 +163,41 @@ def _validate_pure_config(
             f"start={start!r} is after end={end!r}; the date range must be "
             "non-empty (`start <= end`)."
         )
+
+
+def _validate_filters(
+    filters: Sequence[CollectionFilter] | None,
+) -> tuple[CollectionFilter, ...]:
+    """Normalise the constructor `filters` into a validated tuple.
+
+    Args:
+        filters: The raw `filters=` argument — `None`, or a sequence of
+            `ee.ImageCollection -> ee.ImageCollection` callables.
+
+    Returns:
+        The filters as a tuple (empty when `filters is None`).
+
+    Raises:
+        TypeError: If `filters` is a `str` / `bytes`, is not iterable, or
+            contains a non-callable entry.
+    """
+    if filters is None:
+        return ()
+    if isinstance(filters, (str, bytes)) or not isinstance(filters, Iterable):
+        raise TypeError(
+            "filters must be a sequence of callables "
+            "(ee.ImageCollection -> ee.ImageCollection) or None, got "
+            f"{type(filters).__name__}"
+        )
+    collection_filters = tuple(filters)
+    for image_filter in collection_filters:
+        if not callable(image_filter):
+            raise TypeError(
+                "each entry in filters must be a callable "
+                "ee.ImageCollection -> ee.ImageCollection, got "
+                f"{type(image_filter).__name__}"
+            )
+    return collection_filters
 
 
 class GEE(LazyClientMixin, AbstractDataSource):
@@ -223,6 +268,24 @@ class GEE(LazyClientMixin, AbstractDataSource):
             so the caller can track them asynchronously via
             :mod:`earthlens.gee.jobs`. Ignored for `export_via="url"`,
             which is always synchronous.
+        cloud_mask: Optional per-image mask `.map`-applied to every image
+            in the stack *before* the reducer, so the composite is built
+            from cloud-screened pixels — the standard way to get a clean
+            optical mosaic. A callable `ee.Image -> ee.Image`; see
+            :mod:`earthlens.gee.cloud_masks` (`landsat_sr` /
+            `sentinel2_scl`). It runs before the band `select`, so it may
+            read quality bands (`QA_PIXEL` / `SCL`) that are not listed in
+            `variables`. Defaults to `None` (no masking).
+        filters: Optional sequence of `ee.ImageCollection ->
+            ee.ImageCollection` filters applied to the stack after
+            `filterDate` / `filterBounds` and before the `cloud_mask` and
+            reducer — e.g. a metadata cloud-cover cap. Each entry takes
+            the collection and returns it; wrap the
+            :mod:`earthlens.gee.filters` helpers (`by_cloud_cover_lte` /
+            `by_property_in` / ...), whose first argument is the
+            collection, with `functools.partial` or a lambda —
+            `partial(by_cloud_cover_lte, max_pct=60)`. Applied left to
+            right. Defaults to `None` (no extra filters).
 
     Credentials are not constructor arguments — the constructor describes
     only what to fetch. Supply them at the authentication step:
@@ -302,6 +365,8 @@ class GEE(LazyClientMixin, AbstractDataSource):
         auto_split: bool = False,
         discover_extent: bool = False,
         wait_for_export: bool = True,
+        cloud_mask: CloudMask | None = None,
+        filters: Sequence[CollectionFilter] | None = None,
     ):
         # Validate the cheap (no-I/O) config first so user typos surface
         # before the ~3.3 s cold-cache catalog parse below.
@@ -319,6 +384,12 @@ class GEE(LazyClientMixin, AbstractDataSource):
                 "export_via='asset' requires asset_id= (the parent folder "
                 "asset, e.g. 'projects/my-project/assets/my-folder')"
             )
+        if cloud_mask is not None and not callable(cloud_mask):
+            raise TypeError(
+                "cloud_mask must be a callable ee.Image -> ee.Image (or None), "
+                f"got {type(cloud_mask).__name__}"
+            )
+        collection_filters = _validate_filters(filters)
         _validate_pure_config(start, end, temporal_resolution, fmt)
 
         # These must be set before `super().__init__` runs, because the
@@ -346,6 +417,10 @@ class GEE(LazyClientMixin, AbstractDataSource):
         self.auto_split = bool(auto_split)
         self.discover_extent = bool(discover_extent)
         self.wait_for_export = bool(wait_for_export)
+        self.cloud_mask = cloud_mask
+        #: The validated `filters` as a tuple (empty when none were given),
+        #: applied left to right in :meth:`_build_collection`.
+        self.filters: tuple[CollectionFilter, ...] = collection_filters
         self._ee_geometry: Any = None  # lazily built in `_ee_region`
 
         super().__init__(
@@ -699,7 +774,7 @@ class GEE(LazyClientMixin, AbstractDataSource):
     def _build_collection(
         self, var_info: Dataset, bands: list[str], start: dt.datetime, end: dt.datetime
     ):
-        """Build the filtered, band-selected `ee.ImageCollection`.
+        """Build the filtered, cloud-masked, band-selected `ee.ImageCollection`.
 
         For an `ee_type="image"` dataset the single `ee.Image` is wrapped
         in a one-element collection so the rest of the pipeline is
@@ -707,6 +782,13 @@ class GEE(LazyClientMixin, AbstractDataSource):
         (Earth Engine convention); the `end` passed here is already
         bumped by one day by :meth:`_clamp_window_to_extent` so the
         user's inclusive end date is covered.
+
+        The pipeline is `filterDate` → `filterBounds` → the constructor
+        `filters` (left to right) → the per-image `cloud_mask` (`.map`) →
+        `select(bands)`. The `cloud_mask` runs *before* `select` on
+        purpose: an optical mask reads a quality band (`QA_PIXEL` /
+        `SCL`) that the user's `bands` usually omit, so selecting the
+        requested bands first would strip it.
 
         Args:
             var_info: The catalog entry.
@@ -725,7 +807,12 @@ class GEE(LazyClientMixin, AbstractDataSource):
             # A static image: no temporal filtering (the asset may not
             # carry a `system:time_start` inside the request window).
             collection = ee.ImageCollection([ee.Image(var_info.id)])
-        return collection.filterBounds(self._ee_region()).select(list(bands))
+        collection = collection.filterBounds(self._ee_region())
+        for image_filter in self.filters:
+            collection = image_filter(collection)
+        if self.cloud_mask is not None:
+            collection = collection.map(self.cloud_mask)
+        return collection.select(list(bands))
 
     def _composite(
         self, collection, var_info: Dataset, start: dt.datetime, end: dt.datetime

--- a/libs/providers/imagery/src/earthlens/gee/backend.py
+++ b/libs/providers/imagery/src/earthlens/gee/backend.py
@@ -173,7 +173,9 @@ def _validate_filters(
     Args:
         filters: The raw `filters=` argument — `None`, or an iterable of
             `ee.ImageCollection -> ee.ImageCollection` callables (a
-            one-shot generator is accepted and materialised).
+            one-shot generator is accepted and materialised). Order is
+            preserved, so an *ordered* iterable is expected (a `set`
+            applies in arbitrary order).
 
     Returns:
         The filters as a tuple (empty when `filters is None`).
@@ -290,8 +292,9 @@ class GEE(LazyClientMixin, AbstractDataSource):
             `by_property_in` / ...), whose first argument is the
             collection, with `functools.partial` or a lambda —
             `partial(by_cloud_cover_lte, max_pct=60)`. Applied left to
-            right; like `cloud_mask`, meant for image collections.
-            Defaults to `None` (no extra filters).
+            right, so pass an *ordered* iterable (a `set` would apply in
+            arbitrary order); like `cloud_mask`, meant for image
+            collections. Defaults to `None` (no extra filters).
 
     Credentials are not constructor arguments — the constructor describes
     only what to fetch. Supply them at the authentication step:
@@ -426,6 +429,8 @@ class GEE(LazyClientMixin, AbstractDataSource):
         self.auto_split = bool(auto_split)
         self.discover_extent = bool(discover_extent)
         self.wait_for_export = bool(wait_for_export)
+        #: The per-image `cloud_mask` hook (or `None`), `.map`-applied
+        #: before the reducer in :meth:`_build_collection`.
         self.cloud_mask = cloud_mask
         #: The validated `filters` as a tuple (empty when none were given),
         #: applied left to right in :meth:`_build_collection`.

--- a/libs/providers/imagery/src/earthlens/gee/backend.py
+++ b/libs/providers/imagery/src/earthlens/gee/backend.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 import datetime as dt
 import os
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -166,13 +166,14 @@ def _validate_pure_config(
 
 
 def _validate_filters(
-    filters: Sequence[CollectionFilter] | None,
+    filters: Iterable[CollectionFilter] | None,
 ) -> tuple[CollectionFilter, ...]:
     """Normalise the constructor `filters` into a validated tuple.
 
     Args:
-        filters: The raw `filters=` argument — `None`, or a sequence of
-            `ee.ImageCollection -> ee.ImageCollection` callables.
+        filters: The raw `filters=` argument — `None`, or an iterable of
+            `ee.ImageCollection -> ee.ImageCollection` callables (a
+            one-shot generator is accepted and materialised).
 
     Returns:
         The filters as a tuple (empty when `filters is None`).
@@ -374,7 +375,7 @@ class GEE(LazyClientMixin, AbstractDataSource):
         discover_extent: bool = False,
         wait_for_export: bool = True,
         cloud_mask: CloudMask | None = None,
-        filters: Sequence[CollectionFilter] | None = None,
+        filters: Iterable[CollectionFilter] | None = None,
     ):
         # Validate the cheap (no-I/O) config first so user typos surface
         # before the ~3.3 s cold-cache catalog parse below.

--- a/libs/providers/imagery/src/earthlens/gee/backend.py
+++ b/libs/providers/imagery/src/earthlens/gee/backend.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 import datetime as dt
 import os
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -179,14 +179,14 @@ def _validate_filters(
         The filters as a tuple (empty when `filters is None`).
 
     Raises:
-        TypeError: If `filters` is a `str` / `bytes`, is not iterable, or
-            contains a non-callable entry.
+        TypeError: If `filters` is a `str` / `bytes` / mapping, is not
+            iterable, or contains a non-callable entry.
     """
     if filters is None:
         return ()
-    if isinstance(filters, (str, bytes)) or not isinstance(filters, Iterable):
+    if isinstance(filters, (str, bytes, Mapping)) or not isinstance(filters, Iterable):
         raise TypeError(
-            "filters must be a sequence of callables "
+            "filters must be an iterable of callables "
             "(ee.ImageCollection -> ee.ImageCollection) or None, got "
             f"{type(filters).__name__}"
         )

--- a/libs/providers/imagery/src/earthlens/gee/backend.py
+++ b/libs/providers/imagery/src/earthlens/gee/backend.py
@@ -85,7 +85,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
     from earthlens.base.http import HttpClient
 
-__all__ = ["GEE", "AuthenticationError"]
+__all__ = ["GEE", "AuthenticationError", "CloudMask", "CollectionFilter"]
 
 # `temporal_resolution` → pandas frequency alias for the per-bucket
 # date range. `"raw"` is special-cased (one bucket spanning the whole

--- a/libs/providers/imagery/src/earthlens/gee/cloud_masks.py
+++ b/libs/providers/imagery/src/earthlens/gee/cloud_masks.py
@@ -1,12 +1,22 @@
 """Cloud-masking helpers for Earth Engine Landsat / Sentinel collections.
 
-Currently exposes :func:`landsat_sr`, which masks an LS7 / LS8 / LS9
-Collection-2 Level-2 surface-reflectance image to its `QA_PIXEL` Clear
-bit (bit 6). The Landsat C2-L2 `QA_PIXEL` bitmask is identical across
-LS7 / LS8 / LS9, so the `sensor` argument is currently informational —
-kept on the signature so callers can be explicit and so future
-per-sensor refinements (e.g. extra confidence-bit thresholds) don't
-break the public API.
+Each helper is a per-image `ee.Image -> ee.Image` mask, suitable for
+`ee.ImageCollection.map(...)` before a reducer — or for the `GEE`
+backend's `cloud_mask=` hook, which `.map`-applies it to the stack
+before compositing, so a cloud-screened median mosaic can be expressed
+through the facade instead of raw `ee`.
+
+:func:`landsat_sr` masks an LS7 / LS8 / LS9 Collection-2 Level-2
+surface-reflectance image to its `QA_PIXEL` Clear bit (bit 6). The
+Landsat C2-L2 `QA_PIXEL` bitmask is identical across LS7 / LS8 / LS9,
+so the `sensor` argument is currently informational — kept on the
+signature so callers can be explicit and so future per-sensor
+refinements (e.g. extra confidence-bit thresholds) don't break the
+public API.
+
+:func:`sentinel2_scl` masks a Sentinel-2 L2A image via its Scene
+Classification (`SCL`) band, dropping cloud shadow (class 3), cloud
+medium / high probability (8 / 9) and thin cirrus (10).
 
 Bit layout (USGS LSDS-1330):
 
@@ -74,3 +84,36 @@ def landsat_sr(image: ee.Image, sensor: Sensor = "auto") -> ee.Image:
     qa = image.select("QA_PIXEL")
     clear_pixels = qa.bitwiseAnd(_QA_PIXEL_CLEAR_BIT)
     return image.updateMask(clear_pixels)
+
+
+#: Sentinel-2 L2A Scene Classification (`SCL`) codes dropped by
+#: :func:`sentinel2_scl`: cloud shadow (3), cloud medium probability (8),
+#: cloud high probability (9) and thin cirrus (10). Every other class
+#: (vegetation, bare soil, water, snow/ice, ...) is kept.
+_S2_SCL_MASKED_CLASSES: tuple[int, ...] = (3, 8, 9, 10)
+
+
+def sentinel2_scl(image: ee.Image) -> ee.Image:
+    """Mask a Sentinel-2 L2A image to its clear pixels via the `SCL` band.
+
+    Reads the Scene Classification (`SCL`) band and keeps only pixels
+    whose class is neither cloud shadow (3), cloud medium / high
+    probability (8 / 9), nor thin cirrus (10) — the standard recipe for
+    a clean surface-reflectance composite over
+    `COPERNICUS/S2_SR_HARMONIZED`.
+
+    Args:
+        image: An `ee.Image` from `COPERNICUS/S2_SR_HARMONIZED` (or the
+            older `COPERNICUS/S2_SR`). Must carry the `SCL` band, which
+            the Level-2A products provide.
+
+    Returns:
+        The input image with `updateMask(...)` applied, the mask being
+        the logical AND of `SCL != c` over every dropped class `c` in
+        :data:`_S2_SCL_MASKED_CLASSES`.
+    """
+    scl = image.select("SCL")
+    keep = scl.neq(_S2_SCL_MASKED_CLASSES[0])
+    for masked_class in _S2_SCL_MASKED_CLASSES[1:]:
+        keep = keep.And(scl.neq(masked_class))
+    return image.updateMask(keep)

--- a/libs/providers/imagery/src/earthlens/gee/cloud_masks.py
+++ b/libs/providers/imagery/src/earthlens/gee/cloud_masks.py
@@ -76,6 +76,29 @@ def landsat_sr(image: ee.Image, sensor: Sensor = "auto") -> ee.Image:
 
     Raises:
         ValueError: If `sensor` is not one of the supported names.
+
+    Examples:
+        - Screen a Landsat-8 C2-L2 stack to clear pixels, then composite
+          (`.map` the mask over the collection before the reducer):
+            ```python
+            >>> import ee  # doctest: +SKIP
+            >>> stack = ee.ImageCollection("LANDSAT/LC08/C02/T1_L2")  # doctest: +SKIP
+            >>> clear_median = stack.map(landsat_sr).median()  # doctest: +SKIP
+
+            ```
+        - Hand it to the GEE backend as the per-image `cloud_mask` so the
+          facade builds the cloud-free composite for you:
+            ```python
+            >>> from earthlens.core import EarthLens  # doctest: +SKIP
+            >>> el = EarthLens(  # doctest: +SKIP
+            ...     data_source="gee",
+            ...     dataset="LANDSAT/LC08/C02/T1_L2",
+            ...     variables=["SR_B4", "SR_B3", "SR_B2"],
+            ...     start="2023-06-01", end="2023-09-01",
+            ...     reducer="median", cloud_mask=landsat_sr,
+            ... )
+
+            ```
     """
     if sensor not in _SUPPORTED_SENSORS:
         raise ValueError(
@@ -111,6 +134,28 @@ def sentinel2_scl(image: ee.Image) -> ee.Image:
         The input image with `updateMask(...)` applied, the mask being
         the logical AND of `SCL != c` over every dropped class `c` in
         :data:`_S2_SCL_MASKED_CLASSES`.
+
+    Examples:
+        - Drop cloudy pixels from a Sentinel-2 L2A stack before compositing:
+            ```python
+            >>> import ee  # doctest: +SKIP
+            >>> s2 = ee.ImageCollection("COPERNICUS/S2_SR_HARMONIZED")  # doctest: +SKIP
+            >>> clear_median = s2.map(sentinel2_scl).median()  # doctest: +SKIP
+
+            ```
+        - Use it as the GEE backend `cloud_mask` for a facade-built RGB mosaic
+          — no raw `ee` needed:
+            ```python
+            >>> from earthlens.core import EarthLens  # doctest: +SKIP
+            >>> el = EarthLens(  # doctest: +SKIP
+            ...     data_source="gee",
+            ...     dataset="COPERNICUS/S2_SR_HARMONIZED",
+            ...     variables=["B4", "B3", "B2"],
+            ...     start="2024-05-01", end="2024-06-15",
+            ...     reducer="median", cloud_mask=sentinel2_scl,
+            ... )
+
+            ```
     """
     scl = image.select("SCL")
     keep = scl.neq(_S2_SCL_MASKED_CLASSES[0])

--- a/libs/providers/imagery/src/earthlens/gee/cloud_masks.py
+++ b/libs/providers/imagery/src/earthlens/gee/cloud_masks.py
@@ -121,9 +121,14 @@ def sentinel2_scl(image: ee.Image) -> ee.Image:
 
     Reads the Scene Classification (`SCL`) band and keeps only pixels
     whose class is neither cloud shadow (3), cloud medium / high
-    probability (8 / 9), nor thin cirrus (10) — the standard recipe for
-    a clean surface-reflectance composite over
-    `COPERNICUS/S2_SR_HARMONIZED`.
+    probability (8 / 9), nor thin cirrus (10) — a common recipe for a
+    clean surface-reflectance composite over `COPERNICUS/S2_SR_HARMONIZED`.
+
+    It deliberately keeps some non-clear classes that other recipes also
+    drop — notably saturated / defective (1) and snow / ice (11) — so a
+    scene with those will retain them; screen them separately if that
+    matters. The masked set (:data:`_S2_SCL_MASKED_CLASSES`) is the one
+    specified for this helper and is not a universal standard.
 
     Args:
         image: An `ee.Image` from `COPERNICUS/S2_SR_HARMONIZED` (or the

--- a/libs/providers/imagery/tests/gee/test_backend.py
+++ b/libs/providers/imagery/tests/gee/test_backend.py
@@ -23,6 +23,7 @@ from earthlens.base import SpatialExtent, TemporalExtent
 from earthlens.gee import backend as backend_module
 from earthlens.gee.backend import GEE
 from earthlens.gee.catalog import Dataset, Extent
+from earthlens.gee.cloud_masks import sentinel2_scl
 
 # -- fakes ------------------------------------------------------------------
 
@@ -421,6 +422,43 @@ class TestInit:
         """A mapping is rejected up front, not iterated into its keys."""
         with pytest.raises(TypeError, match="filters must be an iterable"):
             make_gee(filters={"a": lambda c: c})
+
+    def test_bytes_filters_rejected(self, make_gee):
+        """A `bytes` value is rejected like `str`, not iterated per byte."""
+        with pytest.raises(TypeError, match="filters must be an iterable"):
+            make_gee(filters=b"abc")
+
+    @pytest.mark.parametrize(
+        "kwargs, match",
+        [
+            ({"cloud_mask": "x"}, r"cloud_mask must be a callable"),
+            ({"filters": 42}, r"filters must be an iterable"),
+            ({"filters": [object()]}, r"each entry in filters"),
+        ],
+    )
+    def test_bad_hooks_fail_before_catalog_load(
+        self, monkeypatch, tmp_path, kwargs, match
+    ):
+        """A bad `cloud_mask` / `filters` raises before the catalog parse."""
+        from earthlens.gee import backend as backend_module
+
+        class _ExplodingCatalog:
+            def __init__(self, *_a, **_k):
+                raise AssertionError(
+                    "Catalog() must not be constructed before hook validation"
+                )
+
+        monkeypatch.setattr(backend_module, "Catalog", _ExplodingCatalog)
+        with pytest.raises(TypeError, match=match):
+            GEE(
+                start="2000-02-11",
+                end="2000-02-12",
+                variables={"USGS/SRTMGL1_003": ["elevation"]},
+                lat_lim=[29.9, 30.0],
+                lon_lim=[31.2, 31.3],
+                path=str(tmp_path),
+                **kwargs,
+            )
 
     def test_generator_filters_normalised_to_tuple(self, make_gee):
         """A one-shot generator is materialised into a reusable tuple."""
@@ -1117,6 +1155,19 @@ class TestBuildCollection:
             "select",
         ]
 
+    def test_real_cloud_mask_threaded_through_build(self, make_gee):
+        """A real mask (`sentinel2_scl`) is the exact callable handed to `.map`."""
+        gee = make_gee(
+            variables={"UCSB-CHG/CHIRPS/DAILY": ["precipitation"]},
+            scale=5566.0,
+            cloud_mask=sentinel2_scl,
+        )
+        ds = gee.catalog.get_dataset("UCSB-CHG/CHIRPS/DAILY")
+        col = gee._build_collection(
+            ds, ["precipitation"], dt.datetime(2020, 6, 1), dt.datetime(2020, 6, 2)
+        )
+        assert [args for name, args in col.calls if name == "map"] == [(sentinel2_scl,)]
+
     def test_static_image_applies_filters_and_cloud_mask(self, make_gee, monkeypatch):
         """A static image dataset applies the hooks before select and logs a warning."""
         warnings: list[str] = []
@@ -1179,6 +1230,27 @@ class TestComposite:
             dt.datetime(2020, 6, 1),
             dt.datetime(2020, 7, 1),
         ]
+        assert all(img.reducer == "mean" for _, img in buckets)
+
+    def test_monthly_maps_cloud_mask_once_not_per_bucket(self, make_gee):
+        """The `cloud_mask` is `.map`-applied once at build, not re-applied per bucket."""
+        gee = make_gee(
+            start="2020-06-01",
+            end="2020-07-31",
+            temporal_resolution="monthly",
+            variables={"UCSB-CHG/CHIRPS/DAILY": ["precipitation"]},
+            scale=5566.0,
+            cloud_mask=_identity_mask,
+        )
+        ds = gee.catalog.get_dataset("UCSB-CHG/CHIRPS/DAILY")
+        col = gee._build_collection(
+            ds, ["precipitation"], dt.datetime(2020, 6, 1), dt.datetime(2020, 8, 1)
+        )
+        assert col.method_names().count("map") == 1
+        buckets = list(
+            gee._composite(col, ds, dt.datetime(2020, 6, 1), dt.datetime(2020, 8, 1))
+        )
+        assert len(buckets) == 2
         assert all(img.reducer == "mean" for _, img in buckets)
 
     def test_static_image_one_bucket_regardless_of_resolution(self, make_gee):

--- a/libs/providers/imagery/tests/gee/test_backend.py
+++ b/libs/providers/imagery/tests/gee/test_backend.py
@@ -1085,8 +1085,12 @@ class TestBuildCollection:
         )
         assert col.method_names() == ["filterDate", "filterBounds", "select"]
 
-    def test_static_image_skips_filter_date(self, make_gee):
-        """A static `image` dataset is *not* date-filtered."""
+    def test_static_image_skips_filter_date(self, make_gee, monkeypatch):
+        """A hookless static image dataset is not date-filtered and logs no warning."""
+        warnings: list[str] = []
+        monkeypatch.setattr(
+            backend_module.logger, "warning", lambda msg, *a, **k: warnings.append(msg)
+        )
         gee = make_gee()
         ds = gee.catalog.get_dataset("USGS/SRTMGL1_003")
         col = gee._build_collection(
@@ -1094,6 +1098,7 @@ class TestBuildCollection:
         )
         assert col.method_names() == ["filterBounds", "select"]
         assert gee.client.image_log == ["USGS/SRTMGL1_003"]
+        assert warnings == []
 
     def test_filters_applied_after_bounds_before_select(self, make_gee):
         """Constructor `filters` are applied left to right, after bounds."""
@@ -1135,8 +1140,12 @@ class TestBuildCollection:
             (_identity_mask,)
         ]
 
-    def test_filters_then_cloud_mask_then_select(self, make_gee):
-        """With both, the order is filters → cloud_mask → select."""
+    def test_filters_then_cloud_mask_then_select(self, make_gee, monkeypatch):
+        """On a collection the order is filters → cloud_mask → select, with no warning."""
+        warnings: list[str] = []
+        monkeypatch.setattr(
+            backend_module.logger, "warning", lambda msg, *a, **k: warnings.append(msg)
+        )
         gee = make_gee(
             variables={"UCSB-CHG/CHIRPS/DAILY": ["precipitation"]},
             scale=5566.0,
@@ -1154,6 +1163,7 @@ class TestBuildCollection:
             "map",
             "select",
         ]
+        assert warnings == []
 
     def test_real_cloud_mask_threaded_through_build(self, make_gee):
         """A real mask (`sentinel2_scl`) is the exact callable handed to `.map`."""

--- a/libs/providers/imagery/tests/gee/test_backend.py
+++ b/libs/providers/imagery/tests/gee/test_backend.py
@@ -412,6 +412,18 @@ class TestInit:
         with pytest.raises(TypeError, match="each entry in filters"):
             make_gee(filters=[lambda c: c, "nope"])
 
+    def test_str_filters_rejected(self, make_gee):
+        """A `str` (iterable of chars) is rejected rather than iterated per char."""
+        with pytest.raises(TypeError, match="filters must be a sequence"):
+            make_gee(filters="abc")
+
+    def test_generator_filters_normalised_to_tuple(self, make_gee):
+        """A one-shot generator is materialised into a reusable tuple."""
+        first, second = (lambda c: c), (lambda c: c)
+        gee = make_gee(filters=(f for f in (first, second)))
+        assert gee.filters == (first, second)
+        assert isinstance(gee.filters, tuple)
+
     def test_bad_export_via_fails_before_catalog_load(self, monkeypatch, tmp_path):
         """A typo'd `export_via` raises before paying for the catalog parse (M3)."""
         from earthlens.gee import backend as backend_module
@@ -1099,6 +1111,22 @@ class TestBuildCollection:
             "map",
             "select",
         ]
+
+    def test_static_image_applies_filters_and_cloud_mask(self, make_gee):
+        """A static `image` dataset also runs `filters` / `cloud_mask` before select.
+
+        The hooks sit between `filterBounds` and `select` for both branches, so a
+        single-image dataset is masked the same way (no `filterDate` is issued).
+        """
+        gee = make_gee(
+            filters=[lambda c: c.filter("cc")],
+            cloud_mask=_identity_mask,
+        )
+        ds = gee.catalog.get_dataset("USGS/SRTMGL1_003")
+        col = gee._build_collection(
+            ds, ["elevation"], dt.datetime(2000, 2, 11), dt.datetime(2000, 2, 13)
+        )
+        assert col.method_names() == ["filterBounds", "filter", "map", "select"]
 
 
 class TestComposite:

--- a/libs/providers/imagery/tests/gee/test_backend.py
+++ b/libs/providers/imagery/tests/gee/test_backend.py
@@ -404,7 +404,7 @@ class TestInit:
 
     def test_non_iterable_filters_rejected(self, make_gee):
         """A non-iterable `filters` raises `TypeError` at construction."""
-        with pytest.raises(TypeError, match="filters must be a sequence"):
+        with pytest.raises(TypeError, match="filters must be an iterable"):
             make_gee(filters=42)
 
     def test_non_callable_filter_entry_rejected(self, make_gee):
@@ -414,8 +414,13 @@ class TestInit:
 
     def test_str_filters_rejected(self, make_gee):
         """A `str` (iterable of chars) is rejected rather than iterated per char."""
-        with pytest.raises(TypeError, match="filters must be a sequence"):
+        with pytest.raises(TypeError, match="filters must be an iterable"):
             make_gee(filters="abc")
+
+    def test_mapping_filters_rejected(self, make_gee):
+        """A mapping is rejected up front, not iterated into its keys."""
+        with pytest.raises(TypeError, match="filters must be an iterable"):
+            make_gee(filters={"a": lambda c: c})
 
     def test_generator_filters_normalised_to_tuple(self, make_gee):
         """A one-shot generator is materialised into a reusable tuple."""

--- a/libs/providers/imagery/tests/gee/test_backend.py
+++ b/libs/providers/imagery/tests/gee/test_backend.py
@@ -423,10 +423,11 @@ class TestInit:
         with pytest.raises(TypeError, match="filters must be an iterable"):
             make_gee(filters={"a": lambda c: c})
 
-    def test_bytes_filters_rejected(self, make_gee):
-        """A `bytes` value is rejected like `str`, not iterated per byte."""
+    @pytest.mark.parametrize("value", [b"abc", bytearray(b"abc"), memoryview(b"abc")])
+    def test_bytes_like_filters_rejected(self, make_gee, value):
+        """bytes / bytearray / memoryview are rejected up front, not iterated per byte."""
         with pytest.raises(TypeError, match="filters must be an iterable"):
-            make_gee(filters=b"abc")
+            make_gee(filters=value)
 
     @pytest.mark.parametrize(
         "kwargs, match",

--- a/libs/providers/imagery/tests/gee/test_backend.py
+++ b/libs/providers/imagery/tests/gee/test_backend.py
@@ -1195,6 +1195,26 @@ class TestBuildCollection:
         assert col.method_names() == ["filterBounds", "filter", "map", "select"]
         assert any("static single-image" in w for w in warnings), warnings
 
+    @pytest.mark.parametrize(
+        "hooks",
+        [
+            {"filters": [lambda c: c.filter("cc")]},
+            {"cloud_mask": _identity_mask},
+        ],
+    )
+    def test_static_image_single_hook_warns(self, make_gee, monkeypatch, hooks):
+        """A static image warns when only one of filters / cloud_mask is set."""
+        warnings: list[str] = []
+        monkeypatch.setattr(
+            backend_module.logger, "warning", lambda msg, *a, **k: warnings.append(msg)
+        )
+        gee = make_gee(**hooks)
+        ds = gee.catalog.get_dataset("USGS/SRTMGL1_003")
+        gee._build_collection(
+            ds, ["elevation"], dt.datetime(2000, 2, 11), dt.datetime(2000, 2, 13)
+        )
+        assert any("static single-image" in w for w in warnings), warnings
+
 
 class TestComposite:
     """Tests for `GEE._composite`."""

--- a/libs/providers/imagery/tests/gee/test_backend.py
+++ b/libs/providers/imagery/tests/gee/test_backend.py
@@ -1112,12 +1112,12 @@ class TestBuildCollection:
             "select",
         ]
 
-    def test_static_image_applies_filters_and_cloud_mask(self, make_gee):
-        """A static `image` dataset also runs `filters` / `cloud_mask` before select.
-
-        The hooks sit between `filterBounds` and `select` for both branches, so a
-        single-image dataset is masked the same way (no `filterDate` is issued).
-        """
+    def test_static_image_applies_filters_and_cloud_mask(self, make_gee, monkeypatch):
+        """A static image dataset applies the hooks before select and logs a warning."""
+        warnings: list[str] = []
+        monkeypatch.setattr(
+            backend_module.logger, "warning", lambda msg, *a, **k: warnings.append(msg)
+        )
         gee = make_gee(
             filters=[lambda c: c.filter("cc")],
             cloud_mask=_identity_mask,
@@ -1127,6 +1127,7 @@ class TestBuildCollection:
             ds, ["elevation"], dt.datetime(2000, 2, 11), dt.datetime(2000, 2, 13)
         )
         assert col.method_names() == ["filterBounds", "filter", "map", "select"]
+        assert any("static single-image" in w for w in warnings), warnings
 
 
 class TestComposite:

--- a/libs/providers/imagery/tests/gee/test_backend.py
+++ b/libs/providers/imagery/tests/gee/test_backend.py
@@ -72,6 +72,12 @@ class _FakeImageCollection:
     def filterBounds(self, geom):  # noqa: N802
         return self._chain("filterBounds", geom)
 
+    def filter(self, filt):
+        return self._chain("filter", filt)
+
+    def map(self, fn):
+        return self._chain("map", fn)
+
     def select(self, bands):
         return self._chain("select", tuple(bands))
 
@@ -274,6 +280,11 @@ class _FakePyramidsDataset:
 _FAKE_TIFF_BYTES = b"MM\x00*" + b"\x00" * 64
 
 
+def _identity_mask(image):
+    """A no-op `cloud_mask` used to assert `.map` wiring (returns the image)."""
+    return image
+
+
 # -- fixtures ---------------------------------------------------------------
 
 
@@ -372,6 +383,34 @@ class TestInit:
         """An unknown `export_via` raises `ValueError` at construction."""
         with pytest.raises(ValueError, match="export_via must be"):
             make_gee(export_via="ftp")
+
+    def test_cloud_mask_and_filters_default_to_none(self, make_gee):
+        """Omitting the hooks leaves `cloud_mask=None` and `filters=()`."""
+        gee = make_gee()
+        assert gee.cloud_mask is None
+        assert gee.filters == ()
+
+    def test_cloud_mask_and_filters_captured(self, make_gee):
+        """The hooks are stored; `filters` is normalised to a tuple."""
+        first, second = (lambda c: c), (lambda c: c)
+        gee = make_gee(cloud_mask=_identity_mask, filters=[first, second])
+        assert gee.cloud_mask is _identity_mask
+        assert gee.filters == (first, second)
+
+    def test_non_callable_cloud_mask_rejected(self, make_gee):
+        """A non-callable `cloud_mask` raises `TypeError` at construction."""
+        with pytest.raises(TypeError, match="cloud_mask must be a callable"):
+            make_gee(cloud_mask="not-callable")
+
+    def test_non_iterable_filters_rejected(self, make_gee):
+        """A non-iterable `filters` raises `TypeError` at construction."""
+        with pytest.raises(TypeError, match="filters must be a sequence"):
+            make_gee(filters=42)
+
+    def test_non_callable_filter_entry_rejected(self, make_gee):
+        """A non-callable entry in `filters` raises `TypeError`."""
+        with pytest.raises(TypeError, match="each entry in filters"):
+            make_gee(filters=[lambda c: c, "nope"])
 
     def test_bad_export_via_fails_before_catalog_load(self, monkeypatch, tmp_path):
         """A typo'd `export_via` raises before paying for the catalog parse (M3)."""
@@ -1000,6 +1039,66 @@ class TestBuildCollection:
         )
         assert col.method_names() == ["filterBounds", "select"]
         assert gee.client.image_log == ["USGS/SRTMGL1_003"]
+
+    def test_filters_applied_after_bounds_before_select(self, make_gee):
+        """Constructor `filters` are applied left to right, after bounds."""
+        gee = make_gee(
+            variables={"UCSB-CHG/CHIRPS/DAILY": ["precipitation"]},
+            scale=5566.0,
+            filters=[lambda c: c.filter("a"), lambda c: c.filter("b")],
+        )
+        ds = gee.catalog.get_dataset("UCSB-CHG/CHIRPS/DAILY")
+        col = gee._build_collection(
+            ds, ["precipitation"], dt.datetime(2020, 6, 1), dt.datetime(2020, 6, 2)
+        )
+        assert col.method_names() == [
+            "filterDate",
+            "filterBounds",
+            "filter",
+            "filter",
+            "select",
+        ]
+        assert [args for name, args in col.calls if name == "filter"] == [
+            ("a",),
+            ("b",),
+        ]
+
+    def test_cloud_mask_mapped_before_select(self, make_gee):
+        """A `cloud_mask` is `.map`-applied before the band `select`."""
+        gee = make_gee(
+            variables={"UCSB-CHG/CHIRPS/DAILY": ["precipitation"]},
+            scale=5566.0,
+            cloud_mask=_identity_mask,
+        )
+        ds = gee.catalog.get_dataset("UCSB-CHG/CHIRPS/DAILY")
+        col = gee._build_collection(
+            ds, ["precipitation"], dt.datetime(2020, 6, 1), dt.datetime(2020, 6, 2)
+        )
+        assert col.method_names() == ["filterDate", "filterBounds", "map", "select"]
+        # The exact callable is threaded through to `.map`.
+        assert [args for name, args in col.calls if name == "map"] == [
+            (_identity_mask,)
+        ]
+
+    def test_filters_then_cloud_mask_then_select(self, make_gee):
+        """With both, the order is filters → cloud_mask → select."""
+        gee = make_gee(
+            variables={"UCSB-CHG/CHIRPS/DAILY": ["precipitation"]},
+            scale=5566.0,
+            filters=[lambda c: c.filter("cc")],
+            cloud_mask=_identity_mask,
+        )
+        ds = gee.catalog.get_dataset("UCSB-CHG/CHIRPS/DAILY")
+        col = gee._build_collection(
+            ds, ["precipitation"], dt.datetime(2020, 6, 1), dt.datetime(2020, 6, 2)
+        )
+        assert col.method_names() == [
+            "filterDate",
+            "filterBounds",
+            "filter",
+            "map",
+            "select",
+        ]
 
 
 class TestComposite:

--- a/libs/providers/imagery/tests/gee/test_cloud_masks.py
+++ b/libs/providers/imagery/tests/gee/test_cloud_masks.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from earthlens.gee.cloud_masks import _QA_PIXEL_CLEAR_BIT, landsat_sr
+from earthlens.gee.cloud_masks import (
+    _QA_PIXEL_CLEAR_BIT,
+    _S2_SCL_MASKED_CLASSES,
+    landsat_sr,
+    sentinel2_scl,
+)
 
 
 class _FakeMaskedImage:
@@ -59,3 +64,57 @@ class TestLandsatSr:
         """An unrecognised sensor name raises `ValueError` listing the valid ones."""
         with pytest.raises(ValueError, match="sensor must be one of"):
             landsat_sr(_FakeImage(), sensor="S2")
+
+
+class _FakeMask:
+    """A boolean mask term; `.And(other)` composes into a nested expr."""
+
+    def __init__(self, expr):
+        self.expr = expr
+
+    def And(self, other):  # noqa: N802
+        return _FakeMask(("and", self.expr, other.expr))
+
+
+class _FakeSclBand:
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    def neq(self, value):
+        self._recorder["neq"].append(value)
+        return _FakeMask(("neq", value))
+
+
+class _FakeS2Image:
+    def __init__(self):
+        self.recorder: dict = {"selects": [], "neq": [], "mask": None}
+
+    def select(self, band):
+        self.recorder["selects"].append(band)
+        return _FakeSclBand(self.recorder)
+
+    def updateMask(self, mask):  # noqa: N802
+        self.recorder["mask"] = mask
+        return _FakeMaskedImage(mask)
+
+
+class TestSentinel2Scl:
+    """Tests for `sentinel2_scl`."""
+
+    def test_masked_classes_are_shadow_cloud_cirrus(self):
+        """The dropped SCL classes are shadow (3), cloud (8/9), cirrus (10)."""
+        assert _S2_SCL_MASKED_CLASSES == (3, 8, 9, 10)
+
+    def test_masks_out_each_scl_class(self):
+        """The image is masked by `AND(SCL != c)` over every dropped class."""
+        image = _FakeS2Image()
+        out = sentinel2_scl(image)
+        assert image.recorder["selects"] == ["SCL"]
+        assert image.recorder["neq"] == list(_S2_SCL_MASKED_CLASSES)
+        # Left-to-right AND: ((((SCL!=3) & SCL!=8) & SCL!=9) & SCL!=10).
+        assert out.mask.expr == (
+            "and",
+            ("and", ("and", ("neq", 3), ("neq", 8)), ("neq", 9)),
+            ("neq", 10),
+        )
+        assert isinstance(out, _FakeMaskedImage)

--- a/libs/providers/imagery/tests/gee/test_earthlens_gee.py
+++ b/libs/providers/imagery/tests/gee/test_earthlens_gee.py
@@ -250,6 +250,8 @@ class TestFacadeConstruction:
             drive_folder="ee_out",
             gcs_bucket="b",
             region="a-geodataframe-sentinel",
+            cloud_mask="a-cloud-mask-sentinel",
+            filters=["a-filter-sentinel"],
         )
         EarthLens(**_gee_kwargs(**extra))
         kwargs = fake_gee.call_args.kwargs

--- a/libs/providers/imagery/tests/gee/test_init.py
+++ b/libs/providers/imagery/tests/gee/test_init.py
@@ -13,6 +13,8 @@ from earthlens.gee import (
     Band,
     Cadence,
     Catalog,
+    CloudMask,
+    CollectionFilter,
     Dataset,
     EarthEngineAuth,
     create_feature,
@@ -22,6 +24,8 @@ from earthlens.gee import (
 _EXPECTED_EXPORTS = {
     "GEE",
     "AuthenticationError",
+    "CloudMask",
+    "CollectionFilter",
     "Catalog",
     "Dataset",
     "Band",
@@ -63,6 +67,13 @@ class TestPublicSurface:
         assert EarthEngineAuth.__module__ == "earthlens.gee.auth"
         for cls in (Catalog, Dataset, Band, Cadence):
             assert cls.__module__ == "earthlens.gee.catalog", cls
+
+    def test_type_aliases_are_reexported_from_backend(self):
+        """`CloudMask` / `CollectionFilter` are the backend's callable aliases."""
+        from earthlens.gee import backend
+
+        assert CloudMask is backend.CloudMask
+        assert CollectionFilter is backend.CollectionFilter
 
     def test_catalog_path_points_at_the_bundled_catalog_dir(self):
         """`CATALOG_PATH` is the bundled `catalog/` directory and exists."""


### PR DESCRIPTION
# Description

The GEE backend built an `ImageCollection` over `[start, end]`, applied the reducer, and downloaded the
composite — with no way to mask or filter the per-image stack *before* the reducer. So a cloud-masked median
composite (the usual way to get a clean optical mosaic) could not be expressed through the facade and had to
drop to raw `ee` (filter → SCL mask → `median()` → `getDownloadURL`).

This adds two per-image hooks and wires them into the compositing pipeline:

- **`cloud_mask`** — a per-image `ee.Image -> ee.Image` mask, `.map`-applied to the stack **before** the reducer,
  so the composite is built from cloud-screened pixels.
- **`filters`** — an iterable of `ee.ImageCollection -> ee.ImageCollection` filters applied after
  `filterDate` / `filterBounds` (e.g. a metadata cloud-cover cap).

`_build_collection` now runs `filterDate → filterBounds → filters → map(cloud_mask) → select(bands)`. The mask
runs **before** `select` on purpose: an optical mask reads a quality band (`QA_PIXEL` / `SCL`) that the requested
`variables` usually omit, so selecting first would strip it.

A new `sentinel2_scl` mask is added to `earthlens.gee.cloud_masks` (drops SCL cloud shadow (3), cloud
medium/high probability (8/9) and thin cirrus (10)), alongside the existing `landsat_sr`. The two callable type
aliases `CloudMask` / `CollectionFilter` are exported from `earthlens.gee` so callers can annotate their own
masks / filters. Both hooks are forwarded through the `EarthLens` facade like the other GEE backend kwargs — no
facade code change was needed, since it forwards `**backend_kwargs` and validates them against the real
`GEE.__init__` signature.

**Robustness & validation.** Inputs are validated at construction, before the catalog parse: `cloud_mask` must be
callable; `filters` rejects a `str` / bytes-like (`bytes` / `bytearray` / `memoryview`) / mapping / non-iterable
up front, and any non-callable entry, while a one-shot generator is accepted and materialised to a reusable
tuple (order preserved). The hooks are meant for image collections; on a static `ee_type="image"` dataset they
are applied verbatim and a `logger.warning` flags the likely misuse (a metadata filter empties the one-image
collection; a mask reading an absent band fails when the graph is computed — either way it surfaces at download
time).

Example:

```python
from functools import partial
from earthlens.core import EarthLens
from earthlens.gee import cloud_masks, filters

el = EarthLens(
    data_source="gee",
    dataset="COPERNICUS/S2_SR_HARMONIZED",
    variables=["B4", "B3", "B2"],
    aoi=[34.28, 31.32, 34.33, 31.37],
    start="2024-05-01", end="2024-06-15",
    reducer="median",
    filters=[partial(filters.by_cloud_cover_lte, max_pct=60,
                     property_name="CLOUDY_PIXEL_PERCENTAGE")],
    cloud_mask=cloud_masks.sentinel2_scl,
)
el.authenticate(...)
el.load()   # cloud-masked median composite — no raw ee
```

Note: the `earthlens.gee.filters` helpers take the collection as their first argument, so a `filters=` entry
wraps one with `functools.partial` / a lambda to form a `collection -> collection` callable (documented on the
`filters` parameter).

No new runtime dependencies.

# Issues

- Closes #411 — expose per-image `cloud_mask` / `filters` on the GEE backend so the facade can build
  cloud-masked composites

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested against an isolated uv env synced from this branch (`--extra gee --group dev`):

- [x] Unit — `sentinel2_scl` masks by `AND(SCL != c)` over each dropped class; `_build_collection` applies
  `filters` (left to right) after bounds and `.map`s the `cloud_mask` before `select`; ordering is
  `filterDate → filterBounds → filter → map → select`, and the mask is applied once at build (not per bucket).
- [x] Unit — construction rejects a non-callable `cloud_mask`, and `filters` that is a `str` / `bytes` /
  `bytearray` / `memoryview` / mapping / non-iterable / has a non-callable entry (each `TypeError`, before the
  catalog parse); a generator normalises to a tuple; defaults are `cloud_mask=None` / `filters=()`.
- [x] Unit — the static-`image` warning fires only when a hook is set (single- and both-hook cases), and stays
  silent for a hookless static image and for a hooked image-collection.
- [x] Facade / package — `cloud_mask=` / `filters=` are forwarded verbatim to `GEE(...)`, and
  `CloudMask` / `CollectionFilter` are re-exported from `earthlens.gee`.

Reproduce:

```bash
uv sync --extra gee --group dev
uv run pytest libs/providers/imagery/tests/gee/ -m "not e2e" -q
```

Result: **416 passed** (1 e2e deselected). `ruff check` / `ruff format` clean; `mypy` clean (404 source files);
the added docstring examples are `# doctest: +SKIP` (live-EE), so the doctest gate stays green.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
