### PR TITLE
feat(fdsn): add optional ShakeMap raster side-output for USGS events

### DIFF
--- a/docs/reference/fdsn/fdsn.md
+++ b/docs/reference/fdsn/fdsn.md
@@ -14,3 +14,5 @@ rendered API.
 ::: earthlens.fdsn.events
 
 ::: earthlens.fdsn.auth
+
+::: earthlens.fdsn.cli

--- a/docs/reference/fdsn/introduction.md
+++ b/docs/reference/fdsn/introduction.md
@@ -32,10 +32,11 @@ imagery). FDSN is different in two ways that shape the backend:
   `NotImplementedError` — by the shared guard in
   `AbstractDataSource`, so a direct `FDSN(...).download(aggregate=...)`
   is rejected exactly like one made through the `EarthLens` facade.
-  The one exception to the vector rule is opt-in: `with_shakemap=True`
-  additionally writes each USGS event's gridded ShakeMap as a GeoTIFF,
-  which makes that instance `"mixed"` (`aggregate=` stays refused).
-  See [Usage](usage.md#shakemap-rasters-usgs-only).
+  Opt-in, `with_shakemap=True` additionally writes each USGS event's
+  gridded ShakeMap as a GeoTIFF. That does not change `OUTPUT_KIND`:
+  `download()` still returns the event FeatureCollection, and the
+  rasters are a side effect on disk. See
+  [Usage](usage.md#shakemap-rasters-usgs-only).
 
 - **There is no dataset catalog to curate.** FDSN is a *fixed query
   protocol*, not a 600-dataset archive. The entire "catalog" is a

--- a/docs/reference/fdsn/introduction.md
+++ b/docs/reference/fdsn/introduction.md
@@ -43,11 +43,12 @@ imagery). FDSN is different in two ways that shape the backend:
   six-row provider-dispatch table mapping a user-facing network name
   to an `obspy` URL mapping. There is no growth task — adding another
   network later (ORFEUS, GFZ, …) is a hand-edit of one YAML row. The
-  backend still ships `refresh` / `audit` / `validate` handlers
-  (`earthlens datasets refresh fdsn`, `… audit fdsn`, `… validate
-  fdsn`); `refresh` diffs the data centres `obspy` can reach against
-  the curated rows, so a centre `obspy` gains or drops is surfaced
-  rather than missed. There is no `probe` handler.
+  backend still ships `refresh` and `validate` handlers
+  (`earthlens datasets refresh fdsn`, `… validate fdsn`); `refresh`
+  diffs the data centres `obspy` can reach against the curated rows, so
+  a centre `obspy` gains or drops is surfaced rather than missed.
+  `audit fdsn` works too, derived from the refresher's drift axis rather
+  than from an FDSN-owned handler. There is no `probe` handler.
 
 ## The networks
 

--- a/docs/reference/fdsn/introduction.md
+++ b/docs/reference/fdsn/introduction.md
@@ -28,15 +28,25 @@ imagery). FDSN is different in two ways that shape the backend:
   [pyramids](https://github.com/serapeum-org/pyramids)
   `FeatureCollection` (a `geopandas.GeoDataFrame` subclass) rather than
   writing a raster. Because there is no meaningful gridded reduction of
-  an event table, the `EarthLens` facade rejects an `aggregate=`
-  argument for this backend with `NotImplementedError`.
+  an event table, an `aggregate=` argument is refused with
+  `NotImplementedError` — by the shared guard in
+  `AbstractDataSource`, so a direct `FDSN(...).download(aggregate=...)`
+  is rejected exactly like one made through the `EarthLens` facade.
+  The one exception to the vector rule is opt-in: `with_shakemap=True`
+  additionally writes each USGS event's gridded ShakeMap as a GeoTIFF,
+  which makes that instance `"mixed"` (`aggregate=` stays refused).
+  See [Usage](usage.md#shakemap-rasters-usgs-only).
 
 - **There is no dataset catalog to curate.** FDSN is a *fixed query
   protocol*, not a 600-dataset archive. The entire "catalog" is a
   six-row provider-dispatch table mapping a user-facing network name
-  to an `obspy` URL mapping. There is no `refresh` / `probe` / `audit`
-  tooling and no growth task — adding another network later (ORFEUS,
-  GFZ, …) is a hand-edit of one YAML row.
+  to an `obspy` URL mapping. There is no growth task — adding another
+  network later (ORFEUS, GFZ, …) is a hand-edit of one YAML row. The
+  backend still ships `refresh` / `audit` / `validate` handlers
+  (`earthlens datasets refresh fdsn`, `… audit fdsn`, `… validate
+  fdsn`); `refresh` diffs the data centres `obspy` can reach against
+  the curated rows, so a centre `obspy` gains or drops is surfaced
+  rather than missed. There is no `probe` handler.
 
 ## The networks
 

--- a/docs/reference/fdsn/usage.md
+++ b/docs/reference/fdsn/usage.md
@@ -183,15 +183,21 @@ layer you asked for, which would otherwise be refetched forever.
 Three consequences worth knowing:
 
 - **Reuse requires the earlier run to have asked for at least what you now ask
-  for.** Widening `shakemap_layers` refetches; narrowing it does not, and does
-  not discard what is already on disk.
-- **"This event published no ShakeMap" is remembered only for a week.** ShakeMap
-  is generated minutes to hours after an event, so a query over a recent window
-  is re-checked on a later run rather than cached as empty forever. Such an
-  event leaves a directory containing only the hidden manifest.
+  for.** The manifest merges across runs, so asking for `mmi_mean`, then
+  `pga_mean`, then both is served from disk — nothing already fetched is
+  discarded or fetched twice.
+- **A layer the archive did not carry is re-checked after a week.** That covers
+  both an event with no ShakeMap at all and one whose archive carried only some
+  of the layers you asked for — ShakeMap is generated minutes to hours after an
+  event, so neither is cached as final. A run returning fewer layers than
+  requested says so in a warning. An event with no grid at all leaves a
+  directory holding only the hidden manifest.
 - **A revised grid is not detected.** USGS republishes ShakeMaps for years (the
   2023 Kahramanmaraş grid is on its twelfth version). A run with the rasters
   already on disk does not re-check; pass `download(force=True)` to refetch.
+- **The ceiling counts fetches, not events.** Events already on disk cost no
+  budget, so re-running advances through a long list. An event that fails every
+  time keeps its place rather than being skipped.
 
 To clear one event's cache, delete its directory under `out/shakemap/`.
 

--- a/docs/reference/fdsn/usage.md
+++ b/docs/reference/fdsn/usage.md
@@ -72,6 +72,9 @@ by the facade's `**backend_kwargs`):
 | `orderby` | `"time"`, `"time-asc"`, `"magnitude"`, `"magnitude-asc"` | `"time"` |
 | `limit` | max events per network | `None` |
 | `file_format` | `"gpkg"` or `"geojson"` | `"gpkg"` |
+| `with_shakemap` | also write each USGS event's ShakeMap as GeoTIFF | `False` |
+| `shakemap_layers` | which ShakeMap grids to write | `["mmi_mean"]` |
+| `max_shakemap_events` | ceiling on events fetched a ShakeMap for | `100` |
 
 `min_magnitude=None` (the default) falls back **per network** to that
 provider's catalog floor — USGS / EMSC / EarthScope / ISC use `4.5`,
@@ -161,10 +164,16 @@ event `FeatureCollection`; the rasters are a side effect.
 
 **USGS only.** ShakeMap is a USGS ComCat product and is not part of the
 FDSN event standard, so a non-USGS network in the same request still
-contributes events but no rasters (it is logged once). ShakeMap costs
-one extra request and an ~8.5 MB archive **per event**, so bound the
-event count with `limit=` or a high `min_magnitude` before enabling it
-on a busy window.
+contributes events but no rasters (each such network is logged once).
+ShakeMap costs one extra request and an ~8.5 MB archive **per event**,
+so a broad
+window is gigabytes. `max_shakemap_events` (default `100`) caps how many
+events one call will fetch: past the ceiling the rest are skipped with a
+warning naming the count — never silently. Raise it deliberately, or
+narrow the query with `limit=` / `min_magnitude=`.
+
+A re-run reuses rasters already on disk; pass `download(force=True)` to
+refetch them.
 
 By default only `mmi_mean` (macroseismic intensity) is written. The
 archive carries fourteen grids — `mmi`, `pga`, `pgv`, `psa0p3`,
@@ -198,9 +207,10 @@ EarthLens(variables=["USGS"], data_source="fdsn", ...).download(aggregate=cfg)
 The aggregator only reduces gridded raster outputs. Post-process the
 returned FeatureCollection directly instead (it is a GeoDataFrame).
 
-This holds with `with_shakemap=True` too, even though that makes the
-instance `"mixed"`: the ShakeMap grids are a per-event side-output with
-no time axis to reduce over.
+This holds with `with_shakemap=True` too. That flag does not change
+`OUTPUT_KIND` — `download()` still returns the event FeatureCollection,
+and the ShakeMap grids are an on-disk side effect with no time axis to
+reduce over.
 
 ## EarthScope token (optional)
 

--- a/docs/reference/fdsn/usage.md
+++ b/docs/reference/fdsn/usage.md
@@ -173,9 +173,27 @@ events one call will fetch: past the ceiling the rest are skipped with a
 warning naming the count — never silently. Raise it deliberately, or
 narrow the query with `limit=` / `min_magnitude=`.
 
-A re-run reuses whatever an earlier run recorded for that event — including
-"this archive carries no such layer" and "this event publishes no ShakeMap" —
-so a repeat costs nothing. Pass `download(force=True)` to refetch anyway.
+### Re-running
+
+Each event directory carries a hidden `.shakemap.json` manifest recording which
+layers that event's archive actually produced. A re-run consults it, so a repeat
+costs nothing — including for an event whose archive simply does not carry a
+layer you asked for, which would otherwise be refetched forever.
+
+Three consequences worth knowing:
+
+- **Reuse requires the earlier run to have asked for at least what you now ask
+  for.** Widening `shakemap_layers` refetches; narrowing it does not, and does
+  not discard what is already on disk.
+- **"This event published no ShakeMap" is remembered only for a week.** ShakeMap
+  is generated minutes to hours after an event, so a query over a recent window
+  is re-checked on a later run rather than cached as empty forever. Such an
+  event leaves a directory containing only the hidden manifest.
+- **A revised grid is not detected.** USGS republishes ShakeMaps for years (the
+  2023 Kahramanmaraş grid is on its twelfth version). A run with the rasters
+  already on disk does not re-check; pass `download(force=True)` to refetch.
+
+To clear one event's cache, delete its directory under `out/shakemap/`.
 
 By default only `mmi_mean` (macroseismic intensity) is written. The
 archive carries fourteen grids — `mmi`, `pga`, `pgv`, `psa0p3`,

--- a/docs/reference/fdsn/usage.md
+++ b/docs/reference/fdsn/usage.md
@@ -136,6 +136,56 @@ events.to_file("all_events.gpkg", driver="GPKG")     # GeoPackage
 events.to_file("all_events.geojson", driver="GeoJSON")  # GeoJSON
 ```
 
+## ShakeMap rasters (USGS only)
+
+Pass `with_shakemap=True` to also pull each event's gridded **ShakeMap**
+and write it as a GeoTIFF beside the vector output:
+
+```python
+events = EarthLens(
+    variables=["USGS"],
+    data_source="fdsn",
+    start="2023-02-06",
+    end="2023-02-07",
+    lat_lim=[35.0, 39.0],
+    lon_lim=[35.0, 39.0],
+    path="out",
+    min_magnitude=7.0,
+    with_shakemap=True,
+).download()
+```
+
+That writes `out/shakemap/<event-id>/mmi_mean.tif` per event, alongside
+the usual `out/usgs.gpkg`. The return value is unchanged — still the
+event `FeatureCollection`; the rasters are a side effect.
+
+**USGS only.** ShakeMap is a USGS ComCat product and is not part of the
+FDSN event standard, so a non-USGS network in the same request still
+contributes events but no rasters (it is logged once). ShakeMap costs
+one extra request and an ~8.5 MB archive **per event**, so bound the
+event count with `limit=` or a high `min_magnitude` before enabling it
+on a busy window.
+
+By default only `mmi_mean` (macroseismic intensity) is written. The
+archive carries fourteen grids — `mmi`, `pga`, `pgv`, `psa0p3`,
+`psa0p6`, `psa1p0`, `psa3p0`, each as `_mean` and `_std` — and any
+subset can be requested:
+
+```python
+EarthLens(
+    ...,
+    with_shakemap=True,
+    shakemap_layers=["mmi_mean", "pga_mean", "pgv_mean"],
+).download()
+```
+
+The grids are published as ESRI float rasters carrying no projection;
+earthlens assigns `EPSG:4326` (their true graticule) during the
+conversion to GeoTIFF.
+
+PAGER is **not** included: its ComCat product ships PDFs, PNGs, and
+JSON summaries, with no raster grid to write.
+
 ## Aggregation is not supported
 
 FDSN output is vector, so the `aggregate=` argument is rejected:
@@ -147,6 +197,10 @@ EarthLens(variables=["USGS"], data_source="fdsn", ...).download(aggregate=cfg)
 
 The aggregator only reduces gridded raster outputs. Post-process the
 returned FeatureCollection directly instead (it is a GeoDataFrame).
+
+This holds with `with_shakemap=True` too, even though that makes the
+instance `"mixed"`: the ShakeMap grids are a per-event side-output with
+no time axis to reduce over.
 
 ## EarthScope token (optional)
 

--- a/docs/reference/fdsn/usage.md
+++ b/docs/reference/fdsn/usage.md
@@ -165,15 +165,17 @@ event `FeatureCollection`; the rasters are a side effect.
 **USGS only.** ShakeMap is a USGS ComCat product and is not part of the
 FDSN event standard, so a non-USGS network in the same request still
 contributes events but no rasters (each such network is logged once).
-ShakeMap costs one extra request and an ~8.5 MB archive **per event**,
-so a broad
-window is gigabytes. `max_shakemap_events` (default `100`) caps how many
+ShakeMap costs one extra request and a multi-megabyte archive **per
+event** — measured at 8 MB and 20 MB for the two events of the 2023
+Kahramanmaraş sequence, and it scales with the event's footprint — so a
+broad window is gigabytes. `max_shakemap_events` (default `100`) caps how many
 events one call will fetch: past the ceiling the rest are skipped with a
 warning naming the count — never silently. Raise it deliberately, or
 narrow the query with `limit=` / `min_magnitude=`.
 
-A re-run reuses rasters already on disk; pass `download(force=True)` to
-refetch them.
+A re-run reuses whatever an earlier run recorded for that event — including
+"this archive carries no such layer" and "this event publishes no ShakeMap" —
+so a repeat costs nothing. Pass `download(force=True)` to refetch anyway.
 
 By default only `mmi_mean` (macroseismic intensity) is written. The
 archive carries fourteen grids — `mmi`, `pga`, `pgv`, `psa0p3`,

--- a/libs/core/src/earthlens/base/abstractdatasource.py
+++ b/libs/core/src/earthlens/base/abstractdatasource.py
@@ -1986,7 +1986,7 @@ class AbstractDataSource(ABC):
         if failures and policy == "warn":
             logger.warning(
                 f"{type(self).__name__}: {len(failures)} of {len(items)} "
-                f"{label}(s) failed; {len(results)} succeeded."
+                f"{label}(s) failed; {len(items) - len(failures)} succeeded."
             )
         return results, failures
 

--- a/libs/core/tests/base/test_hook_defaults.py
+++ b/libs/core/tests/base/test_hook_defaults.py
@@ -980,3 +980,43 @@ class TestAggregateNoneStaysAccepted:
         config = object()
         backend.download(aggregate=config)
         assert seen["aggregate"] is config
+
+
+class TestRunItemsSummary:
+    """The warning line the partial-failure loop emits."""
+
+    @staticmethod
+    def _backend(tmp_path):
+        """Build the minimal backend used to exercise `_run_items`."""
+        return _build(_Minimal, tmp_path)
+
+    def test_placeholders_are_not_counted_as_successes(self, tmp_path):
+        """With `on_failure`, the summary counts real successes, not results.
+
+        Every failure contributes a placeholder to `results`, so counting that
+        list reports as many successes as there were items.
+        """
+        from loguru import logger as loguru_logger
+
+        def flaky(n):
+            if n == 2:
+                raise RuntimeError("boom")
+            return n
+
+        messages: list[str] = []
+        sink_id = loguru_logger.add(lambda message: messages.append(str(message)))
+        try:
+            self._backend(tmp_path)._run_items(
+                [1, 2, 3],
+                flaky,
+                label="thing",
+                on_failure=lambda item, _exc: f"empty-{item}",
+            )
+        finally:
+            loguru_logger.remove(sink_id)
+
+        summary = [m for m in messages if "thing(s) failed" in m]
+        assert summary, f"expected a partial-failure summary, got: {messages}"
+        assert "1 of 3 thing(s) failed; 2 succeeded" in summary[0], (
+            f"the summary should not count placeholders as successes: {summary[0]}"
+        )

--- a/libs/providers/hazards/src/earthlens/fdsn/__init__.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/__init__.py
@@ -10,8 +10,10 @@ features (CRS `EPSG:4326`).
 
 This is the package's first `vector` backend: the result is a table of
 events, not a gridded array, so :data:`FDSN.OUTPUT_KIND` is
-`"vector"` and the :class:`earthlens.earthlens.EarthLens` facade
-rejects an `aggregate=` argument for it.
+`"vector"` and an `aggregate=` argument is refused — by the shared
+guard in :class:`earthlens.base.AbstractDataSource`, so a direct
+`FDSN(...).download(aggregate=...)` is rejected identically to one
+made through the :class:`earthlens.earthlens.EarthLens` facade.
 
 Provider selection: for this backend `variables` is a `list[str]` of
 network keys — `variables=["USGS"]`, `variables=["USGS", "EMSC"]` —
@@ -33,6 +35,9 @@ Public surface (re-exported from this package):
   FeatureCollection mapper and its empty-result counterpart.
 * :func:`resolve_earthscope_token` — optional EarthScope-token
   resolver (env / file); the public event services need no token.
+* :data:`SHAKEMAP_LAYERS` / :data:`DEFAULT_SHAKEMAP_LAYERS` — the
+  fourteen ShakeMap grids `with_shakemap=True` can write, and the
+  one written by default.
 * :data:`CATALOG_PATH` — path to the bundled provider YAML.
 
 Examples:
@@ -48,6 +53,10 @@ Examples:
 
 from __future__ import annotations
 
+from earthlens.fdsn._helpers import (
+    DEFAULT_SHAKEMAP_LAYERS,
+    SHAKEMAP_LAYERS,
+)
 from earthlens.fdsn.auth import resolve_earthscope_token
 from earthlens.fdsn.backend import FDSN
 from earthlens.fdsn.catalog import CATALOG_PATH, Catalog, Provider
@@ -55,6 +64,8 @@ from earthlens.fdsn.events import catalog_to_fc, empty_fc
 
 __all__ = [
     "CATALOG_PATH",
+    "DEFAULT_SHAKEMAP_LAYERS",
+    "SHAKEMAP_LAYERS",
     "Catalog",
     "FDSN",
     "Provider",

--- a/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
@@ -32,6 +32,7 @@ earthlens only decides *which* grid to ask for.
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import zipfile
@@ -319,7 +320,13 @@ def shakemap_raster_url(detail: Mapping[str, Any]) -> str | None:
         return None
     contents = (entries[0] or {}).get("contents") or {}
     entry = contents.get(RASTER_CONTENT_KEY) or {}
-    return entry.get("url") or None
+    url = entry.get("url") or None
+    if url is not None and not str(url).lower().startswith("https://"):
+        # The URL comes from an upstream document and is handed straight to the
+        # downloader; anything but https is refused rather than fetched.
+        logger.warning(f"refusing non-https ShakeMap archive URL {url!r}.")
+        return None
+    return url
 
 
 def extract_layers(
@@ -510,11 +517,14 @@ def flt_to_geotiff(flt_path: Path, dest: Path) -> Path:
     return dest
 
 
-def read_manifest(dest_dir: Path) -> dict[str, Any] | None:
+def read_manifest(dest_dir: Path, quiet: bool = False) -> dict[str, Any] | None:
     """Read an event directory's ShakeMap manifest, if it has one.
 
     Args:
         dest_dir: The event's output directory.
+        quiet: Suppress the warning a malformed or unreadable manifest
+            normally logs. Set by `write_manifest`, which reads the old
+            payload only to merge it and is about to replace it anyway.
 
     Returns:
         The parsed manifest, or `None` when the event has never been
@@ -572,13 +582,15 @@ def read_manifest(dest_dir: Path) -> dict[str, Any] | None:
     try:
         loaded = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        logger.warning(f"unreadable ShakeMap manifest at {path} — refetching.")
+        if not quiet:
+            logger.warning(f"unreadable ShakeMap manifest at {path} — refetching.")
         return None
     if not _is_valid_manifest(loaded):
         # Structurally wrong, not merely unreadable: treated as absent so the
         # event refetches and the next write repairs the file, rather than
         # letting a bad type escape as an error from somewhere downstream.
-        logger.warning(f"malformed ShakeMap manifest at {path} — refetching.")
+        if not quiet:
+            logger.warning(f"malformed ShakeMap manifest at {path} — refetching.")
         return None
     validated: dict[str, Any] = loaded
     return validated
@@ -604,8 +616,11 @@ def _is_valid_manifest(loaded: object) -> bool:
             isinstance(item, str) for item in value
         ):
             return False
+    version = loaded.get("product_version")
+    if version is not None and not isinstance(version, str):
+        return False
     checked = loaded.get("checked")
-    return isinstance(checked, (int, float))
+    return isinstance(checked, (int, float)) and not isinstance(checked, bool)
 
 
 def write_manifest(
@@ -694,7 +709,9 @@ def write_manifest(
     # requested layers on a later run would otherwise drop the record of
     # rasters still sitting on disk, so the next widening run would refetch an
     # archive it already has.
-    existing = read_manifest(dest_dir) or {}
+    # Read quietly: a malformed file being repaired by this very write should
+    # not log "refetching", which describes what a *reader* would do.
+    existing = read_manifest(dest_dir, quiet=True) or {}
     payload = {
         "schema": MANIFEST_SCHEMA,
         "requested": sorted(set(existing.get("requested", [])) | set(requested)),
@@ -704,7 +721,9 @@ def write_manifest(
     }
     # Staged and renamed, like the rasters it describes: a manifest truncated
     # by an interrupted write would otherwise be read back as malformed.
-    staged = dest_dir / f".{MANIFEST_NAME}.partial"
+    # Process-unique, like the scratch directory: two runs staging the same
+    # name would otherwise rename each other's half-written file into place.
+    staged = dest_dir / f".{MANIFEST_NAME}.{os.getpid()}.partial"
     try:
         staged.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         staged.replace(dest_dir / MANIFEST_NAME)

--- a/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
@@ -285,8 +285,11 @@ def shakemap_raster_url(detail: Mapping[str, Any]) -> str | None:
 
     Returns:
         The `download/raster.zip` URL, or `None` when the event has no
-            ShakeMap product or that product ships no raster bundle —
-            both of which are ordinary for a small or very recent event.
+            ShakeMap product, that product ships no raster bundle — both
+            ordinary for a small or very recent event — or the URL is not
+            `https`. The value comes from an upstream document and is
+            handed straight to the downloader, so any other scheme is
+            refused rather than fetched.
 
     Examples:
         - Walk a minimal detail document:

--- a/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
@@ -1,0 +1,306 @@
+"""Private helpers for the FDSN ShakeMap side-output.
+
+The FDSN event standard obspy speaks carries no product links: a
+`get_events` response is QuakeML, which stops at an event's origins and
+magnitudes. USGS publishes its gridded ShakeMap through a *different*
+surface — the ComCat event-detail GeoJSON — so pulling a shaking field
+for an event means a second, USGS-only request keyed by that event's
+ComCat id. This module holds the steps of that path, kept out of
+`backend.py` so each is testable on its own:
+
+1. `parse_comcat_id` — recover the ComCat id from the QuakeML resource
+   identifier `earthlens.fdsn.events` records in the `event_id` column.
+2. `detail_url` / `shakemap_raster_url` — address the detail document
+   and walk it to the ShakeMap raster archive's download URL.
+3. `extract_layers` / `flt_to_geotiff` — unpack the archive and convert
+   one grid into a georeferenced GeoTIFF.
+
+**The archive is not a GeoTIFF.** `download/raster.zip` holds fourteen
+ESRI float grids — a `.flt` payload plus a `.hdr` header per layer,
+which GDAL reads through its `EHdr` driver — covering seven intensity
+measures (`mmi`, `pga`, `pgv`, and spectral acceleration at 0.3 / 0.6 /
+1.0 / 3.0 s) each as a `_mean` and a `_std`. The headers carry an
+origin, a cell size, and a nodata value, but **no projection**, so
+`flt_to_geotiff` assigns `EPSG:4326` explicitly — the grids are
+published on a plain lon/lat graticule.
+
+The conversion itself goes through pyramids rather than raw GDAL:
+reading a format and writing another one is pyramids' scope, and
+earthlens only decides *which* grid to ask for.
+"""
+
+from __future__ import annotations
+
+import re
+import zipfile
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+from loguru import logger
+from pyramids.dataset import Dataset
+
+#: ComCat event-detail endpoint. The same FDSN-event service the backend
+#: already queries, asked for `format=geojson` instead of QuakeML — only
+#: that representation carries the `products` block.
+COMCAT_DETAIL_URL = "https://earthquake.usgs.gov/fdsnws/event/1/query"
+
+#: The `fdsn_id` whose events carry ShakeMap products. ShakeMap is a USGS
+#: product, so a non-USGS network in the same request is skipped.
+COMCAT_PROVIDER = "USGS"
+
+#: The seven intensity measures a ShakeMap raster archive carries.
+SHAKEMAP_MEASURES: tuple[str, ...] = (
+    "mmi",
+    "pga",
+    "pgv",
+    "psa0p3",
+    "psa0p6",
+    "psa1p0",
+    "psa3p0",
+)
+
+#: Every grid in the archive: each measure as a mean and a standard
+#: deviation, named exactly as the archive's members are.
+SHAKEMAP_LAYERS: tuple[str, ...] = tuple(
+    f"{measure}_{statistic}"
+    for measure in SHAKEMAP_MEASURES
+    for statistic in ("mean", "std")
+)
+
+#: Written when the caller asks for no layer explicitly. Macroseismic
+#: intensity is the headline shaking field, and one layer per event keeps
+#: a multi-event query from writing fourteen rasters and ~8.5 MB apiece.
+DEFAULT_SHAKEMAP_LAYERS: tuple[str, ...] = ("mmi_mean",)
+
+#: The grids are lon/lat WGS84 but their `.hdr` headers say no such
+#: thing, so the CRS is assigned rather than read.
+SHAKEMAP_EPSG = 4326
+
+#: Key of the raster bundle inside a ShakeMap product's `contents` map.
+RASTER_CONTENT_KEY = "download/raster.zip"
+
+# The QuakeML resource identifier USGS returns embeds the ComCat id as a
+# query parameter, e.g.
+# `quakeml:earthquake.usgs.gov/fdsnws/event/1/query?eventid=us6000jlqa&format=quakeml`.
+_EVENT_ID_PATTERN = re.compile(r"[?&]eventid=([A-Za-z0-9_.-]+)")
+
+
+def parse_comcat_id(event_id: str | None) -> str | None:
+    """Recover a ComCat event id from a QuakeML resource identifier.
+
+    Args:
+        event_id: The value of an event row's `event_id` column — a
+            QuakeML resource identifier, or `None` / empty for a row
+            whose provider did not supply one.
+
+    Returns:
+        The bare ComCat id (e.g. `"us6000jlqa"`), or `None` when the
+            identifier carries no `eventid` parameter — which is the
+            normal case for a non-USGS network.
+
+    Examples:
+        - Pull the id out of a USGS resource identifier:
+            ```python
+            >>> from earthlens.fdsn._helpers import parse_comcat_id
+            >>> parse_comcat_id(
+            ...     "quakeml:earthquake.usgs.gov/fdsnws/event/1/query"
+            ...     "?eventid=us6000jlqa&format=quakeml"
+            ... )
+            'us6000jlqa'
+
+            ```
+        - An identifier without one yields `None`:
+            ```python
+            >>> from earthlens.fdsn._helpers import parse_comcat_id
+            >>> parse_comcat_id("smi:ch.ethz.sed/sc3a/2024abcd") is None
+            True
+
+            ```
+    """
+    if not event_id:
+        return None
+    match = _EVENT_ID_PATTERN.search(event_id)
+    return match.group(1) if match else None
+
+
+def normalize_layers(layers: Iterable[str] | None) -> tuple[str, ...]:
+    """Validate and de-duplicate a requested set of ShakeMap layers.
+
+    Args:
+        layers: Layer names to keep, or `None` for
+            `DEFAULT_SHAKEMAP_LAYERS`. Order is preserved; a repeated
+            name is collapsed.
+
+    Returns:
+        The requested layers as a tuple, in first-seen order.
+
+    Raises:
+        ValueError: If a name is not one of `SHAKEMAP_LAYERS`, or if an
+            explicitly empty selection is passed — asking for the
+            ShakeMap side-output and then for no layer of it is a
+            contradiction worth surfacing rather than silently writing
+            nothing.
+
+    Examples:
+        - The default selection is macroseismic intensity:
+            ```python
+            >>> from earthlens.fdsn._helpers import normalize_layers
+            >>> normalize_layers(None)
+            ('mmi_mean',)
+
+            ```
+        - An unknown name is refused:
+            ```python
+            >>> from earthlens.fdsn._helpers import normalize_layers
+            >>> normalize_layers(["mmi_median"])  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: unknown ShakeMap layer(s): ['mmi_median']. Choose from [...].
+
+            ```
+    """
+    if layers is None:
+        return DEFAULT_SHAKEMAP_LAYERS
+    requested = list(layers)
+    if not requested:
+        raise ValueError(
+            "shakemap_layers is empty. Pass at least one of "
+            f"{list(SHAKEMAP_LAYERS)}, or leave it as None for "
+            f"{list(DEFAULT_SHAKEMAP_LAYERS)}."
+        )
+    unknown = [name for name in requested if name not in SHAKEMAP_LAYERS]
+    if unknown:
+        raise ValueError(
+            f"unknown ShakeMap layer(s): {sorted(unknown)}. "
+            f"Choose from {list(SHAKEMAP_LAYERS)}."
+        )
+    seen: dict[str, None] = {}
+    for name in requested:
+        seen.setdefault(name, None)
+    return tuple(seen)
+
+
+def detail_url(comcat_id: str) -> str:
+    """Build the ComCat event-detail URL for one event.
+
+    Args:
+        comcat_id: A bare ComCat event id, as returned by
+            `parse_comcat_id`.
+
+    Returns:
+        The absolute detail URL, asked for as GeoJSON.
+
+    Examples:
+        - Address one event's detail document:
+            ```python
+            >>> from earthlens.fdsn._helpers import detail_url
+            >>> detail_url("us6000jlqa").endswith("eventid=us6000jlqa")
+            True
+
+            ```
+    """
+    query = urlencode({"format": "geojson", "eventid": comcat_id})
+    return f"{COMCAT_DETAIL_URL}?{query}"
+
+
+def shakemap_raster_url(detail: Mapping[str, Any]) -> str | None:
+    """Find the ShakeMap raster archive's URL in a detail document.
+
+    Args:
+        detail: A parsed ComCat event-detail GeoJSON document.
+
+    Returns:
+        The `download/raster.zip` URL, or `None` when the event has no
+            ShakeMap product or that product ships no raster bundle —
+            both of which are ordinary for a small or very recent event.
+
+    Examples:
+        - Walk a minimal detail document:
+            ```python
+            >>> from earthlens.fdsn._helpers import shakemap_raster_url
+            >>> shakemap_raster_url(
+            ...     {"properties": {"products": {"shakemap": [
+            ...         {"contents": {"download/raster.zip":
+            ...             {"url": "https://example.invalid/raster.zip"}}}
+            ...     ]}}}
+            ... )
+            'https://example.invalid/raster.zip'
+
+            ```
+        - An event with no ShakeMap yields `None`:
+            ```python
+            >>> from earthlens.fdsn._helpers import shakemap_raster_url
+            >>> shakemap_raster_url({"properties": {"products": {}}}) is None
+            True
+
+            ```
+    """
+    properties = detail.get("properties") or {}
+    products = properties.get("products") or {}
+    entries = products.get("shakemap") or []
+    if not entries:
+        return None
+    contents = (entries[0] or {}).get("contents") or {}
+    entry = contents.get(RASTER_CONTENT_KEY) or {}
+    return entry.get("url") or None
+
+
+def extract_layers(
+    archive: Path,
+    layers: Iterable[str],
+    dest_dir: Path,
+) -> dict[str, Path]:
+    """Extract the `.flt` / `.hdr` pair for each requested layer.
+
+    Only the exact member names built from `layers` are read, so a
+    hostile archive cannot place a file outside `dest_dir`.
+
+    Args:
+        archive: The downloaded `raster.zip`.
+        layers: Layer names, already validated by `normalize_layers`.
+        dest_dir: Directory the pairs are written into; created if absent.
+
+    Returns:
+        A mapping of layer name to the extracted `.flt` path, holding
+            only the layers the archive actually carried.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    extracted: dict[str, Path] = {}
+    with zipfile.ZipFile(archive) as bundle:
+        available = set(bundle.namelist())
+        for layer in layers:
+            members = (f"{layer}.flt", f"{layer}.hdr")
+            if not available.issuperset(members):
+                logger.warning(
+                    f"ShakeMap archive {archive.name} carries no {layer!r} grid "
+                    f"(expected {members[0]} + {members[1]}) — skipping it."
+                )
+                continue
+            for member in members:
+                (dest_dir / member).write_bytes(bundle.read(member))
+            extracted[layer] = dest_dir / members[0]
+    return extracted
+
+
+def flt_to_geotiff(flt_path: Path, dest: Path) -> Path:
+    """Convert one ESRI float grid into a georeferenced GeoTIFF.
+
+    The `.hdr` sibling must sit next to `flt_path` — GDAL's `EHdr`
+    driver reads the two together. The header defines the grid's origin,
+    cell size, and nodata value but no projection, so `EPSG:4326` is
+    assigned before writing.
+
+    Args:
+        flt_path: The extracted `.flt` payload.
+        dest: Destination GeoTIFF path; parents are created.
+
+    Returns:
+        `dest`, for chaining.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dataset = Dataset.read_file(str(flt_path), read_only=False)
+    dataset.set_crs(epsg=SHAKEMAP_EPSG)
+    dataset.to_file(str(dest))
+    return dest

--- a/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
@@ -32,6 +32,7 @@ earthlens only decides *which* grid to ask for.
 from __future__ import annotations
 
 import re
+import shutil
 import zipfile
 from collections.abc import Iterable, Mapping
 from pathlib import Path
@@ -81,10 +82,22 @@ SHAKEMAP_EPSG = 4326
 #: Key of the raster bundle inside a ShakeMap product's `contents` map.
 RASTER_CONTENT_KEY = "download/raster.zip"
 
+#: Ceiling on a single decompressed archive member. A real ShakeMap grid is
+#: well under a megabyte (a 30 arc-second raster over one event's footprint),
+#: so this is generous for legitimate data while refusing an archive whose
+#: declared expansion is absurd rather than reading it into memory first.
+MAX_MEMBER_BYTES = 256 * 1024 * 1024
+
 # The QuakeML resource identifier USGS returns embeds the ComCat id as a
 # query parameter, e.g.
 # `quakeml:earthquake.usgs.gov/fdsnws/event/1/query?eventid=us6000jlqa&format=quakeml`.
-_EVENT_ID_PATTERN = re.compile(r"[?&]eventid=([A-Za-z0-9_.-]+)")
+#
+# The captured id becomes a directory name, so the character class deliberately
+# excludes `.`: a capture of `.` or `..` would resolve the event directory to
+# somewhere the caller never asked for. Real ComCat ids are a network code plus
+# alphanumerics (`us6000jlqa`, `nc73872510`, `official20110311054624120_30`) and
+# never contain a dot, so excluding it costs nothing.
+_EVENT_ID_PATTERN = re.compile(r"[?&]eventid=([A-Za-z0-9_-]+)")
 
 
 def parse_comcat_id(event_id: str | None) -> str | None:
@@ -118,6 +131,16 @@ def parse_comcat_id(event_id: str | None) -> str | None:
             True
 
             ```
+        - A degenerate id that would escape the output directory is refused:
+            ```python
+            >>> from earthlens.fdsn._helpers import parse_comcat_id
+            >>> parse_comcat_id("quakeml:x?eventid=..&format=quakeml") is None
+            True
+
+            ```
+
+    See Also:
+        detail_url: Builds the request URL from the id returned here.
     """
     if not event_id:
         return None
@@ -137,6 +160,8 @@ def normalize_layers(layers: Iterable[str] | None) -> tuple[str, ...]:
         The requested layers as a tuple, in first-seen order.
 
     Raises:
+        TypeError: If a bare string is passed. A string is iterable, so
+            it would otherwise be read one character at a time.
         ValueError: If a name is not one of `SHAKEMAP_LAYERS`, or if an
             explicitly empty selection is passed — asking for the
             ShakeMap side-output and then for no layer of it is a
@@ -163,6 +188,11 @@ def normalize_layers(layers: Iterable[str] | None) -> tuple[str, ...]:
     """
     if layers is None:
         return DEFAULT_SHAKEMAP_LAYERS
+    if isinstance(layers, str):
+        raise TypeError(
+            f"shakemap_layers must be a sequence of layer names, not the bare "
+            f"string {layers!r} — pass [{layers!r}] for a single layer."
+        )
     requested = list(layers)
     if not requested:
         raise ValueError(
@@ -284,7 +314,7 @@ def extract_layers(
     Examples:
         - Pull one layer out of a two-layer archive:
             ```python
-            >>> import tempfile, zipfile
+            >>> import shutil, tempfile, zipfile
             >>> from pathlib import Path
             >>> from earthlens.fdsn._helpers import extract_layers
             >>> workspace = Path(tempfile.mkdtemp())
@@ -300,11 +330,12 @@ def extract_layers(
             'mmi_mean.flt'
             >>> (workspace / "out" / "mmi_mean.hdr").is_file()
             True
+            >>> shutil.rmtree(workspace)
 
             ```
         - A layer the archive lacks is skipped rather than raised:
             ```python
-            >>> import tempfile, zipfile
+            >>> import shutil, tempfile, zipfile
             >>> from pathlib import Path
             >>> from earthlens.fdsn._helpers import extract_layers
             >>> workspace = Path(tempfile.mkdtemp())
@@ -314,6 +345,7 @@ def extract_layers(
             ...     bundle.writestr("mmi_mean.hdr", "NROWS 1")
             >>> sorted(extract_layers(archive, ["mmi_mean", "pgv_std"], workspace / "out"))
             ['mmi_mean']
+            >>> shutil.rmtree(workspace)
 
             ```
 
@@ -333,8 +365,23 @@ def extract_layers(
                     f"(expected {members[0]} + {members[1]}) — skipping it."
                 )
                 continue
+            oversized = [
+                name
+                for name in members
+                if bundle.getinfo(name).file_size > MAX_MEMBER_BYTES
+            ]
+            if oversized:
+                logger.warning(
+                    f"ShakeMap archive {archive.name} declares {oversized} larger "
+                    f"than {MAX_MEMBER_BYTES} bytes — refusing {layer!r}."
+                )
+                continue
             for member in members:
-                (dest_dir / member).write_bytes(bundle.read(member))
+                with (
+                    bundle.open(member) as source,
+                    (dest_dir / member).open("wb") as target,
+                ):
+                    shutil.copyfileobj(source, target)
             extracted[layer] = dest_dir / members[0]
     return extracted
 
@@ -347,6 +394,13 @@ def flt_to_geotiff(flt_path: Path, dest: Path) -> Path:
     cell size, and nodata value but no projection, so `EPSG:4326` is
     assigned before writing.
 
+    Assigning it means opening the source read-write, and the `EHdr`
+    driver persists a projection by dropping a `<basename>.prj` beside
+    the grid. That mutation is deliberate but confined: callers pass a
+    grid they extracted into a scratch directory, which is discarded
+    wholesale, so nothing GDAL writes alongside the source reaches the
+    caller's output.
+
     Args:
         flt_path: The extracted `.flt` payload.
         dest: Destination GeoTIFF path; parents are created.
@@ -357,7 +411,7 @@ def flt_to_geotiff(flt_path: Path, dest: Path) -> Path:
     Examples:
         - Convert a small grid and read back its georeferencing:
             ```python
-            >>> import struct, tempfile
+            >>> import shutil, struct, tempfile
             >>> from pathlib import Path
             >>> from earthlens.fdsn._helpers import flt_to_geotiff
             >>> workspace = Path(tempfile.mkdtemp())
@@ -382,6 +436,8 @@ def flt_to_geotiff(flt_path: Path, dest: Path) -> Path:
             4326
             >>> converted.rows, converted.columns
             (2, 2)
+            >>> del converted
+            >>> shutil.rmtree(workspace)
 
             ```
 
@@ -390,7 +446,19 @@ def flt_to_geotiff(flt_path: Path, dest: Path) -> Path:
         SHAKEMAP_EPSG: The CRS assigned during the conversion.
     """
     dest.parent.mkdir(parents=True, exist_ok=True)
-    dataset = Dataset.read_file(str(flt_path), read_only=False)
-    dataset.set_crs(epsg=SHAKEMAP_EPSG)
-    dataset.to_file(str(dest))
+    # Written to a sibling and renamed on success. `Dataset.to_file` writes
+    # straight to the path it is given, so without this a run interrupted
+    # mid-write (Ctrl-C, a full disk) would leave a non-empty but unreadable
+    # `.tif` — and the caller's skip-if-present check, which can only ask
+    # whether a file exists and is non-empty, would honour it forever. The
+    # staged name keeps the `.tif` suffix so GDAL still infers the driver.
+    staged = dest.with_name(f".{dest.stem}.partial.tif")
+    try:
+        dataset = Dataset.read_file(str(flt_path), read_only=False)
+        dataset.set_crs(epsg=SHAKEMAP_EPSG)
+        dataset.to_file(str(staged))
+        del dataset
+        staged.replace(dest)
+    finally:
+        staged.unlink(missing_ok=True)
     return dest

--- a/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
@@ -518,8 +518,10 @@ def read_manifest(dest_dir: Path) -> dict[str, Any] | None:
 
     Returns:
         The parsed manifest, or `None` when the event has never been
-            fetched or its manifest is unreadable — both of which mean
-            "fetch it again".
+            fetched, its manifest is unreadable, or the payload does not
+            match `MANIFEST_SCHEMA` — every one of which means "fetch it
+            again". A structurally wrong manifest is reported and treated
+            as absent rather than raising, so the next write repairs it.
 
     Examples:
         - A directory with no manifest reads as `None`:
@@ -543,6 +545,26 @@ def read_manifest(dest_dir: Path) -> dict[str, Any] | None:
             >>> shutil.rmtree(workspace)
 
             ```
+        - A manifest from a different layout version reads as absent, so the
+          event is refetched rather than half-understood:
+            ```python
+            >>> import json, shutil, tempfile
+            >>> from pathlib import Path
+            >>> from earthlens.fdsn._helpers import MANIFEST_NAME, read_manifest
+            >>> workspace = Path(tempfile.mkdtemp())
+            >>> _ = (workspace / MANIFEST_NAME).write_text(
+            ...     json.dumps({"schema": 99, "requested": [], "produced": [],
+            ...                 "checked": 0.0})
+            ... )
+            >>> read_manifest(workspace) is None
+            True
+            >>> shutil.rmtree(workspace)
+
+            ```
+
+    See Also:
+        write_manifest: Produces the file read here.
+        MANIFEST_SCHEMA: The layout version this accepts.
     """
     path = dest_dir / MANIFEST_NAME
     if not path.is_file():

--- a/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
@@ -193,6 +193,10 @@ def normalize_layers(layers: Iterable[str] | None) -> tuple[str, ...]:
             ValueError: unknown ShakeMap layer(s): ['mmi_median']. Choose from [...].
 
             ```
+
+    See Also:
+        SHAKEMAP_LAYERS: The fourteen names accepted here.
+        DEFAULT_SHAKEMAP_LAYERS: What `None` resolves to.
     """
     if layers is None:
         return DEFAULT_SHAKEMAP_LAYERS
@@ -289,6 +293,10 @@ def shakemap_raster_url(detail: Mapping[str, Any]) -> str | None:
             True
 
             ```
+
+    See Also:
+        detail_url: Addresses the document this walks.
+        RASTER_CONTENT_KEY: The `contents` key looked up here.
     """
     properties = detail.get("properties") or {}
     products = properties.get("products") or {}
@@ -549,6 +557,56 @@ def write_manifest(
         produced: The layers the archive actually carried. Empty when the
             event publishes no ShakeMap at all, which is itself worth
             recording so the detail request is not repeated.
+
+    Returns:
+        None: The manifest is written to `dest_dir` as a side effect.
+
+    Examples:
+        - Record a fetch that produced one of the two requested grids:
+            ```python
+            >>> import shutil, tempfile
+            >>> from pathlib import Path
+            >>> from earthlens.fdsn._helpers import read_manifest, write_manifest
+            >>> workspace = Path(tempfile.mkdtemp())
+            >>> write_manifest(workspace, ["mmi_mean", "pga_mean"], ["mmi_mean"])
+            >>> manifest = read_manifest(workspace)
+            >>> manifest["requested"]
+            ['mmi_mean', 'pga_mean']
+            >>> manifest["produced"]
+            ['mmi_mean']
+            >>> shutil.rmtree(workspace)
+
+            ```
+        - Record an event that publishes no ShakeMap, so the next run can
+          skip it without re-requesting its detail document:
+            ```python
+            >>> import shutil, tempfile
+            >>> from pathlib import Path
+            >>> from earthlens.fdsn._helpers import read_manifest, write_manifest
+            >>> workspace = Path(tempfile.mkdtemp())
+            >>> write_manifest(workspace, ["mmi_mean"], [])
+            >>> read_manifest(workspace)["produced"]
+            []
+            >>> shutil.rmtree(workspace)
+
+            ```
+        - The event directory is created if it does not exist yet:
+            ```python
+            >>> import shutil, tempfile
+            >>> from pathlib import Path
+            >>> from earthlens.fdsn._helpers import MANIFEST_NAME, write_manifest
+            >>> workspace = Path(tempfile.mkdtemp())
+            >>> event_dir = workspace / "us6000jlqa"
+            >>> write_manifest(event_dir, ["mmi_mean"], ["mmi_mean"])
+            >>> (event_dir / MANIFEST_NAME).is_file()
+            True
+            >>> shutil.rmtree(workspace)
+
+            ```
+
+    See Also:
+        read_manifest: Reads back what this records.
+        MANIFEST_NAME: The filename written inside `dest_dir`.
     """
     dest_dir.mkdir(parents=True, exist_ok=True)
     payload = {"requested": sorted(set(requested)), "produced": sorted(set(produced))}

--- a/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
@@ -31,6 +31,7 @@ earthlens only decides *which* grid to ask for.
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import zipfile
@@ -72,7 +73,7 @@ SHAKEMAP_LAYERS: tuple[str, ...] = tuple(
 
 #: Written when the caller asks for no layer explicitly. Macroseismic
 #: intensity is the headline shaking field, and one layer per event keeps
-#: a multi-event query from writing fourteen rasters and ~8.5 MB apiece.
+#: a multi-event query from writing fourteen rasters and several megabytes apiece.
 DEFAULT_SHAKEMAP_LAYERS: tuple[str, ...] = ("mmi_mean",)
 
 #: The grids are lon/lat WGS84 but their `.hdr` headers say no such
@@ -82,11 +83,15 @@ SHAKEMAP_EPSG = 4326
 #: Key of the raster bundle inside a ShakeMap product's `contents` map.
 RASTER_CONTENT_KEY = "download/raster.zip"
 
+#: Name of the per-event manifest recording what its archive yielded.
+MANIFEST_NAME = ".shakemap.json"
+
 #: Ceiling on a single decompressed archive member. A real ShakeMap grid is
-#: well under a megabyte (a 30 arc-second raster over one event's footprint),
-#: so this is generous for legitimate data while refusing an archive whose
-#: declared expansion is absurd rather than reading it into memory first.
-MAX_MEMBER_BYTES = 256 * 1024 * 1024
+#: well under a megabyte (a 30 arc-second raster over one event's footprint,
+#: ~810 KB for the 2023 Kahramanmaras event), so 64 MB leaves two orders of
+#: magnitude of headroom for legitimate data while refusing an archive whose
+#: declared expansion is absurd, before any of it is written.
+MAX_MEMBER_BYTES = 64 * 1024 * 1024
 
 # The QuakeML resource identifier USGS returns embeds the ComCat id as a
 # query parameter, e.g.
@@ -97,7 +102,10 @@ MAX_MEMBER_BYTES = 256 * 1024 * 1024
 # somewhere the caller never asked for. Real ComCat ids are a network code plus
 # alphanumerics (`us6000jlqa`, `nc73872510`, `official20110311054624120_30`) and
 # never contain a dot, so excluding it costs nothing.
-_EVENT_ID_PATTERN = re.compile(r"[?&]eventid=([A-Za-z0-9_-]+)")
+# Length-bounded as well: the id becomes a directory name, and a pathological
+# identifier should be refused rather than handed to the filesystem. Real ComCat
+# ids are well under 40 characters (`official20110311054624120_30` is 28).
+_EVENT_ID_PATTERN = re.compile(r"[?&]eventid=([A-Za-z0-9_-]{1,64})(?:&|$)")
 
 
 def parse_comcat_id(event_id: str | None) -> str | None:
@@ -454,11 +462,96 @@ def flt_to_geotiff(flt_path: Path, dest: Path) -> Path:
     # staged name keeps the `.tif` suffix so GDAL still infers the driver.
     staged = dest.with_name(f".{dest.stem}.partial.tif")
     try:
-        dataset = Dataset.read_file(str(flt_path), read_only=False)
-        dataset.set_crs(epsg=SHAKEMAP_EPSG)
-        dataset.to_file(str(staged))
-        del dataset
+        # The context manager, not a trailing `del`: on failure the exception's
+        # traceback keeps this frame — and any local still bound to the dataset
+        # — alive, so GDAL's handle on the grid outlives the call. Windows then
+        # refuses to unlink the file and the caller's scratch directory survives
+        # inside the user's output. `__exit__` closes it on both paths.
+        with Dataset.read_file(str(flt_path), read_only=False) as dataset:
+            dataset.set_crs(epsg=SHAKEMAP_EPSG)
+            dataset.to_file(str(staged))
+        if not staged.is_file():
+            raise RuntimeError(
+                f"converting {flt_path.name} produced no output at {staged} — "
+                "refusing to publish a missing raster."
+            )
         staged.replace(dest)
     finally:
+        # Only ever removes the staged name. A successful `replace` has already
+        # moved it, so this cannot touch a finished output.
         staged.unlink(missing_ok=True)
     return dest
+
+
+def read_manifest(dest_dir: Path) -> dict[str, Any] | None:
+    """Read an event directory's ShakeMap manifest, if it has one.
+
+    Args:
+        dest_dir: The event's output directory.
+
+    Returns:
+        The parsed manifest, or `None` when the event has never been
+            fetched or its manifest is unreadable — both of which mean
+            "fetch it again".
+
+    Examples:
+        - A directory with no manifest reads as `None`:
+            ```python
+            >>> import tempfile
+            >>> from pathlib import Path
+            >>> from earthlens.fdsn._helpers import read_manifest
+            >>> read_manifest(Path(tempfile.mkdtemp())) is None
+            True
+
+            ```
+        - A written manifest round-trips:
+            ```python
+            >>> import shutil, tempfile
+            >>> from pathlib import Path
+            >>> from earthlens.fdsn._helpers import read_manifest, write_manifest
+            >>> workspace = Path(tempfile.mkdtemp())
+            >>> write_manifest(workspace, ["mmi_mean", "pga_mean"], ["mmi_mean"])
+            >>> read_manifest(workspace)["produced"]
+            ['mmi_mean']
+            >>> shutil.rmtree(workspace)
+
+            ```
+    """
+    path = dest_dir / MANIFEST_NAME
+    if not path.is_file():
+        return None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        logger.warning(f"unreadable ShakeMap manifest at {path} — refetching.")
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def write_manifest(
+    dest_dir: Path,
+    requested: Iterable[str],
+    produced: Iterable[str],
+) -> None:
+    """Record what one event's archive actually yielded.
+
+    Without this, a rerun cannot tell an event it has never fetched from
+    one whose archive simply does not carry a requested layer. The
+    skip-if-present check compares against the layers that *exist*, so an
+    archive permanently missing a grid stops being re-downloaded on every
+    run.
+
+    Args:
+        dest_dir: The event's output directory; created if absent.
+        requested: The layers this call asked for. Recorded so a later
+            call asking for *more* layers refetches rather than reusing a
+            narrower result.
+        produced: The layers the archive actually carried. Empty when the
+            event publishes no ShakeMap at all, which is itself worth
+            recording so the detail request is not repeated.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"requested": sorted(set(requested)), "produced": sorted(set(produced))}
+    (dest_dir / MANIFEST_NAME).write_text(
+        json.dumps(payload, indent=2), encoding="utf-8"
+    )

--- a/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
@@ -196,10 +196,25 @@ def detail_url(comcat_id: str) -> str:
         - Address one event's detail document:
             ```python
             >>> from earthlens.fdsn._helpers import detail_url
-            >>> detail_url("us6000jlqa").endswith("eventid=us6000jlqa")
-            True
+            >>> detail_url("us6000jlqa")
+            'https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&eventid=us6000jlqa'
 
             ```
+        - Chain it onto an id recovered from an event row:
+            ```python
+            >>> from earthlens.fdsn._helpers import detail_url, parse_comcat_id
+            >>> row_id = (
+            ...     "quakeml:earthquake.usgs.gov/fdsnws/event/1/query"
+            ...     "?eventid=nc73872510&format=quakeml"
+            ... )
+            >>> detail_url(parse_comcat_id(row_id)).split("eventid=")[1]
+            'nc73872510'
+
+            ```
+
+    See Also:
+        parse_comcat_id: Recovers the id this URL is built from.
+        shakemap_raster_url: Walks the document this URL returns.
     """
     query = urlencode({"format": "geojson", "eventid": comcat_id})
     return f"{COMCAT_DETAIL_URL}?{query}"
@@ -265,6 +280,46 @@ def extract_layers(
     Returns:
         A mapping of layer name to the extracted `.flt` path, holding
             only the layers the archive actually carried.
+
+    Examples:
+        - Pull one layer out of a two-layer archive:
+            ```python
+            >>> import tempfile, zipfile
+            >>> from pathlib import Path
+            >>> from earthlens.fdsn._helpers import extract_layers
+            >>> workspace = Path(tempfile.mkdtemp())
+            >>> archive = workspace / "raster.zip"
+            >>> with zipfile.ZipFile(archive, "w") as bundle:
+            ...     for layer in ("mmi_mean", "pga_mean"):
+            ...         bundle.writestr(f"{layer}.flt", bytes(4))
+            ...         bundle.writestr(f"{layer}.hdr", "NROWS 1")
+            >>> found = extract_layers(archive, ["mmi_mean"], workspace / "out")
+            >>> sorted(found)
+            ['mmi_mean']
+            >>> found["mmi_mean"].name
+            'mmi_mean.flt'
+            >>> (workspace / "out" / "mmi_mean.hdr").is_file()
+            True
+
+            ```
+        - A layer the archive lacks is skipped rather than raised:
+            ```python
+            >>> import tempfile, zipfile
+            >>> from pathlib import Path
+            >>> from earthlens.fdsn._helpers import extract_layers
+            >>> workspace = Path(tempfile.mkdtemp())
+            >>> archive = workspace / "raster.zip"
+            >>> with zipfile.ZipFile(archive, "w") as bundle:
+            ...     bundle.writestr("mmi_mean.flt", bytes(4))
+            ...     bundle.writestr("mmi_mean.hdr", "NROWS 1")
+            >>> sorted(extract_layers(archive, ["mmi_mean", "pgv_std"], workspace / "out"))
+            ['mmi_mean']
+
+            ```
+
+    See Also:
+        normalize_layers: Validates the layer names passed here.
+        flt_to_geotiff: Converts an extracted `.flt` into a GeoTIFF.
     """
     dest_dir.mkdir(parents=True, exist_ok=True)
     extracted: dict[str, Path] = {}
@@ -298,6 +353,41 @@ def flt_to_geotiff(flt_path: Path, dest: Path) -> Path:
 
     Returns:
         `dest`, for chaining.
+
+    Examples:
+        - Convert a small grid and read back its georeferencing:
+            ```python
+            >>> import struct, tempfile
+            >>> from pathlib import Path
+            >>> from earthlens.fdsn._helpers import flt_to_geotiff
+            >>> workspace = Path(tempfile.mkdtemp())
+            >>> header = [
+            ...     "BYTEORDER  LSBFIRST", "LAYOUT  BIL", "NROWS  2", "NCOLS  2",
+            ...     "NBANDS  1", "NBITS  32", "BANDROWBYTES  8", "TOTALROWBYTES  8",
+            ...     "PIXELTYPE  FLOAT", "ULXMAP  35.0", "ULYMAP  39.0",
+            ...     "XDIM  0.5", "YDIM  0.5", "NODATA  999.0",
+            ... ]
+            >>> _ = (workspace / "mmi_mean.hdr").write_text(chr(10).join(header))
+            >>> _ = (workspace / "mmi_mean.flt").write_bytes(
+            ...     struct.pack("<4f", 5.0, 6.0, 7.0, 8.0)
+            ... )
+            >>> written = flt_to_geotiff(
+            ...     workspace / "mmi_mean.flt", workspace / "mmi_mean.tif"
+            ... )
+            >>> written.name
+            'mmi_mean.tif'
+            >>> from pyramids.dataset import Dataset
+            >>> converted = Dataset.read_file(str(written))
+            >>> converted.epsg
+            4326
+            >>> converted.rows, converted.columns
+            (2, 2)
+
+            ```
+
+    See Also:
+        extract_layers: Produces the `.flt` / `.hdr` pair this reads.
+        SHAKEMAP_EPSG: The CRS assigned during the conversion.
     """
     dest.parent.mkdir(parents=True, exist_ok=True)
     dataset = Dataset.read_file(str(flt_path), read_only=False)

--- a/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/_helpers.py
@@ -36,6 +36,7 @@ import re
 import shutil
 import zipfile
 from collections.abc import Iterable, Mapping
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlencode
@@ -86,6 +87,11 @@ RASTER_CONTENT_KEY = "download/raster.zip"
 #: Name of the per-event manifest recording what its archive yielded.
 MANIFEST_NAME = ".shakemap.json"
 
+#: Layout version of the manifest payload. A manifest written by a different
+#: version is treated as absent rather than guessed at, so the event is simply
+#: refetched — which is always safe, if occasionally wasteful.
+MANIFEST_SCHEMA = 1
+
 #: Ceiling on a single decompressed archive member. A real ShakeMap grid is
 #: well under a megabyte (a 30 arc-second raster over one event's footprint,
 #: ~810 KB for the 2023 Kahramanmaras event), so 64 MB leaves two orders of
@@ -105,6 +111,10 @@ MAX_MEMBER_BYTES = 64 * 1024 * 1024
 # Length-bounded as well: the id becomes a directory name, and a pathological
 # identifier should be refused rather than handed to the filesystem. Real ComCat
 # ids are well under 40 characters (`official20110311054624120_30` is 28).
+#
+# The capture must be terminated by `&` or the end of the string, so a value
+# carrying anything outside the character class is refused outright rather than
+# silently truncated to its leading run of legal characters.
 _EVENT_ID_PATTERN = re.compile(r"[?&]eventid=([A-Za-z0-9_-]{1,64})(?:&|$)")
 
 
@@ -214,8 +224,12 @@ def normalize_layers(layers: Iterable[str] | None) -> tuple[str, ...]:
         )
     unknown = [name for name in requested if name not in SHAKEMAP_LAYERS]
     if unknown:
+        # Rendered by repr and sorted as text: a mixed-type list would make a
+        # plain `sorted` raise TypeError, hiding the layer-name error behind an
+        # unrelated one.
+        rendered = sorted(repr(name) for name in unknown)
         raise ValueError(
-            f"unknown ShakeMap layer(s): {sorted(unknown)}. "
+            f"unknown ShakeMap layer(s): [{', '.join(rendered)}]. "
             f"Choose from {list(SHAKEMAP_LAYERS)}."
         )
     seen: dict[str, None] = {}
@@ -468,7 +482,10 @@ def flt_to_geotiff(flt_path: Path, dest: Path) -> Path:
     # `.tif` — and the caller's skip-if-present check, which can only ask
     # whether a file exists and is non-empty, would honour it forever. The
     # staged name keeps the `.tif` suffix so GDAL still infers the driver.
-    staged = dest.with_name(f".{dest.stem}.partial.tif")
+    # Staged beside the *source* grid — which the caller keeps in a scratch
+    # directory — rather than beside the destination, so an interrupted run
+    # leaves nothing at all in the user's output folder.
+    staged = flt_path.parent / f".{dest.stem}.partial.tif"
     try:
         # The context manager, not a trailing `del`: on failure the exception's
         # traceback keeps this frame — and any local still bound to the dataset
@@ -485,9 +502,11 @@ def flt_to_geotiff(flt_path: Path, dest: Path) -> Path:
             )
         staged.replace(dest)
     finally:
-        # Only ever removes the staged name. A successful `replace` has already
-        # moved it, so this cannot touch a finished output.
-        staged.unlink(missing_ok=True)
+        # Only ever removes the staged name, and never at the cost of the real
+        # error: a failed cleanup here would otherwise replace the exception
+        # that explains why the conversion failed.
+        with suppress(OSError):
+            staged.unlink(missing_ok=True)
     return dest
 
 
@@ -533,13 +552,46 @@ def read_manifest(dest_dir: Path) -> dict[str, Any] | None:
     except (OSError, ValueError):
         logger.warning(f"unreadable ShakeMap manifest at {path} — refetching.")
         return None
-    return loaded if isinstance(loaded, dict) else None
+    if not _is_valid_manifest(loaded):
+        # Structurally wrong, not merely unreadable: treated as absent so the
+        # event refetches and the next write repairs the file, rather than
+        # letting a bad type escape as an error from somewhere downstream.
+        logger.warning(f"malformed ShakeMap manifest at {path} — refetching.")
+        return None
+    validated: dict[str, Any] = loaded
+    return validated
+
+
+def _is_valid_manifest(loaded: object) -> bool:
+    """Report whether a parsed manifest has the shape this version writes.
+
+    Args:
+        loaded: The object `json.loads` produced from the manifest file.
+
+    Returns:
+        `True` when every field is present with the expected type and the
+            schema version matches, `False` otherwise.
+    """
+    if not isinstance(loaded, dict):
+        return False
+    if loaded.get("schema") != MANIFEST_SCHEMA:
+        return False
+    for key in ("requested", "produced"):
+        value = loaded.get(key)
+        if not isinstance(value, list) or not all(
+            isinstance(item, str) for item in value
+        ):
+            return False
+    checked = loaded.get("checked")
+    return isinstance(checked, (int, float))
 
 
 def write_manifest(
     dest_dir: Path,
     requested: Iterable[str],
     produced: Iterable[str],
+    checked: float = 0.0,
+    product_version: str | None = None,
 ) -> None:
     """Record what one event's archive actually yielded.
 
@@ -556,7 +608,14 @@ def write_manifest(
             narrower result.
         produced: The layers the archive actually carried. Empty when the
             event publishes no ShakeMap at all, which is itself worth
-            recording so the detail request is not repeated.
+            recording so the detail request is not repeated. Merged with
+            anything already recorded rather than replacing it.
+        checked: POSIX timestamp of this check, used to age out a negative
+            result. `0.0` (the default) reads as "long ago", so an entry
+            written without one is re-checked.
+        product_version: The ShakeMap product's `updateTime`, when the detail
+            document supplied one. Recorded so a later version can tell a
+            revised grid from the one on disk; nothing reads it yet.
 
     Returns:
         None: The manifest is written to `dest_dir` as a side effect.
@@ -609,7 +668,70 @@ def write_manifest(
         MANIFEST_NAME: The filename written inside `dest_dir`.
     """
     dest_dir.mkdir(parents=True, exist_ok=True)
-    payload = {"requested": sorted(set(requested)), "produced": sorted(set(produced))}
-    (dest_dir / MANIFEST_NAME).write_text(
-        json.dumps(payload, indent=2), encoding="utf-8"
-    )
+    # Merged with whatever is already recorded, never replaced. Narrowing the
+    # requested layers on a later run would otherwise drop the record of
+    # rasters still sitting on disk, so the next widening run would refetch an
+    # archive it already has.
+    existing = read_manifest(dest_dir) or {}
+    payload = {
+        "schema": MANIFEST_SCHEMA,
+        "requested": sorted(set(existing.get("requested", [])) | set(requested)),
+        "produced": sorted(set(existing.get("produced", [])) | set(produced)),
+        "checked": checked,
+        "product_version": product_version,
+    }
+    # Staged and renamed, like the rasters it describes: a manifest truncated
+    # by an interrupted write would otherwise be read back as malformed.
+    staged = dest_dir / f".{MANIFEST_NAME}.partial"
+    try:
+        staged.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        staged.replace(dest_dir / MANIFEST_NAME)
+    finally:
+        with suppress(OSError):
+            staged.unlink(missing_ok=True)
+
+
+def shakemap_product_version(detail: Mapping[str, Any]) -> str | None:
+    """Return the ShakeMap product's `updateTime`, when the document has one.
+
+    ComCat republishes ShakeMaps — the 2023 Kahramanmaras grid is on its
+    twelfth version, last updated in 2025 — so the value is recorded
+    alongside a fetch to give a later version something to compare against.
+
+    Args:
+        detail: A parsed ComCat event-detail GeoJSON document.
+
+    Returns:
+        The `updateTime` as a string, or `None` when the event has no
+            ShakeMap product or the product omits it.
+
+    Examples:
+        - Read the version off a minimal detail document:
+            ```python
+            >>> from earthlens.fdsn._helpers import shakemap_product_version
+            >>> shakemap_product_version(
+            ...     {"properties": {"products": {"shakemap": [
+            ...         {"updateTime": 1756575631263}
+            ...     ]}}}
+            ... )
+            '1756575631263'
+
+            ```
+        - An event with no ShakeMap yields `None`:
+            ```python
+            >>> from earthlens.fdsn._helpers import shakemap_product_version
+            >>> shakemap_product_version({"properties": {"products": {}}}) is None
+            True
+
+            ```
+
+    See Also:
+        write_manifest: Records the value returned here.
+    """
+    properties = detail.get("properties") or {}
+    products = properties.get("products") or {}
+    entries = products.get("shakemap") or []
+    if not entries:
+        return None
+    update_time = (entries[0] or {}).get("updateTime")
+    return None if update_time is None else str(update_time)

--- a/libs/providers/hazards/src/earthlens/fdsn/backend.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/backend.py
@@ -43,6 +43,7 @@ day/month — so `temporal_resolution` carries the sentinel `"all"`.
 from __future__ import annotations
 
 import shutil
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -86,8 +87,8 @@ _SHAKEMAP_DIR = "shakemap"
 _STAGING_DIR = "_staging"
 
 #: Default ceiling on how many events one call fetches a ShakeMap for.
-#: Each event is a separate ComCat request plus an ~8.5 MB archive, so an
-#: unbounded window is gigabytes; 100 events is roughly a gigabyte, which is
+#: Each event is a separate ComCat request plus a multi-megabyte archive, so an
+#: unbounded window is gigabytes; 100 events is a gigabyte or two, which is
 #: a defensible accident rather than a catastrophic one.
 _DEFAULT_MAX_SHAKEMAP_EVENTS = 100
 
@@ -96,6 +97,11 @@ _DEFAULT_MAX_SHAKEMAP_EVENTS = 100
 #: itself was a single call; USGS publishes no rate limit, and this is a
 #: politeness floor rather than a documented requirement.
 _COMCAT_MIN_INTERVAL = 0.2
+
+#: `(connect, read)` budget for a ComCat request. The read half is generous
+#: because the archive is several megabytes; the connect half fails a dead
+#: host quickly instead of stalling a long batch on its first event.
+_COMCAT_TIMEOUT = (10.0, 120.0)
 
 
 class FDSN(AbstractDataSource):
@@ -215,7 +221,7 @@ class FDSN(AbstractDataSource):
                 **USGS only** — ShakeMap is a ComCat product, not part
                 of the FDSN event standard, so a non-USGS network in the
                 same request contributes events but no rasters. Costs
-                one extra ComCat request plus an ~8.5 MB archive per
+                one extra ComCat request plus a multi-megabyte archive per
                 event, so bound the event count with `limit=` before
                 turning it on for a busy window; beyond
                 `max_shakemap_events` the side-output stops and says how
@@ -225,11 +231,17 @@ class FDSN(AbstractDataSource):
             max_shakemap_events: Ceiling on how many events one call
                 will fetch a ShakeMap for, guarding against a broad
                 query quietly pulling gigabytes (each event is a
-                separate request plus an ~8.5 MB archive). Events past
+                separate request plus a multi-megabyte archive). Events past
                 the ceiling are skipped with a warning naming the count
-                — never silently. Raise it deliberately for a large
-                job, or narrow the query with `limit=` /
-                `min_magnitude=`.
+                — never silently. The events kept are the first
+                `max_shakemap_events` in the order the networks returned
+                them, which `orderby=` controls (`"magnitude"` puts the
+                largest first, the usual intent when capping). Because
+                an event already on disk is skipped without spending
+                budget, re-running the same request walks further
+                through the list each time. Raise the ceiling
+                deliberately for a large job, or narrow the query with
+                `limit=` / `min_magnitude=`.
             shakemap_layers: Which ShakeMap grids to write when
                 `with_shakemap` is on. `None` (the default) writes
                 `["mmi_mean"]` — macroseismic intensity, the headline
@@ -367,7 +379,9 @@ class FDSN(AbstractDataSource):
                 provider.
         """
         products: list[RemoteProduct] = []
-        for key in self.vars:
+        # De-duplicated, order preserved: a repeated key would otherwise issue
+        # the same query twice and union the same events into the result.
+        for key in dict.fromkeys(self.vars):
             provider: Provider = self._catalog.get_provider(key)
             products.append(
                 RemoteProduct(
@@ -559,7 +573,9 @@ class FDSN(AbstractDataSource):
                 Leave it at `"warn"` unless a missing raster should
                 genuinely abort the request.
             force: Refetch a ShakeMap whose GeoTIFFs are already on
-                disk instead of reusing them. The rasters are written
+                disk instead of reusing them. A `download()` argument,
+                not a constructor one — `EarthLens(...).download(force=True)`,
+                not `EarthLens(force=True, ...)`. The rasters are written
                 atomically, so a present file is a finished one and the
                 default reuse is safe; this is the escape hatch for a
                 file damaged after the fact, or for picking up a
@@ -570,7 +586,9 @@ class FDSN(AbstractDataSource):
                 than a total across networks — and accepted here so it can be
                 passed through `EarthLens(...).download(limit=...)` like the
                 other bounded backends. `None` (the default) keeps whatever the
-                constructor set.
+                constructor set — note that a value passed here is **sticky**:
+                it replaces the constructor's for this and every later call on
+                the same instance, as `force=` and `errors=` do not.
 
         Returns:
             FeatureCollection: The row-wise union of every requested
@@ -653,8 +671,16 @@ class FDSN(AbstractDataSource):
             # the whole batch; retrying transport errors matches flodis/hanze.
             # The default user-agent is already `earthlens/{version}`.
             self._http = HttpClient(
+                timeout=_COMCAT_TIMEOUT,
                 min_interval=_COMCAT_MIN_INTERVAL,
-                retry_on_exceptions=(requests.ConnectionError, requests.Timeout),
+                # ChunkedEncodingError is the one a multi-megabyte body actually hits:
+                # the connection survives the handshake and dies mid-stream, which
+                # is neither a ConnectionError nor a Timeout.
+                retry_on_exceptions=(
+                    requests.ConnectionError,
+                    requests.Timeout,
+                    requests.exceptions.ChunkedEncodingError,
+                ),
             )
         return self._http
 
@@ -668,7 +694,15 @@ class FDSN(AbstractDataSource):
         built per call and used for a bounded burst.
         """
         if self._http is not None:
-            self._http.session.close()
+            # `session` is annotated `requests.Session`, but `HttpClient`
+            # accepts any session-like object and `RequestsGet` — the
+            # per-call adapter earthlens.testing swaps in as the default
+            # transport — has no `close()`. Closing unconditionally therefore
+            # fails against a perfectly valid transport, which is why this is
+            # a probe rather than a direct call.
+            closer = getattr(self._http.session, "close", None)
+            if callable(closer):
+                closer()
             self._http = None
 
     def _download_shakemaps(
@@ -718,7 +752,7 @@ class FDSN(AbstractDataSource):
                 f"with_shakemap=True matched {len(event_ids)} USGS events, over "
                 f"the max_shakemap_events={self._max_shakemap_events} ceiling: "
                 f"fetching the first {self._max_shakemap_events} and skipping "
-                f"{dropped}. Each event costs a request plus an ~8.5 MB archive. "
+                f"{dropped}. Each event costs a request plus a multi-megabyte archive. "
                 "Raise max_shakemap_events= to take them all, or narrow the "
                 "query with limit= / min_magnitude=."
             )
@@ -739,6 +773,53 @@ class FDSN(AbstractDataSource):
             on_failure=lambda _event_id, _exc: [],
         )
         return [path for paths in results for path in paths]
+
+    def _reuse_existing(self, dest_dir: Path, comcat_id: str) -> list[Path] | None:
+        """Return an event's cached rasters, or `None` to fetch it again.
+
+        Reuse is decided from the event's manifest rather than from the
+        requested layer names, because an archive need not carry every
+        layer that was asked for. Without the manifest, an event whose
+        archive permanently lacks one requested grid could never satisfy
+        an "all requested rasters present" check and would re-download
+        its multi-megabyte archive on every single run.
+
+        Args:
+            dest_dir: The event's output directory.
+            comcat_id: The event's ComCat id, for the log line.
+
+        Returns:
+            list[Path] | None: The rasters already on disk for this
+                request — possibly empty, when the event publishes no
+                ShakeMap at all — or `None` when the event must be
+                fetched.
+        """
+        if self._force:
+            return None
+        manifest = _helpers.read_manifest(dest_dir)
+        if manifest is None:
+            return None
+        # A previous call may have asked for fewer layers than this one. Reuse
+        # only when the earlier request covered everything now wanted.
+        previously = set(manifest.get("requested", []))
+        if not set(self._shakemap_layers).issubset(previously):
+            return None
+        produced = [
+            layer
+            for layer in self._shakemap_layers
+            if layer in manifest.get("produced", [])
+        ]
+        cached = [dest_dir / f"{layer}.tif" for layer in produced]
+        if not all(self._is_complete(path) for path in cached):
+            return None
+        if cached:
+            logger.info(f"ShakeMap for {comcat_id} already on disk — skipping.")
+        else:
+            logger.info(
+                f"event {comcat_id} is known to publish no ShakeMap raster for "
+                "the requested layer(s) — skipping."
+            )
+        return cached
 
     def _shakemap_for_event(
         self, event_id: str, progress_bar: bool = True
@@ -782,10 +863,9 @@ class FDSN(AbstractDataSource):
             )
             return []
 
-        expected = [dest_dir / f"{layer}.tif" for layer in self._shakemap_layers]
-        if all(self._is_complete(path, force=self._force) for path in expected):
-            logger.info(f"ShakeMap for {comcat_id} already on disk — skipping.")
-            return expected
+        reused = self._reuse_existing(dest_dir, comcat_id)
+        if reused is not None:
+            return reused
 
         detail = self._client().get_json(_helpers.detail_url(comcat_id))
         url = _helpers.shakemap_raster_url(detail)
@@ -793,6 +873,9 @@ class FDSN(AbstractDataSource):
             logger.info(
                 f"event {comcat_id} publishes no ShakeMap raster — skipping it."
             )
+            # Recorded so a re-run does not re-request this event's detail
+            # document only to reach the same conclusion.
+            _helpers.write_manifest(dest_dir, self._shakemap_layers, [])
             return []
 
         # Everything the fetch and the conversion touch is confined to a staging
@@ -816,12 +899,25 @@ class FDSN(AbstractDataSource):
                 written.append(
                     _helpers.flt_to_geotiff(flt_path, dest_dir / f"{layer}.tif")
                 )
+            # Only after every conversion succeeded: a manifest written on a
+            # partial failure would cache an incomplete result as final.
+            _helpers.write_manifest(dest_dir, self._shakemap_layers, list(extracted))
         finally:
             shutil.rmtree(staging, ignore_errors=True)
+            if staging.exists():
+                # Reported, not swallowed. On Windows this means something still
+                # holds a handle on an extracted grid; silently leaving it would
+                # accumulate one scratch directory per failed event inside the
+                # user's output.
+                logger.warning(
+                    f"could not remove the ShakeMap staging directory {staging} — "
+                    "it is left behind; remove it by hand if it persists."
+                )
             # An event whose archive was unusable leaves no rasters, and an
             # empty directory named after it reads like a successful fetch.
-            if dest_dir.is_dir() and not any(dest_dir.iterdir()):
-                dest_dir.rmdir()
+            with suppress(OSError):
+                if dest_dir.is_dir() and not any(dest_dir.iterdir()):
+                    dest_dir.rmdir()
         return written
 
     def _write(self, provider_key: str, collection: FeatureCollection) -> Path:

--- a/libs/providers/hazards/src/earthlens/fdsn/backend.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/backend.py
@@ -875,6 +875,10 @@ class FDSN(AbstractDataSource):
             dest_dir: The event's output directory.
             produced: The layers the archive actually carried.
             product_version: The ShakeMap product's `updateTime`, if known.
+
+        Returns:
+            None: The manifest is written as a side effect; a failure is
+                logged rather than raised.
         """
         try:
             _helpers.write_manifest(

--- a/libs/providers/hazards/src/earthlens/fdsn/backend.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/backend.py
@@ -25,11 +25,12 @@ network to `path`.
 
 Optionally the backend also writes a **raster** side-output: with
 `with_shakemap=True` each USGS event's gridded ShakeMap is fetched and
-written as a GeoTIFF alongside the vector files, which makes the
-instance's `OUTPUT_KIND` `"mixed"` for that request. ShakeMap is a
-USGS ComCat product and is not exposed through the FDSN event standard
-at all, so that path is USGS-only and costs one extra request per
-event — see :mod:`earthlens.fdsn._helpers`.
+written as a GeoTIFF alongside the vector files. This does not change
+`OUTPUT_KIND` — `download()` still returns the event FeatureCollection
+and the rasters are a side effect on disk. ShakeMap is a USGS ComCat
+product and is not exposed through the FDSN event standard at all, so
+that path is USGS-only and costs one extra request per event — see
+:mod:`earthlens.fdsn._helpers`.
 
 Provider selection follows the FDSN-specific reading of `variables`
 (see the package docstring): `variables` is a `list[str]` of network
@@ -41,9 +42,11 @@ day/month — so `temporal_resolution` carries the sentinel `"all"`.
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+import requests
 from loguru import logger
 
 from earthlens.base import (
@@ -76,6 +79,18 @@ _DEFAULT_PROVIDERS = ["USGS"]
 #: folder per event so a multi-event query stays navigable.
 _SHAKEMAP_DIR = "shakemap"
 
+#: Scratch subdirectory inside an event's folder. The archive is fetched and
+#: unpacked here and the whole directory is removed afterwards, so no
+#: intermediate — including the `.prj` GDAL writes when the grid's CRS is
+#: assigned — can survive in the user-facing output.
+_STAGING_DIR = "_staging"
+
+#: Default ceiling on how many events one call fetches a ShakeMap for.
+#: Each event is a separate ComCat request plus an ~8.5 MB archive, so an
+#: unbounded window is gigabytes; 100 events is roughly a gigabyte, which is
+#: a defensible accident rather than a catastrophic one.
+_DEFAULT_MAX_SHAKEMAP_EVENTS = 100
+
 #: Seconds between consecutive ComCat detail requests. ShakeMap costs one
 #: request per event, so a busy window fans out where the event query
 #: itself was a single call; USGS publishes no rate limit, and this is a
@@ -102,11 +117,13 @@ class FDSN(AbstractDataSource):
     Attributes:
         OUTPUT_KIND: `"vector"` — the result is a table of point
             features (events), so `aggregate=` is refused with
-            `NotImplementedError`. Resolved per instance: a request
-            built with `with_shakemap=True` also emits GeoTIFF rasters,
-            which makes it `"mixed"`. `aggregate=` stays refused either
-            way, because the ShakeMap grids are a per-event side-output
-            with no time axis to reduce over.
+            `NotImplementedError`. It stays `"vector"` even under
+            `with_shakemap=True`: `OUTPUT_KIND` describes what
+            `download()` *returns*, and that is always a
+            FeatureCollection. The ShakeMap GeoTIFFs are an on-disk
+            side effect, not a second return shape — `"mixed"` is
+            reserved for a backend whose returned format is only known
+            at download time and which honours `aggregate=` itself.
     """
 
     OUTPUT_KIND: OutputKind = "vector"
@@ -116,6 +133,10 @@ class FDSN(AbstractDataSource):
     #: Partial-failure policy for the per-provider loop; `download(errors=...)`
     #: overrides it per call.
     _errors: str = "warn"
+
+    #: Whether `download(force=...)` asked for cached ShakeMap rasters to be
+    #: refetched rather than reused.
+    _force: bool = False
 
     def __init__(
         self,
@@ -139,6 +160,7 @@ class FDSN(AbstractDataSource):
         file_format: FileFormat = "gpkg",
         with_shakemap: bool = False,
         shakemap_layers: list[str] | None = None,
+        max_shakemap_events: int = _DEFAULT_MAX_SHAKEMAP_EVENTS,
     ):
         """Initialise an FDSN backend instance.
 
@@ -195,8 +217,19 @@ class FDSN(AbstractDataSource):
                 same request contributes events but no rasters. Costs
                 one extra ComCat request plus an ~8.5 MB archive per
                 event, so bound the event count with `limit=` before
-                turning it on for a busy window. Turning it on makes
-                this instance's `OUTPUT_KIND` `"mixed"`.
+                turning it on for a busy window; beyond
+                `max_shakemap_events` the side-output stops and says how
+                many events it skipped. It does not change
+                `OUTPUT_KIND` — `download()` still returns the event
+                FeatureCollection, and the rasters are a side effect.
+            max_shakemap_events: Ceiling on how many events one call
+                will fetch a ShakeMap for, guarding against a broad
+                query quietly pulling gigabytes (each event is a
+                separate request plus an ~8.5 MB archive). Events past
+                the ceiling are skipped with a warning naming the count
+                — never silently. Raise it deliberately for a large
+                job, or narrow the query with `limit=` /
+                `min_magnitude=`.
             shakemap_layers: Which ShakeMap grids to write when
                 `with_shakemap` is on. `None` (the default) writes
                 `["mmi_mean"]` — macroseismic intensity, the headline
@@ -240,9 +273,16 @@ class FDSN(AbstractDataSource):
         # construction-time error rather than a surprise the day someone
         # turns the flag on.
         self._shakemap_layers = _helpers.normalize_layers(shakemap_layers)
+        # Validated inline rather than through `check_limit`, which is typed
+        # for an optional cap: this one is always an int, and keeping it that
+        # way lets the ceiling comparison stay a plain `>`.
+        if max_shakemap_events <= 0:
+            raise ValueError(
+                "max_shakemap_events must be a positive integer, got "
+                f"{max_shakemap_events!r}."
+            )
+        self._max_shakemap_events: int = max_shakemap_events
         self._http: HttpClient | None = None
-        if self._with_shakemap:
-            self.OUTPUT_KIND = "mixed"
         if isinstance(variables, dict):
             raise TypeError(
                 "FDSN `variables` must be a list of network keys (e.g. "
@@ -480,6 +520,7 @@ class FDSN(AbstractDataSource):
         progress_bar: bool = True,
         errors: str = "warn",
         limit: int | None = None,
+        force: bool = False,
     ) -> FeatureCollection:
         """Query every requested network and return the unioned events.
 
@@ -502,9 +543,27 @@ class FDSN(AbstractDataSource):
         missing grid never costs the event table.
 
         Args:
-            progress_bar: Accepted for signature parity with the other
-                backends; obspy's `get_events` has no progress bar, so
-                this is currently a no-op.
+            progress_bar: Whether to show a progress bar. obspy's
+                `get_events` has none, so this only governs the ShakeMap
+                loop, which is the long part of a `with_shakemap=True`
+                call; a plain event query ignores it.
+            errors: Partial-failure policy, applied to **both** the
+                per-network query loop and the per-event ShakeMap loop.
+                `"warn"` (the default) logs each failure and continues,
+                `"ignore"` continues silently, and `"raise"` propagates
+                the first failure. Note what `"raise"` costs on a
+                `with_shakemap=True` call: the events have already been
+                fetched and written by then, but raising out of
+                `download()` means they are not *returned*, so a single
+                missing ShakeMap loses the whole in-memory event table.
+                Leave it at `"warn"` unless a missing raster should
+                genuinely abort the request.
+            force: Refetch a ShakeMap whose GeoTIFFs are already on
+                disk instead of reusing them. The rasters are written
+                atomically, so a present file is a finished one and the
+                default reuse is safe; this is the escape hatch for a
+                file damaged after the fact, or for picking up a
+                revised ShakeMap for an event USGS has since updated.
             limit: Maximum events **per network**, overriding the constructor's
                 `limit=` for this call. Same meaning as that one — pushed into
                 the FDSN query itself, so a per-network server-side cap rather
@@ -520,12 +579,19 @@ class FDSN(AbstractDataSource):
 
         Raises:
             RuntimeError: If **every** requested network's query failed
-                (propagated from :meth:`_fetch`). A partial failure does
-                not raise — the healthy networks' events are returned.
+                (propagated from :meth:`_fetch`). A partial failure of
+                the *network* loop does not raise — the healthy
+                networks' events are returned. The ShakeMap loop is
+                governed by the same `errors=` policy, so under the
+                default `"warn"` a failed raster does not raise either;
+                under `errors="raise"` it does, and because the raise
+                escapes `download()` the event table is not returned
+                even though its files are already on disk.
         """
         if limit is not None:
             self._request_limit = self.check_limit(limit)
         self._errors = self.check_errors_policy(errors)
+        self._force = force
         products = self._search()
         collections = self._fetch(products) if products else []
 
@@ -538,7 +604,12 @@ class FDSN(AbstractDataSource):
         if self._with_shakemap:
             # Before the concat: the per-network split is what says which
             # events came from USGS, and the union has thrown that away.
-            rasters = self._download_shakemaps(products, collections)
+            try:
+                rasters = self._download_shakemaps(
+                    products, collections, progress_bar=progress_bar
+                )
+            finally:
+                self._close_client()
 
         combined = events.concat_fcs(collections)
         # `concat_fcs` has copied every network's events, so the per-network
@@ -548,8 +619,11 @@ class FDSN(AbstractDataSource):
         # caller keeps the result.
         collections.clear()
         if written:
+            # "available" rather than "written": a re-run reuses rasters that
+            # were already on disk, and calling those written would overstate
+            # what this call did.
             raster_note = (
-                f" plus {len(rasters)} ShakeMap raster(s)"
+                f" plus {len(rasters)} ShakeMap raster(s) available"
                 if self._with_shakemap
                 else ""
             )
@@ -574,18 +648,34 @@ class FDSN(AbstractDataSource):
             HttpClient: The same instance on every later call.
         """
         if self._http is None:
-            from earthlens.core import __version__
-
+            # ComCat is a single origin fetched once per event, so a dropped
+            # connection is a normal event rather than a signal to give up on
+            # the whole batch; retrying transport errors matches flodis/hanze.
+            # The default user-agent is already `earthlens/{version}`.
             self._http = HttpClient(
-                user_agent=f"earthlens/{__version__}",
                 min_interval=_COMCAT_MIN_INTERVAL,
+                retry_on_exceptions=(requests.ConnectionError, requests.Timeout),
             )
         return self._http
+
+    def _close_client(self) -> None:
+        """Release the pooled ComCat client, if one was ever built.
+
+        `HttpClient` exposes no `close()` of its own — only `HttpRangeFile`
+        does — so the underlying `requests.Session` is closed directly. A
+        session left open holds its connection pool for the lifetime of the
+        backend instance, which matters here because the ShakeMap client is
+        built per call and used for a bounded burst.
+        """
+        if self._http is not None:
+            self._http.session.close()
+            self._http = None
 
     def _download_shakemaps(
         self,
         products: list[RemoteProduct],
         collections: list[FeatureCollection],
+        progress_bar: bool = True,
     ) -> list[Path]:
         """Write the ShakeMap side-output for every USGS event fetched.
 
@@ -597,9 +687,14 @@ class FDSN(AbstractDataSource):
             products: The products from :meth:`_search`.
             collections: The per-product FeatureCollections from
                 :meth:`_fetch`, still split by network.
+            progress_bar: Whether each archive fetch shows a progress
+                bar. This is the long part of a `with_shakemap=True`
+                call, so it is the only place the flag does anything.
 
         Returns:
-            list[Path]: Every GeoTIFF written, across all events.
+            list[Path]: Every GeoTIFF available for the requested
+                events — those written by this call plus any reused
+                from a previous run.
         """
         event_ids: list[str] = []
         for product, collection in zip(products, collections):
@@ -617,13 +712,27 @@ class FDSN(AbstractDataSource):
         if not event_ids:
             return []
 
+        if len(event_ids) > self._max_shakemap_events:
+            dropped = len(event_ids) - self._max_shakemap_events
+            logger.warning(
+                f"with_shakemap=True matched {len(event_ids)} USGS events, over "
+                f"the max_shakemap_events={self._max_shakemap_events} ceiling: "
+                f"fetching the first {self._max_shakemap_events} and skipping "
+                f"{dropped}. Each event costs a request plus an ~8.5 MB archive. "
+                "Raise max_shakemap_events= to take them all, or narrow the "
+                "query with limit= / min_magnitude=."
+            )
+            event_ids = event_ids[: self._max_shakemap_events]
+
         logger.info(
             f"Fetching ShakeMap {list(self._shakemap_layers)} for "
             f"{len(event_ids)} USGS event(s)"
         )
         results, _failed = self._run_items(
             event_ids,
-            self._shakemap_for_event,
+            lambda event_id: self._shakemap_for_event(
+                event_id, progress_bar=progress_bar
+            ),
             errors=self._errors,
             label="ShakeMap",
             describe=repr,
@@ -631,7 +740,9 @@ class FDSN(AbstractDataSource):
         )
         return [path for paths in results for path in paths]
 
-    def _shakemap_for_event(self, event_id: str) -> list[Path]:
+    def _shakemap_for_event(
+        self, event_id: str, progress_bar: bool = True
+    ) -> list[Path]:
         """Fetch, unpack, and convert one event's requested ShakeMap grids.
 
         Skips the network entirely when every requested GeoTIFF is
@@ -643,6 +754,7 @@ class FDSN(AbstractDataSource):
         Args:
             event_id: The event's `event_id` column value, a QuakeML
                 resource identifier carrying the ComCat id.
+            progress_bar: Whether the archive fetch shows a progress bar.
 
         Returns:
             list[Path]: The GeoTIFFs written for this event; empty when
@@ -658,9 +770,20 @@ class FDSN(AbstractDataSource):
             )
             return []
 
-        dest_dir = self.root_dir / _SHAKEMAP_DIR / comcat_id
+        shakemap_root = self.root_dir / _SHAKEMAP_DIR
+        dest_dir = shakemap_root / comcat_id
+        # Defence in depth. `parse_comcat_id` already refuses an id that could
+        # traverse, but the id comes from an upstream server and this directory
+        # is deleted from, so the containment is asserted rather than assumed.
+        if not dest_dir.resolve().is_relative_to(shakemap_root.resolve()):
+            logger.warning(
+                f"refusing ComCat id {comcat_id!r}: it does not resolve inside "
+                f"{shakemap_root} — skipping its ShakeMap."
+            )
+            return []
+
         expected = [dest_dir / f"{layer}.tif" for layer in self._shakemap_layers]
-        if expected and all(self._is_complete(path) for path in expected):
+        if all(self._is_complete(path, force=self._force) for path in expected):
             logger.info(f"ShakeMap for {comcat_id} already on disk — skipping.")
             return expected
 
@@ -672,25 +795,33 @@ class FDSN(AbstractDataSource):
             )
             return []
 
-        archive = dest_dir / "raster.zip"
+        # Everything the fetch and the conversion touch is confined to a staging
+        # directory that is removed wholesale, rather than cleaned up by globbing
+        # the user's output directory for suffixes. That keeps GDAL's own
+        # by-products out of the result: opening the `EHdr` grid read-write to
+        # assign its CRS makes the driver drop a `<layer>.prj` beside the `.flt`,
+        # which a suffix-based sweep would leave behind in the output folder.
+        staging = dest_dir / _STAGING_DIR
+        archive = staging / "raster.zip"
         written: list[Path] = []
         try:
+            staging.mkdir(parents=True, exist_ok=True)
             # `expect_magic` keeps an HTML error page served with a 200 from
             # landing as a .zip and failing later as a confusing bad-archive.
-            self._client().download(url, archive, expect_magic=b"PK", progress=False)
-            extracted = _helpers.extract_layers(
-                archive, self._shakemap_layers, dest_dir
+            self._client().download(
+                url, archive, expect_magic=b"PK", progress=progress_bar
             )
+            extracted = _helpers.extract_layers(archive, self._shakemap_layers, staging)
             for layer, flt_path in extracted.items():
                 written.append(
                     _helpers.flt_to_geotiff(flt_path, dest_dir / f"{layer}.tif")
                 )
         finally:
-            for leftover in dest_dir.glob("*.flt"):
-                leftover.unlink(missing_ok=True)
-            for leftover in dest_dir.glob("*.hdr"):
-                leftover.unlink(missing_ok=True)
-            archive.unlink(missing_ok=True)
+            shutil.rmtree(staging, ignore_errors=True)
+            # An event whose archive was unusable leaves no rasters, and an
+            # empty directory named after it reads like a successful fetch.
+            if dest_dir.is_dir() and not any(dest_dir.iterdir()):
+                dest_dir.rmdir()
         return written
 
     def _write(self, provider_key: str, collection: FeatureCollection) -> Path:

--- a/libs/providers/hazards/src/earthlens/fdsn/backend.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/backend.py
@@ -300,16 +300,21 @@ class FDSN(AbstractDataSource):
                 will fetch a ShakeMap for, guarding against a broad
                 query quietly pulling gigabytes (each event is a
                 separate request plus a multi-megabyte archive). Events past
-                the ceiling are skipped with a warning naming the count
-                — never silently. The events kept are the first
+                the ceiling are deferred with a warning naming the
+                count — never silently. The ceiling counts *fetches*,
+                not events: an event already satisfied on disk costs no
+                budget, and an id that can never be fetched at all is
+                dropped before counting. So re-running the same request
+                takes the next batch, and repeating it eventually walks
+                the whole list. The one exception is an event that fails
+                on every attempt: a failure is not cached, so it is
+                retried each run and keeps its place in the queue.
+                Within a run the events kept are the first
                 `max_shakemap_events` in the order the networks returned
                 them, which `orderby=` controls (`"magnitude"` puts the
-                largest first, the usual intent when capping). Because
-                an event already on disk is skipped without spending
-                budget, re-running the same request walks further
-                through the list each time. Raise the ceiling
-                deliberately for a large job, or narrow the query with
-                `limit=` / `min_magnitude=`.
+                largest first, the usual intent when capping). Raise the
+                ceiling deliberately for a large job, or narrow the
+                query with `limit=` / `min_magnitude=`.
             shakemap_layers: Which ShakeMap grids to write when
                 `with_shakemap` is on. `None` (the default) writes
                 `["mmi_mean"]` — macroseismic intensity, the headline

--- a/libs/providers/hazards/src/earthlens/fdsn/backend.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/backend.py
@@ -356,6 +356,13 @@ class FDSN(AbstractDataSource):
         # Validated inline rather than through `check_limit`, which is typed
         # for an optional cap: this one is always an int, and keeping it that
         # way lets the ceiling comparison stay a plain `>`.
+        if not isinstance(max_shakemap_events, int) or isinstance(
+            max_shakemap_events, bool
+        ):
+            raise TypeError(
+                "max_shakemap_events must be an integer, got "
+                f"{type(max_shakemap_events).__name__}."
+            )
         if max_shakemap_events <= 0:
             raise ValueError(
                 "max_shakemap_events must be a positive integer, got "
@@ -810,7 +817,19 @@ class FDSN(AbstractDataSource):
                     )
                 continue
             event_ids.extend(str(value) for value in collection["event_id"])
+        # Two networks can report the same ComCat event, and a catalog can
+        # repeat one; de-duplicated so the ceiling counts each event once.
+        event_ids = list(dict.fromkeys(event_ids))
 
+        if not event_ids:
+            return []
+
+        # Drop what can never succeed before anything is counted. An id that
+        # yields no ComCat id, or one whose directory fails the containment
+        # assertion, is not work waiting to be done — left in, it would sit at
+        # the head of the queue spending budget on every run and starve the
+        # events behind it.
+        event_ids = [event_id for event_id in event_ids if self._is_fetchable(event_id)]
         if not event_ids:
             return []
 
@@ -831,9 +850,10 @@ class FDSN(AbstractDataSource):
             )
             event_ids = [event_id for event_id in event_ids if event_id not in deferred]
 
+        fetching = sum(1 for event_id in event_ids if not self._is_cached(event_id))
         logger.info(
-            f"Fetching ShakeMap {list(self._shakemap_layers)} for "
-            f"{len(event_ids)} USGS event(s)"
+            f"ShakeMap {list(self._shakemap_layers)}: {fetching} event(s) to fetch, "
+            f"{len(event_ids) - fetching} already on disk"
         )
         # A per-archive bar is useful for a single fetch and unreadable for
         # fifty, so a batch reports through the log line above instead.
@@ -941,22 +961,74 @@ class FDSN(AbstractDataSource):
         previously = set(manifest.get("requested", []))
         if not set(self._shakemap_layers).issubset(previously):
             return None
-        produced = [
-            layer
-            for layer in self._shakemap_layers
-            if layer in manifest.get("produced", [])
-        ]
-        if not produced:
-            # A negative result, which ages out: the grid may simply not have
-            # been published yet when the event was first seen.
-            age = time.time() - float(manifest.get("checked", 0.0))
-            if age > _NEGATIVE_CACHE_SECONDS:
-                return None
-            return []
+        recorded = set(manifest.get("produced", []))
+        produced = [layer for layer in self._shakemap_layers if layer in recorded]
+        missing = [layer for layer in self._shakemap_layers if layer not in recorded]
+        if missing and self._record_is_stale(manifest):
+            # Any requested layer the last run did not produce is a negative
+            # result, and negative results age out — whether or not some *other*
+            # requested layer happens to be on disk. Checking this only when the
+            # intersection was empty meant a partially-published event cached its
+            # missing grids permanently, which is exactly the case the manifest
+            # was introduced for.
+            return None
         cached = [dest_dir / f"{layer}.tif" for layer in produced]
         if not all(self._is_complete(path) for path in cached):
             return None
+        if missing:
+            logger.warning(
+                f"ShakeMap layer(s) {missing} are not available for this event and "
+                f"were last checked recently; returning {len(cached)} of "
+                f"{len(self._shakemap_layers)} requested. Pass force=True to "
+                "re-check now."
+            )
         return cached
+
+    @staticmethod
+    def _record_is_stale(manifest: dict[str, object]) -> bool:
+        """Report whether a manifest's negative half should be re-checked.
+
+        Args:
+            manifest: The parsed manifest.
+
+        Returns:
+            bool: `True` when the record is older than the negative-cache
+                window, or carries a timestamp that cannot be trusted — a
+                future one, or a non-finite one. An unusable clock reading
+                fails towards refetching rather than towards caching an
+                answer forever.
+        """
+        stamp = manifest.get("checked", 0.0)
+        if not isinstance(stamp, (int, float)) or isinstance(stamp, bool):
+            return True
+        age = time.time() - float(stamp)
+        # Written as a range test so a negative age (a future stamp) and a NaN
+        # age (every comparison False) both come out stale.
+        return not (0.0 <= age <= _NEGATIVE_CACHE_SECONDS)
+
+    def _is_fetchable(self, event_id: str) -> bool:
+        """Report whether an event could ever yield a ShakeMap.
+
+        Separated from :meth:`_is_cached` because the two answer different
+        questions: this one asks whether the event is *addressable* at all,
+        and an event that is not can never become cached, so counting it as
+        pending work would let it block the queue indefinitely.
+
+        Args:
+            event_id: The event's `event_id` column value.
+
+        Returns:
+            bool: `False` when no ComCat id can be parsed, or the resolved
+                directory would escape the ShakeMap root.
+        """
+        comcat_id = _helpers.parse_comcat_id(event_id)
+        if comcat_id is None:
+            logger.warning(
+                f"cannot resolve a ComCat id from event_id {event_id!r} — "
+                "skipping its ShakeMap."
+            )
+            return False
+        return self._event_dir(comcat_id) is not None
 
     def _is_cached(self, event_id: str) -> bool:
         """Report whether an event needs no work this run.
@@ -1105,8 +1177,21 @@ class FDSN(AbstractDataSource):
             # An event whose archive was unusable leaves no rasters, and an
             # empty directory named after it reads like a successful fetch.
             with suppress(OSError):
-                if dest_dir.is_dir() and not any(dest_dir.iterdir()):
-                    dest_dir.rmdir()
+                if dest_dir.is_dir():
+                    remaining = list(dest_dir.iterdir())
+                    if not remaining:
+                        dest_dir.rmdir()
+                    elif all(
+                        item.name.startswith(_STAGING_PREFIX) for item in remaining
+                    ):
+                        # Another process's scratch space, or one left by a run
+                        # that died. Not ours to delete, but silence would let it
+                        # accumulate unnoticed and keep this directory alive.
+                        logger.warning(
+                            f"{dest_dir} holds only orphaned scratch "
+                            f"director(ies) {[item.name for item in remaining]} "
+                            "from an interrupted run; remove them by hand."
+                        )
         return written
 
     def _write(self, provider_key: str, collection: FeatureCollection) -> Path:

--- a/libs/providers/hazards/src/earthlens/fdsn/backend.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/backend.py
@@ -42,7 +42,9 @@ day/month — so `temporal_resolution` carries the sentinel `"all"`.
 
 from __future__ import annotations
 
+import os
 import shutil
+import time
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -80,11 +82,14 @@ _DEFAULT_PROVIDERS = ["USGS"]
 #: folder per event so a multi-event query stays navigable.
 _SHAKEMAP_DIR = "shakemap"
 
-#: Scratch subdirectory inside an event's folder. The archive is fetched and
-#: unpacked here and the whole directory is removed afterwards, so no
-#: intermediate — including the `.prj` GDAL writes when the grid's CRS is
-#: assigned — can survive in the user-facing output.
-_STAGING_DIR = "_staging"
+#: Prefix of the scratch subdirectory inside an event's folder. The archive is
+#: fetched and unpacked there and the whole directory is removed afterwards, so
+#: no intermediate — including the `.prj` GDAL writes when the grid's CRS is
+#: assigned — can survive in the user-facing output. The process id is appended
+#: so two runs sharing an output root cannot delete each other's scratch space
+#: mid-fetch; a crashed run's directory is left for its owner to clean up
+#: rather than removed by a stranger.
+_STAGING_PREFIX = "_staging"
 
 #: Default ceiling on how many events one call fetches a ShakeMap for.
 #: Each event is a separate ComCat request plus a multi-megabyte archive, so an
@@ -97,6 +102,14 @@ _DEFAULT_MAX_SHAKEMAP_EVENTS = 100
 #: itself was a single call; USGS publishes no rate limit, and this is a
 #: politeness floor rather than a documented requirement.
 _COMCAT_MIN_INTERVAL = 0.2
+
+#: How long a *negative* manifest entry — "this event published no ShakeMap
+#: raster" — is trusted before the event is checked again. ShakeMap is
+#: generated minutes to hours after an event and can lag much longer for
+#: moderate ones, so caching that answer permanently would make a query over a
+#: recent window return nothing forever. A positive entry does not expire: the
+#: rasters are on disk, and `download(force=True)` picks up a revision.
+_NEGATIVE_CACHE_SECONDS = 7 * 24 * 60 * 60
 
 #: `(connect, read)` budget for a ComCat request. The read half is generous
 #: because the archive is several megabytes; the connect half fails a dead
@@ -801,33 +814,163 @@ class FDSN(AbstractDataSource):
         if not event_ids:
             return []
 
-        if len(event_ids) > self._max_shakemap_events:
-            dropped = len(event_ids) - self._max_shakemap_events
+        # The ceiling bounds *work*, not events. An event already satisfied on
+        # disk costs nothing, so spending budget on it would stall a re-run at
+        # the same place forever instead of letting it advance through the list.
+        pending = [event_id for event_id in event_ids if not self._is_cached(event_id)]
+        if len(pending) > self._max_shakemap_events:
+            deferred = set(pending[self._max_shakemap_events :])
             logger.warning(
-                f"with_shakemap=True matched {len(event_ids)} USGS events, over "
-                f"the max_shakemap_events={self._max_shakemap_events} ceiling: "
-                f"fetching the first {self._max_shakemap_events} and skipping "
-                f"{dropped}. Each event costs a request plus a multi-megabyte archive. "
-                "Raise max_shakemap_events= to take them all, or narrow the "
+                f"with_shakemap=True needs {len(pending)} fetches, over the "
+                f"max_shakemap_events={self._max_shakemap_events} ceiling: taking "
+                f"the first {self._max_shakemap_events} and deferring "
+                f"{len(deferred)}. Each fetch costs a request plus a "
+                "multi-megabyte archive. Re-run to take the next batch, raise "
+                "max_shakemap_events= to take them all at once, or narrow the "
                 "query with limit= / min_magnitude=."
             )
-            event_ids = event_ids[: self._max_shakemap_events]
+            event_ids = [event_id for event_id in event_ids if event_id not in deferred]
 
         logger.info(
             f"Fetching ShakeMap {list(self._shakemap_layers)} for "
             f"{len(event_ids)} USGS event(s)"
         )
+        # A per-archive bar is useful for a single fetch and unreadable for
+        # fifty, so a batch reports through the log line above instead.
+        per_archive_bar = progress_bar and len(event_ids) == 1
         results, _failed = self._run_items(
             event_ids,
             lambda event_id: self._shakemap_for_event(
-                event_id, progress_bar=progress_bar
+                event_id, progress_bar=per_archive_bar
             ),
             errors=self._errors,
             label="ShakeMap",
             describe=repr,
             on_failure=lambda _event_id, _exc: [],
         )
-        return [path for paths in results for path in paths]
+        written = [path for paths in results for path in paths]
+        shakemap_root = self.root_dir / _SHAKEMAP_DIR
+        # An empty `shakemap/` reads as "asked for, produced nothing" only if it
+        # is there at all; removing it keeps a fruitless run from looking like a
+        # partial success.
+        with suppress(OSError):
+            if shakemap_root.is_dir() and not any(shakemap_root.iterdir()):
+                shakemap_root.rmdir()
+        return written
+
+    def _record_manifest(
+        self,
+        dest_dir: Path,
+        produced: list[str],
+        product_version: str | None = None,
+    ) -> None:
+        """Record an event's outcome, warning rather than failing if it cannot.
+
+        The manifest is a cache, not the deliverable: a raster already written
+        must not be lost because its bookkeeping could not be saved. A failure
+        is surfaced, though, because the only symptom otherwise is a re-run
+        that silently refetches everything.
+
+        Args:
+            dest_dir: The event's output directory.
+            produced: The layers the archive actually carried.
+            product_version: The ShakeMap product's `updateTime`, if known.
+        """
+        try:
+            _helpers.write_manifest(
+                dest_dir,
+                self._shakemap_layers,
+                produced,
+                checked=time.time(),
+                product_version=product_version,
+            )
+        except OSError as error:
+            logger.warning(
+                f"could not record the ShakeMap manifest in {dest_dir}: {error}. "
+                "The rasters are written, but a re-run will fetch them again."
+            )
+
+    def _event_dir(self, comcat_id: str) -> Path | None:
+        """Resolve an event's output directory, refusing one that escapes.
+
+        Args:
+            comcat_id: The event's ComCat id.
+
+        Returns:
+            Path | None: The directory, or `None` when it does not resolve
+                inside the ShakeMap root.
+        """
+        shakemap_root = self.root_dir / _SHAKEMAP_DIR
+        dest_dir = shakemap_root / comcat_id
+        # Defence in depth. `parse_comcat_id` already refuses an id that could
+        # traverse, but the id comes from an upstream server and this directory
+        # is deleted from, so the containment is asserted rather than assumed.
+        if not dest_dir.resolve().is_relative_to(shakemap_root.resolve()):
+            logger.warning(
+                f"refusing ComCat id {comcat_id!r}: it does not resolve inside "
+                f"{shakemap_root} — skipping its ShakeMap."
+            )
+            return None
+        return dest_dir
+
+    def _cached_rasters(self, dest_dir: Path) -> list[Path] | None:
+        """Decide whether an event can be served from disk, without logging.
+
+        Split from :meth:`_reuse_existing` so the fan-out ceiling can ask the
+        same question about an event it may not process, without emitting a
+        skip line for work it never started.
+
+        Args:
+            dest_dir: The event's output directory.
+
+        Returns:
+            list[Path] | None: The rasters to reuse — empty for an event known
+                to publish none — or `None` when the event must be fetched.
+        """
+        if self._force:
+            return None
+        manifest = _helpers.read_manifest(dest_dir)
+        if manifest is None:
+            return None
+        # A previous call may have asked for fewer layers than this one. Reuse
+        # only when the earlier request covered everything now wanted.
+        previously = set(manifest.get("requested", []))
+        if not set(self._shakemap_layers).issubset(previously):
+            return None
+        produced = [
+            layer
+            for layer in self._shakemap_layers
+            if layer in manifest.get("produced", [])
+        ]
+        if not produced:
+            # A negative result, which ages out: the grid may simply not have
+            # been published yet when the event was first seen.
+            age = time.time() - float(manifest.get("checked", 0.0))
+            if age > _NEGATIVE_CACHE_SECONDS:
+                return None
+            return []
+        cached = [dest_dir / f"{layer}.tif" for layer in produced]
+        if not all(self._is_complete(path) for path in cached):
+            return None
+        return cached
+
+    def _is_cached(self, event_id: str) -> bool:
+        """Report whether an event needs no work this run.
+
+        Args:
+            event_id: The event's `event_id` column value.
+
+        Returns:
+            bool: `True` when the event is already satisfied on disk, so the
+                fan-out ceiling should not spend budget on it.
+        """
+        comcat_id = _helpers.parse_comcat_id(event_id)
+        if comcat_id is None:
+            return False
+        dest_dir = self._event_dir(comcat_id)
+        if dest_dir is None:
+            return False
+        return self._cached_rasters(dest_dir) is not None
 
     def _reuse_existing(self, dest_dir: Path, comcat_id: str) -> list[Path] | None:
         """Return an event's cached rasters, or `None` to fetch it again.
@@ -849,30 +992,15 @@ class FDSN(AbstractDataSource):
                 ShakeMap at all — or `None` when the event must be
                 fetched.
         """
-        if self._force:
-            return None
-        manifest = _helpers.read_manifest(dest_dir)
-        if manifest is None:
-            return None
-        # A previous call may have asked for fewer layers than this one. Reuse
-        # only when the earlier request covered everything now wanted.
-        previously = set(manifest.get("requested", []))
-        if not set(self._shakemap_layers).issubset(previously):
-            return None
-        produced = [
-            layer
-            for layer in self._shakemap_layers
-            if layer in manifest.get("produced", [])
-        ]
-        cached = [dest_dir / f"{layer}.tif" for layer in produced]
-        if not all(self._is_complete(path) for path in cached):
+        cached = self._cached_rasters(dest_dir)
+        if cached is None:
             return None
         if cached:
             logger.info(f"ShakeMap for {comcat_id} already on disk — skipping.")
         else:
             logger.info(
-                f"event {comcat_id} is known to publish no ShakeMap raster for "
-                "the requested layer(s) — skipping."
+                f"as of the last run, event {comcat_id} published no ShakeMap "
+                "raster for the requested layer(s) — skipping."
             )
         return cached
 
@@ -881,11 +1009,17 @@ class FDSN(AbstractDataSource):
     ) -> list[Path]:
         """Fetch, unpack, and convert one event's requested ShakeMap grids.
 
-        Skips the network entirely when every requested GeoTIFF is
-        already on disk, so a re-run costs nothing. The downloaded
-        archive and the intermediate `.flt` / `.hdr` pairs are removed
-        once converted — they are several times the size of the GeoTIFFs
-        and carry nothing the GeoTIFF does not.
+        Skips the network when the event's manifest says this run's
+        layers are already accounted for — either their GeoTIFFs are on
+        disk, or the archive was checked recently and carries none of
+        them. The skip is decided from what a previous run *recorded*,
+        not from whether every requested file exists, because an archive
+        need not carry every layer that was asked for.
+
+        Everything the fetch and the conversion touch stays inside a
+        staging directory that is removed wholesale, so no intermediate
+        — the archive, the `.flt` / `.hdr` pairs, or the `.prj` GDAL
+        writes when the CRS is assigned — reaches the output folder.
 
         Args:
             event_id: The event's `event_id` column value, a QuakeML
@@ -906,16 +1040,8 @@ class FDSN(AbstractDataSource):
             )
             return []
 
-        shakemap_root = self.root_dir / _SHAKEMAP_DIR
-        dest_dir = shakemap_root / comcat_id
-        # Defence in depth. `parse_comcat_id` already refuses an id that could
-        # traverse, but the id comes from an upstream server and this directory
-        # is deleted from, so the containment is asserted rather than assumed.
-        if not dest_dir.resolve().is_relative_to(shakemap_root.resolve()):
-            logger.warning(
-                f"refusing ComCat id {comcat_id!r}: it does not resolve inside "
-                f"{shakemap_root} — skipping its ShakeMap."
-            )
+        dest_dir = self._event_dir(comcat_id)
+        if dest_dir is None:
             return []
 
         reused = self._reuse_existing(dest_dir, comcat_id)
@@ -930,7 +1056,7 @@ class FDSN(AbstractDataSource):
             )
             # Recorded so a re-run does not re-request this event's detail
             # document only to reach the same conclusion.
-            _helpers.write_manifest(dest_dir, self._shakemap_layers, [])
+            self._record_manifest(dest_dir, [])
             return []
 
         # Everything the fetch and the conversion touch is confined to a staging
@@ -939,7 +1065,7 @@ class FDSN(AbstractDataSource):
         # by-products out of the result: opening the `EHdr` grid read-write to
         # assign its CRS makes the driver drop a `<layer>.prj` beside the `.flt`,
         # which a suffix-based sweep would leave behind in the output folder.
-        staging = dest_dir / _STAGING_DIR
+        staging = dest_dir / f"{_STAGING_PREFIX}-{os.getpid()}"
         archive = staging / "raster.zip"
         written: list[Path] = []
         try:
@@ -956,7 +1082,11 @@ class FDSN(AbstractDataSource):
                 )
             # Only after every conversion succeeded: a manifest written on a
             # partial failure would cache an incomplete result as final.
-            _helpers.write_manifest(dest_dir, self._shakemap_layers, list(extracted))
+            self._record_manifest(
+                dest_dir,
+                list(extracted),
+                product_version=_helpers.shakemap_product_version(detail),
+            )
         finally:
             shutil.rmtree(staging, ignore_errors=True)
             if staging.exists():

--- a/libs/providers/hazards/src/earthlens/fdsn/backend.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/backend.py
@@ -13,11 +13,23 @@ by :mod:`earthlens.fdsn.events`.
 
 This is the first `vector` backend: the on-the-wire result is a table
 of point features, not a gridded array, so `OUTPUT_KIND = "vector"`
-and the :class:`earthlens.earthlens.EarthLens` facade rejects an
-`aggregate=` argument (there is no meaningful gridded reduction of an
-event table). `download()` returns the in-memory FeatureCollection
-(the union across requested networks) and, as a side effect, writes
-one vector file per network to `path`.
+and an `aggregate=` argument is refused (there is no meaningful
+gridded reduction of an event table). The refusal itself lives in
+:meth:`earthlens.base.AbstractDataSource._refuse_unsupported_aggregate`,
+which every backend's `download` routes through, so a direct
+`FDSN(...).download(aggregate=...)` is rejected identically to one
+made through the :class:`earthlens.earthlens.EarthLens` facade.
+`download()` returns the in-memory FeatureCollection (the union across
+requested networks) and, as a side effect, writes one vector file per
+network to `path`.
+
+Optionally the backend also writes a **raster** side-output: with
+`with_shakemap=True` each USGS event's gridded ShakeMap is fetched and
+written as a GeoTIFF alongside the vector files, which makes the
+instance's `OUTPUT_KIND` `"mixed"` for that request. ShakeMap is a
+USGS ComCat product and is not exposed through the FDSN event standard
+at all, so that path is USGS-only and costs one extra request per
+event — see :mod:`earthlens.fdsn._helpers`.
 
 Provider selection follows the FDSN-specific reading of `variables`
 (see the package docstring): `variables` is a `list[str]` of network
@@ -40,7 +52,8 @@ from earthlens.base import (
     RemoteProduct,
     TemporalExtent,
 )
-from earthlens.fdsn import events
+from earthlens.base.http import HttpClient
+from earthlens.fdsn import _helpers, events
 from earthlens.fdsn.auth import resolve_earthscope_token
 from earthlens.fdsn.catalog import Catalog, Provider
 
@@ -58,6 +71,16 @@ _DRIVERS: dict[str, tuple[str, str]] = {
 
 #: Default network when `variables` is empty.
 _DEFAULT_PROVIDERS = ["USGS"]
+
+#: Subdirectory of `root_dir` holding the ShakeMap side-output, one
+#: folder per event so a multi-event query stays navigable.
+_SHAKEMAP_DIR = "shakemap"
+
+#: Seconds between consecutive ComCat detail requests. ShakeMap costs one
+#: request per event, so a busy window fans out where the event query
+#: itself was a single call; USGS publishes no rate limit, and this is a
+#: politeness floor rather than a documented requirement.
+_COMCAT_MIN_INTERVAL = 0.2
 
 
 class FDSN(AbstractDataSource):
@@ -78,14 +101,17 @@ class FDSN(AbstractDataSource):
 
     Attributes:
         OUTPUT_KIND: `"vector"` — the result is a table of point
-            features (events), so the facade rejects `aggregate=`
-            with `NotImplementedError`. This backend is the first
-            end-to-end exercise of that facade guard.
+            features (events), so `aggregate=` is refused with
+            `NotImplementedError`. Resolved per instance: a request
+            built with `with_shakemap=True` also emits GeoTIFF rasters,
+            which makes it `"mixed"`. `aggregate=` stays refused either
+            way, because the ShakeMap grids are a per-event side-output
+            with no time axis to reduce over.
     """
 
     OUTPUT_KIND: OutputKind = "vector"
 
-    AGGREGATE_REFUSAL_REASON = "seismic events are vector point features, not gridded rasters, so there is no meaningful gridded reduction. Call download() without aggregate= and post-process the returned FeatureCollection (a GeoDataFrame) directly"
+    AGGREGATE_REFUSAL_REASON = "seismic events are vector point features, not gridded rasters, so there is no meaningful gridded reduction — and the optional with_shakemap= rasters are a per-event side-output with no time axis to reduce over. Call download() without aggregate= and post-process the returned FeatureCollection (a GeoDataFrame) directly"
 
     #: Partial-failure policy for the per-provider loop; `download(errors=...)`
     #: overrides it per call.
@@ -111,6 +137,8 @@ class FDSN(AbstractDataSource):
         limit: int | None = None,
         earthscope_token: str | None = None,
         file_format: FileFormat = "gpkg",
+        with_shakemap: bool = False,
+        shakemap_layers: list[str] | None = None,
     ):
         """Initialise an FDSN backend instance.
 
@@ -160,6 +188,31 @@ class FDSN(AbstractDataSource):
                 Used only for a provider that requires a token.
             file_format: Output vector format — `"gpkg"` (default,
                 GeoPackage) or `"geojson"`.
+            with_shakemap: Also fetch each event's gridded ShakeMap and
+                write it as a GeoTIFF under `path/shakemap/<event>/`.
+                **USGS only** — ShakeMap is a ComCat product, not part
+                of the FDSN event standard, so a non-USGS network in the
+                same request contributes events but no rasters. Costs
+                one extra ComCat request plus an ~8.5 MB archive per
+                event, so bound the event count with `limit=` before
+                turning it on for a busy window. Turning it on makes
+                this instance's `OUTPUT_KIND` `"mixed"`.
+            shakemap_layers: Which ShakeMap grids to write when
+                `with_shakemap` is on. `None` (the default) writes
+                `["mmi_mean"]` — macroseismic intensity, the headline
+                shaking field. The archive carries fourteen grids
+                (`mmi`, `pga`, `pgv`, `psa0p3`, `psa0p6`, `psa1p0`,
+                `psa3p0`, each `_mean` and `_std`); all are reachable,
+                none but the default are written unless asked for.
+                Ignored when `with_shakemap` is `False`.
+
+        Raises:
+            ValueError: If `file_format` is not a supported vector
+                format, if `limit` is zero or negative, or if
+                `shakemap_layers` names a grid the archive does not
+                carry.
+            TypeError: If `variables` is a mapping — for this backend it
+                selects seismic networks, not data variables.
         """
         self._min_magnitude = min_magnitude
         self._max_magnitude = max_magnitude
@@ -182,6 +235,14 @@ class FDSN(AbstractDataSource):
                 f"file_format must be one of {sorted(_DRIVERS)}, got {file_format!r}."
             )
         self._file_format: FileFormat = file_format
+        self._with_shakemap = bool(with_shakemap)
+        # Validated even when the flag is off, so a typo'd layer name is a
+        # construction-time error rather than a surprise the day someone
+        # turns the flag on.
+        self._shakemap_layers = _helpers.normalize_layers(shakemap_layers)
+        self._http: HttpClient | None = None
+        if self._with_shakemap:
+            self.OUTPUT_KIND = "mixed"
         if isinstance(variables, dict):
             raise TypeError(
                 "FDSN `variables` must be a list of network keys (e.g. "
@@ -433,6 +494,14 @@ class FDSN(AbstractDataSource):
         (every network matched nothing) returns a schema-correct empty
         FeatureCollection and writes nothing.
 
+        When the instance was built with `with_shakemap=True`, each USGS
+        event additionally gets its ShakeMap grids written as GeoTIFFs
+        under `path/shakemap/<event>/`. Those rasters are a side effect
+        only — the return value stays the event FeatureCollection. An
+        event whose ShakeMap cannot be fetched is logged and skipped
+        under the same `errors=` policy as a failed network, so one
+        missing grid never costs the event table.
+
         Args:
             progress_bar: Accepted for signature parity with the other
                 backends; obspy's `get_events` has no progress bar, so
@@ -466,6 +535,12 @@ class FDSN(AbstractDataSource):
             if len(collection):
                 written.append(self._write(product.id, collection))
 
+        rasters: list[Path] = []
+        if self._with_shakemap:
+            # Before the concat: the per-network split is what says which
+            # events came from USGS, and the union has thrown that away.
+            rasters = self._download_shakemaps(products, collections)
+
         combined = events.concat_fcs(collections)
         # `concat_fcs` has copied every network's events, so the per-network
         # copies are dead weight from here on. This does not lower the *peak* —
@@ -474,15 +549,150 @@ class FDSN(AbstractDataSource):
         # caller keeps the result.
         collections.clear()
         if written:
+            raster_note = (
+                f" plus {len(rasters)} ShakeMap raster(s)"
+                if self._with_shakemap
+                else ""
+            )
             logger.info(
                 f"FDSN download summary: {len(combined)} events across "
-                f"{len(written)} file(s) written to {self.root_dir}"
+                f"{len(written)} file(s){raster_note} written to {self.root_dir}"
             )
         else:
             logger.warning(
                 "FDSN download summary: no events matched the request, nothing written"
             )
         return combined
+
+    def _client(self) -> HttpClient:
+        """Return this instance's pooled ComCat client, built on first use.
+
+        Only the ShakeMap path needs HTTP — the event query itself goes
+        through obspy — so the client is built lazily and a request
+        without `with_shakemap=True` never opens a session at all.
+
+        Returns:
+            HttpClient: The same instance on every later call.
+        """
+        if self._http is None:
+            from earthlens.core import __version__
+
+            self._http = HttpClient(
+                user_agent=f"earthlens/{__version__}",
+                min_interval=_COMCAT_MIN_INTERVAL,
+            )
+        return self._http
+
+    def _download_shakemaps(
+        self,
+        products: list[RemoteProduct],
+        collections: list[FeatureCollection],
+    ) -> list[Path]:
+        """Write the ShakeMap side-output for every USGS event fetched.
+
+        ShakeMap is a USGS ComCat product with no counterpart in the FDSN
+        event standard, so a non-USGS network that returned events is
+        logged once and skipped rather than silently producing nothing.
+
+        Args:
+            products: The products from :meth:`_search`.
+            collections: The per-product FeatureCollections from
+                :meth:`_fetch`, still split by network.
+
+        Returns:
+            list[Path]: Every GeoTIFF written, across all events.
+        """
+        event_ids: list[str] = []
+        for product, collection in zip(products, collections):
+            if product.metadata.get("fdsn_id") != _helpers.COMCAT_PROVIDER:
+                if len(collection):
+                    logger.warning(
+                        f"with_shakemap=True but {product.id!r} is not "
+                        f"{_helpers.COMCAT_PROVIDER}: ShakeMap is a USGS ComCat "
+                        "product, so this network contributes events but no "
+                        "rasters."
+                    )
+                continue
+            event_ids.extend(str(value) for value in collection["event_id"])
+
+        if not event_ids:
+            return []
+
+        logger.info(
+            f"Fetching ShakeMap {list(self._shakemap_layers)} for "
+            f"{len(event_ids)} USGS event(s)"
+        )
+        results, _failed = self._run_items(
+            event_ids,
+            self._shakemap_for_event,
+            errors=self._errors,
+            label="ShakeMap",
+            describe=repr,
+            on_failure=lambda _event_id, _exc: [],
+        )
+        return [path for paths in results for path in paths]
+
+    def _shakemap_for_event(self, event_id: str) -> list[Path]:
+        """Fetch, unpack, and convert one event's requested ShakeMap grids.
+
+        Skips the network entirely when every requested GeoTIFF is
+        already on disk, so a re-run costs nothing. The downloaded
+        archive and the intermediate `.flt` / `.hdr` pairs are removed
+        once converted — they are several times the size of the GeoTIFFs
+        and carry nothing the GeoTIFF does not.
+
+        Args:
+            event_id: The event's `event_id` column value, a QuakeML
+                resource identifier carrying the ComCat id.
+
+        Returns:
+            list[Path]: The GeoTIFFs written for this event; empty when
+                the identifier carries no ComCat id, the event has no
+                ShakeMap product, or the archive lacked every requested
+                grid.
+        """
+        comcat_id = _helpers.parse_comcat_id(event_id)
+        if comcat_id is None:
+            logger.warning(
+                f"cannot resolve a ComCat id from event_id {event_id!r} — "
+                "skipping its ShakeMap."
+            )
+            return []
+
+        dest_dir = self.root_dir / _SHAKEMAP_DIR / comcat_id
+        expected = [dest_dir / f"{layer}.tif" for layer in self._shakemap_layers]
+        if expected and all(self._is_complete(path) for path in expected):
+            logger.info(f"ShakeMap for {comcat_id} already on disk — skipping.")
+            return expected
+
+        detail = self._client().get_json(_helpers.detail_url(comcat_id))
+        url = _helpers.shakemap_raster_url(detail)
+        if url is None:
+            logger.info(
+                f"event {comcat_id} publishes no ShakeMap raster — skipping it."
+            )
+            return []
+
+        archive = dest_dir / "raster.zip"
+        written: list[Path] = []
+        try:
+            # `expect_magic` keeps an HTML error page served with a 200 from
+            # landing as a .zip and failing later as a confusing bad-archive.
+            self._client().download(url, archive, expect_magic=b"PK", progress=False)
+            extracted = _helpers.extract_layers(
+                archive, self._shakemap_layers, dest_dir
+            )
+            for layer, flt_path in extracted.items():
+                written.append(
+                    _helpers.flt_to_geotiff(flt_path, dest_dir / f"{layer}.tif")
+                )
+        finally:
+            for leftover in dest_dir.glob("*.flt"):
+                leftover.unlink(missing_ok=True)
+            for leftover in dest_dir.glob("*.hdr"):
+                leftover.unlink(missing_ok=True)
+            archive.unlink(missing_ok=True)
+        return written
 
     def _write(self, provider_key: str, collection: FeatureCollection) -> Path:
         """Write one network's events to a vector file under `root_dir`.

--- a/libs/providers/hazards/src/earthlens/fdsn/backend.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/backend.py
@@ -130,6 +130,61 @@ class FDSN(AbstractDataSource):
             side effect, not a second return shape — `"mixed"` is
             reserved for a backend whose returned format is only known
             at download time and which honours `aggregate=` itself.
+
+    Examples:
+        - Build a plain event query and inspect what it resolved:
+            ```python
+            >>> from earthlens.fdsn import FDSN
+            >>> backend = FDSN(
+            ...     start="2024-01-01",
+            ...     end="2024-01-31",
+            ...     variables=["USGS"],
+            ...     lat_lim=[30.0, 45.0],
+            ...     lon_lim=[130.0, 145.0],
+            ... )
+            >>> backend.vars
+            ['USGS']
+            >>> backend.time.resolution
+            'all'
+            >>> backend.space.south, backend.space.east
+            (30.0, 145.0)
+
+            ```
+        - An empty network list falls back to USGS, and the products the
+          query will issue carry the resolved obspy client id:
+            ```python
+            >>> from earthlens.fdsn import FDSN
+            >>> backend = FDSN(
+            ...     start="2024-01-01",
+            ...     end="2024-01-02",
+            ...     variables=[],
+            ...     lat_lim=[-90.0, 90.0],
+            ...     lon_lim=[-180.0, 180.0],
+            ... )
+            >>> backend.vars
+            ['USGS']
+            >>> [product.metadata["fdsn_id"] for product in backend._search()]
+            ['USGS']
+
+            ```
+        - Asking for the ShakeMap side-output selects one grid by default
+          and leaves the returned shape a vector table:
+            ```python
+            >>> from earthlens.fdsn import FDSN
+            >>> backend = FDSN(
+            ...     start="2023-02-06",
+            ...     end="2023-02-07",
+            ...     variables=["USGS"],
+            ...     lat_lim=[35.0, 39.0],
+            ...     lon_lim=[35.0, 39.0],
+            ...     with_shakemap=True,
+            ... )
+            >>> backend.OUTPUT_KIND
+            'vector'
+            >>> backend._shakemap_layers
+            ('mmi_mean',)
+
+            ```
     """
 
     OUTPUT_KIND: OutputKind = "vector"

--- a/libs/providers/hazards/src/earthlens/fdsn/backend.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/backend.py
@@ -360,6 +360,12 @@ class FDSN(AbstractDataSource):
         list stays positionally aligned with `products`. Only a
         **total** failure (every network errored) raises.
 
+        The partial-failure policy is whatever `download(errors=...)`
+        recorded on the instance: `"warn"` (the default) logs each failed
+        network and continues, `"raise"` propagates the first failure, and
+        `"ignore"` continues silently. An all-failed batch raises
+        regardless of the policy.
+
         Args:
             products: The list returned by :meth:`_search`.
 
@@ -367,13 +373,6 @@ class FDSN(AbstractDataSource):
             list[FeatureCollection]: One collection per product, in the
                 same order; empty collections for no-data or failed
                 networks.
-
-        Args:
-            progress_bar: Whether to show per-provider progress.
-            errors: Partial-failure policy for the per-provider loop —
-                `"warn"` (default) logs each failed network and continues,
-                `"raise"` propagates the first failure, `"ignore"` continues
-                silently. An all-failed batch still raises regardless.
 
         Raises:
             RuntimeError: When **every** network's query failed, so a

--- a/libs/providers/hazards/src/earthlens/fdsn/catalog.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/catalog.py
@@ -6,11 +6,12 @@ network name (`"USGS"`, `"EMSC"`, `"INGV"`, `"EARTHSCOPE"`, `"ISC"`,
 `"GEONET"`) to the obspy `URL_MAPPINGS` key plus a little metadata.
 Adding another network later (ORFEUS, GFZ, …) is a hand-edit of one
 YAML row. There is no `probe` handler and no `tools/fdsn/` directory,
-but the backend does ship `refresh` / `audit` / `validate` handlers in
+but the backend does ship `refresh` and `validate` handlers in
 `earthlens.fdsn.cli`: `refresh` lists the data centres obspy can reach
 (its `URL_MAPPINGS` registry, no network call) and diffs them against
 the `fdsn_id` values curated here, so a centre obspy gains or drops
-surfaces instead of going unnoticed.
+surfaces instead of going unnoticed. `audit` works too, derived from
+the refresher's drift axis rather than from a handler of its own.
 
 :class:`Catalog` is a thin :class:`earthlens.base.AbstractCatalog`
 subclass. To stay consistent with the other backends (GEE / ECMWF /

--- a/libs/providers/hazards/src/earthlens/fdsn/catalog.py
+++ b/libs/providers/hazards/src/earthlens/fdsn/catalog.py
@@ -4,9 +4,13 @@ FDSN is a fixed query protocol, not a curated dataset catalogue, so
 this "catalog" is deliberately tiny: a six-row map from a user-facing
 network name (`"USGS"`, `"EMSC"`, `"INGV"`, `"EARTHSCOPE"`, `"ISC"`,
 `"GEONET"`) to the obspy `URL_MAPPINGS` key plus a little metadata.
-There is no `refresh` / `probe` / `audit` tooling and no
-`tools/fdsn/` directory — adding another network later (ORFEUS,
-GFZ, …) is a hand-edit of one YAML row.
+Adding another network later (ORFEUS, GFZ, …) is a hand-edit of one
+YAML row. There is no `probe` handler and no `tools/fdsn/` directory,
+but the backend does ship `refresh` / `audit` / `validate` handlers in
+`earthlens.fdsn.cli`: `refresh` lists the data centres obspy can reach
+(its `URL_MAPPINGS` registry, no network call) and diffs them against
+the `fdsn_id` values curated here, so a centre obspy gains or drops
+surfaces instead of going unnoticed.
 
 :class:`Catalog` is a thin :class:`earthlens.base.AbstractCatalog`
 subclass. To stay consistent with the other backends (GEE / ECMWF /

--- a/libs/providers/hazards/tests/fdsn/test_backend.py
+++ b/libs/providers/hazards/tests/fdsn/test_backend.py
@@ -253,3 +253,31 @@ class TestFDSNDownload:
         results = backend._api()
         assert len(results) == 1
         assert isinstance(results[0], GeoDataFrame)
+
+    def test_download_limit_overrides_constructor(
+        self, tmp_path: Path, fake_fdsn: _FakeFdsn
+    ):
+        """A per-call limit replaces the constructor's for that query."""
+        backend = _make_backend(tmp_path, limit=5)
+        backend.download(limit=2)
+        _base_url, kwargs = fake_fdsn.calls[-1]
+        assert kwargs["limit"] == 2, f"expected the per-call cap, got {kwargs['limit']}"
+
+    def test_download_limit_none_keeps_constructor(
+        self, tmp_path: Path, fake_fdsn: _FakeFdsn
+    ):
+        """Omitting the per-call limit keeps whatever the constructor set."""
+        backend = _make_backend(tmp_path, limit=5)
+        backend.download()
+        _base_url, kwargs = fake_fdsn.calls[-1]
+        assert kwargs["limit"] == 5, (
+            f"expected the constructor cap, got {kwargs['limit']}"
+        )
+
+    def test_download_rejects_non_positive_limit(
+        self, tmp_path: Path, fake_fdsn: _FakeFdsn
+    ):
+        """A zero or negative per-call limit is refused."""
+        backend = _make_backend(tmp_path)
+        with pytest.raises(ValueError):
+            backend.download(limit=0)

--- a/libs/providers/hazards/tests/fdsn/test_earthlens_fdsn.py
+++ b/libs/providers/hazards/tests/fdsn/test_earthlens_fdsn.py
@@ -119,10 +119,10 @@ class TestFacadeShakemapKeywords:
         assert isinstance(fc, GeoDataFrame)
 
     def test_force_with_shakemap_refetches(self, tmp_path: Path, fake_fdsn: _FakeFdsn):
-        """force= reaches the ShakeMap path through the facade."""
-        import earthlens.fdsn.backend as fdsn_backend
-
+        """force= through the facade actually causes a second fetch."""
         facade = _make_facade(tmp_path, with_shakemap=True)
+        facade.download()
+        facade.download()
         facade.download(force=True)
+
         assert facade.datasource._force is True, "force should reach the backend"
-        assert fdsn_backend  # the ShakeMap path is the one under test

--- a/libs/providers/hazards/tests/fdsn/test_earthlens_fdsn.py
+++ b/libs/providers/hazards/tests/fdsn/test_earthlens_fdsn.py
@@ -117,3 +117,12 @@ class TestFacadeShakemapKeywords:
         facade = _make_facade(tmp_path)
         fc = facade.download(force=True)
         assert isinstance(fc, GeoDataFrame)
+
+    def test_force_with_shakemap_refetches(self, tmp_path: Path, fake_fdsn: _FakeFdsn):
+        """force= reaches the ShakeMap path through the facade."""
+        import earthlens.fdsn.backend as fdsn_backend
+
+        facade = _make_facade(tmp_path, with_shakemap=True)
+        facade.download(force=True)
+        assert facade.datasource._force is True, "force should reach the backend"
+        assert fdsn_backend  # the ShakeMap path is the one under test

--- a/libs/providers/hazards/tests/fdsn/test_earthlens_fdsn.py
+++ b/libs/providers/hazards/tests/fdsn/test_earthlens_fdsn.py
@@ -88,3 +88,32 @@ class TestFacadeDownload:
         fc = _make_facade(tmp_path).download()
         assert isinstance(fc, GeoDataFrame)
         assert len(fc) == 1, f"expected 1 event, got {len(fc)}"
+
+
+@pytest.mark.fdsn
+class TestFacadeShakemapKeywords:
+    """The ShakeMap keywords ride through the facade's `**backend_kwargs`."""
+
+    def test_shakemap_keywords_forwarded(self, tmp_path: Path):
+        """with_shakemap, layers and the ceiling reach the backend."""
+        facade = _make_facade(
+            tmp_path,
+            with_shakemap=True,
+            shakemap_layers=["mmi_mean", "pga_mean"],
+            max_shakemap_events=7,
+        )
+        backend = facade.datasource
+        assert backend._with_shakemap is True
+        assert backend._shakemap_layers == ("mmi_mean", "pga_mean")
+        assert backend._max_shakemap_events == 7
+
+    def test_output_kind_unchanged_by_shakemap(self, tmp_path: Path):
+        """The facade still sees a vector backend with the flag on."""
+        facade = _make_facade(tmp_path, with_shakemap=True)
+        assert facade.datasource.OUTPUT_KIND == "vector"
+
+    def test_force_is_a_download_argument(self, tmp_path: Path, fake_fdsn: _FakeFdsn):
+        """force= is accepted by download(), not by the constructor."""
+        facade = _make_facade(tmp_path)
+        fc = facade.download(force=True)
+        assert isinstance(fc, GeoDataFrame)

--- a/libs/providers/hazards/tests/fdsn/test_fdsn_e2e.py
+++ b/libs/providers/hazards/tests/fdsn/test_fdsn_e2e.py
@@ -126,9 +126,10 @@ class TestShakemapLiveSideOutput:
         assert "4326" in dataset.GetProjection(), "CRS should be assigned"
         assert dataset.RasterXSize > 1 and dataset.RasterYSize > 1
 
-        leftovers = [
-            path.name
-            for path in (tmp_path / "shakemap").rglob("*")
-            if path.suffix in {".zip", ".flt", ".hdr"}
-        ]
-        assert leftovers == [], f"intermediates should be cleaned up: {leftovers}"
+        # Exact contents, not an allowlist of forbidden suffixes: GDAL drops a
+        # `.prj` beside the grid when its CRS is assigned, which a suffix filter
+        # would not notice.
+        for event_dir in (tmp_path / "shakemap").iterdir():
+            assert sorted(p.name for p in event_dir.iterdir()) == ["mmi_mean.tif"], (
+                f"{event_dir.name} should hold only the requested raster"
+            )

--- a/libs/providers/hazards/tests/fdsn/test_fdsn_e2e.py
+++ b/libs/providers/hazards/tests/fdsn/test_fdsn_e2e.py
@@ -7,7 +7,7 @@ skips them.
 
 Run with:
 
-    pixi run -e dev pytest -m e2e tests/fdsn
+    uv run pytest -m e2e libs/providers/hazards/tests/fdsn
 """
 
 from __future__ import annotations
@@ -95,3 +95,40 @@ class TestEarthscopeLiveQuery:
 
         assert len(fc) > 0, "expected at least one M5+ event from EarthScope"
         assert fc.crs.to_epsg() == 4326
+
+
+@pytest.mark.e2e
+@pytest.mark.fdsn
+class TestShakemapLiveSideOutput:
+    """Live ShakeMap side-output against USGS ComCat."""
+
+    def test_writes_georeferenced_shakemap(self, tmp_path: Path):
+        """A large USGS event yields a georeferenced ShakeMap GeoTIFF."""
+        from osgeo import gdal
+
+        fc = FDSN(
+            start="2023-02-06",
+            end="2023-02-07",
+            variables=["USGS"],
+            lat_lim=[35.0, 39.0],
+            lon_lim=[35.0, 39.0],
+            path=str(tmp_path),
+            min_magnitude=7.0,
+            with_shakemap=True,
+        ).download()
+
+        assert len(fc) > 0, "expected at least one M7+ event in the window"
+        rasters = sorted((tmp_path / "shakemap").rglob("mmi_mean.tif"))
+        assert rasters, "expected a ShakeMap GeoTIFF per event"
+
+        dataset = gdal.Open(str(rasters[0]))
+        assert dataset.GetDriver().ShortName == "GTiff"
+        assert "4326" in dataset.GetProjection(), "CRS should be assigned"
+        assert dataset.RasterXSize > 1 and dataset.RasterYSize > 1
+
+        leftovers = [
+            path.name
+            for path in (tmp_path / "shakemap").rglob("*")
+            if path.suffix in {".zip", ".flt", ".hdr"}
+        ]
+        assert leftovers == [], f"intermediates should be cleaned up: {leftovers}"

--- a/libs/providers/hazards/tests/fdsn/test_fdsn_e2e.py
+++ b/libs/providers/hazards/tests/fdsn/test_fdsn_e2e.py
@@ -104,7 +104,7 @@ class TestShakemapLiveSideOutput:
 
     def test_writes_georeferenced_shakemap(self, tmp_path: Path):
         """A large USGS event yields a georeferenced ShakeMap GeoTIFF."""
-        from osgeo import gdal
+        from osgeo import gdal, osr
 
         fc = FDSN(
             start="2023-02-06",
@@ -122,14 +122,21 @@ class TestShakemapLiveSideOutput:
         assert rasters, "expected a ShakeMap GeoTIFF per event"
 
         dataset = gdal.Open(str(rasters[0]))
-        assert dataset.GetDriver().ShortName == "GTiff"
-        assert "4326" in dataset.GetProjection(), "CRS should be assigned"
-        assert dataset.RasterXSize > 1 and dataset.RasterYSize > 1
+        try:
+            assert dataset.GetDriver().ShortName == "GTiff"
+            spatial_ref = osr.SpatialReference(wkt=dataset.GetProjection())
+            assert spatial_ref.GetAuthorityCode(None) == "4326", (
+                "the CRS should carry an EPSG authority code"
+            )
+            assert dataset.RasterXSize > 1 and dataset.RasterYSize > 1
+        finally:
+            dataset = None
 
         # Exact contents, not an allowlist of forbidden suffixes: GDAL drops a
         # `.prj` beside the grid when its CRS is assigned, which a suffix filter
         # would not notice.
         for event_dir in (tmp_path / "shakemap").iterdir():
-            assert sorted(p.name for p in event_dir.iterdir()) == ["mmi_mean.tif"], (
-                f"{event_dir.name} should hold only the requested raster"
-            )
+            assert sorted(p.name for p in event_dir.iterdir()) == [
+                ".shakemap.json",
+                "mmi_mean.tif",
+            ], f"{event_dir.name} should hold only the raster and its manifest"

--- a/libs/providers/hazards/tests/fdsn/test_fdsn_e2e.py
+++ b/libs/providers/hazards/tests/fdsn/test_fdsn_e2e.py
@@ -128,7 +128,8 @@ class TestShakemapLiveSideOutput:
             assert spatial_ref.GetAuthorityCode(None) == "4326", (
                 "the CRS should carry an EPSG authority code"
             )
-            assert dataset.RasterXSize > 1 and dataset.RasterYSize > 1
+            assert dataset.RasterXSize > 1, "the grid should have real width"
+            assert dataset.RasterYSize > 1, "the grid should have real height"
         finally:
             dataset = None
 

--- a/libs/providers/hazards/tests/fdsn/test_shakemap.py
+++ b/libs/providers/hazards/tests/fdsn/test_shakemap.py
@@ -1,0 +1,346 @@
+"""Tests for the FDSN ShakeMap side-output (helpers plus backend wiring).
+
+The archive format is reproduced synthetically — a tiny ESRI float grid
+plus its header, zipped the way ComCat ships one — so the whole path
+runs offline.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import earthlens.fdsn.backend as fdsn_backend
+from earthlens.fdsn import _helpers
+from earthlens.fdsn.backend import FDSN
+
+from .conftest import _FakeFdsn
+
+pytestmark = pytest.mark.fdsn
+
+_ROWS, _COLS = 4, 5
+
+
+def _make_hdr() -> str:
+    """Return an EHdr header matching the synthetic grid."""
+    return (
+        "BYTEORDER  LSBFIRST\n"
+        "LAYOUT  BIL\n"
+        f"NROWS  {_ROWS}\n"
+        f"NCOLS  {_COLS}\n"
+        "NBANDS  1\n"
+        "NBITS  32\n"
+        f"BANDROWBYTES  {_COLS * 4}\n"
+        f"TOTALROWBYTES  {_COLS * 4}\n"
+        "PIXELTYPE  FLOAT\n"
+        "ULXMAP  35.2\n"
+        "ULYMAP  39.5\n"
+        "XDIM  0.00833333333333\n"
+        "YDIM  0.00833333333333\n"
+        "NODATA  999.0\n"
+    )
+
+
+def _make_archive(layers: tuple[str, ...] = ("mmi_mean", "pga_mean")) -> bytes:
+    """Return zipped `.flt`/`.hdr` pairs for the named layers."""
+    payload = np.arange(_ROWS * _COLS, dtype="<f4").tobytes()
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as bundle:
+        for layer in layers:
+            bundle.writestr(f"{layer}.flt", payload)
+            bundle.writestr(f"{layer}.hdr", _make_hdr())
+    return buffer.getvalue()
+
+
+def _detail(url: str = "https://example.invalid/raster.zip") -> dict[str, Any]:
+    """Return a minimal ComCat detail document carrying a ShakeMap."""
+    return {
+        "properties": {
+            "products": {
+                "shakemap": [{"contents": {_helpers.RASTER_CONTENT_KEY: {"url": url}}}]
+            }
+        }
+    }
+
+
+def _quakeml_id(comcat_id: str) -> str:
+    """Return the QuakeML resource identifier USGS returns for an id."""
+    return (
+        "quakeml:earthquake.usgs.gov/fdsnws/event/1/query"
+        f"?eventid={comcat_id}&format=quakeml"
+    )
+
+
+class _FakeHttp:
+    """Stand-in for `HttpClient` serving one detail document and archive."""
+
+    def __init__(
+        self,
+        detail: dict[str, Any] | None = None,
+        archive: bytes | None = None,
+    ) -> None:
+        self.detail = _detail() if detail is None else detail
+        self.archive = _make_archive() if archive is None else archive
+        self.json_urls: list[str] = []
+        self.downloads: list[tuple[str, Path]] = []
+
+    def get_json(self, url: str, **_kwargs: Any) -> dict[str, Any]:
+        self.json_urls.append(url)
+        return self.detail
+
+    def download(self, url: str, dest: str | Path, **_kwargs: Any) -> Path:
+        dest = Path(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(self.archive)
+        self.downloads.append((url, dest))
+        return dest
+
+
+@pytest.fixture
+def fake_http(monkeypatch: pytest.MonkeyPatch) -> _FakeHttp:
+    """Patch the backend's `HttpClient` with the canned fake."""
+    fake = _FakeHttp()
+    monkeypatch.setattr(fdsn_backend, "HttpClient", lambda **_kwargs: fake)
+    return fake
+
+
+@pytest.fixture
+def usgs_events(fake_fdsn: _FakeFdsn, make_event: Any) -> _FakeFdsn:
+    """Make the fake client return an event carrying a real ComCat id.
+
+    The shared `make_event` factory leaves obspy's auto-generated
+    `smi:local/...` identifier in place, which no ComCat id can be parsed
+    out of — so the ShakeMap path would be exercised only up to its first
+    guard.
+    """
+    from obspy.core.event import Catalog
+
+    event = make_event()
+    event.resource_id = _quakeml_id("us6000jlqa")
+    fake_fdsn.default_result = Catalog(events=[event])
+    return fake_fdsn
+
+
+def _backend(tmp_path: Path, **overrides: Any) -> FDSN:
+    """Build an FDSN backend over a fixed window and box."""
+    params: dict[str, Any] = dict(
+        start="2024-01-01",
+        end="2024-01-31",
+        variables=["USGS"],
+        lat_lim=[30.0, 45.0],
+        lon_lim=[130.0, 145.0],
+        path=str(tmp_path),
+    )
+    params.update(overrides)
+    return FDSN(**params)
+
+
+class TestParseComcatId:
+    """Recovering a ComCat id from a QuakeML resource identifier."""
+
+    def test_extracts_id(self):
+        """A USGS resource identifier yields its bare ComCat id."""
+        assert _helpers.parse_comcat_id(_quakeml_id("us6000jlqa")) == "us6000jlqa"
+
+    def test_identifier_without_eventid_is_none(self):
+        """An identifier carrying no eventid parameter yields None."""
+        assert _helpers.parse_comcat_id("smi:ch.ethz.sed/sc3a/2024abcd") is None
+
+    @pytest.mark.parametrize("value", ["", None])
+    def test_empty_is_none(self, value: str | None):
+        """An empty or missing identifier yields None."""
+        assert _helpers.parse_comcat_id(value) is None
+
+
+class TestNormalizeLayers:
+    """Validating and de-duplicating a requested layer selection."""
+
+    def test_default_is_mmi_mean(self):
+        """None selects macroseismic intensity."""
+        assert _helpers.normalize_layers(None) == ("mmi_mean",)
+
+    def test_preserves_order_and_dedupes(self):
+        """Repeats collapse and first-seen order survives."""
+        result = _helpers.normalize_layers(["pga_mean", "mmi_mean", "pga_mean"])
+        assert result == ("pga_mean", "mmi_mean")
+
+    def test_unknown_layer_raises(self):
+        """An unknown grid name is refused."""
+        with pytest.raises(ValueError, match="unknown ShakeMap layer"):
+            _helpers.normalize_layers(["mmi_median"])
+
+    def test_empty_selection_raises(self):
+        """An explicitly empty selection is refused."""
+        with pytest.raises(ValueError, match="empty"):
+            _helpers.normalize_layers([])
+
+    def test_every_advertised_layer_is_accepted(self):
+        """All fourteen advertised grids validate."""
+        assert _helpers.normalize_layers(_helpers.SHAKEMAP_LAYERS) == tuple(
+            _helpers.SHAKEMAP_LAYERS
+        )
+
+
+class TestShakemapRasterUrl:
+    """Walking a detail document to the raster archive URL."""
+
+    def test_finds_url(self):
+        """A document with a ShakeMap raster yields its URL."""
+        assert _helpers.shakemap_raster_url(_detail()) == (
+            "https://example.invalid/raster.zip"
+        )
+
+    def test_no_shakemap_product_is_none(self):
+        """An event with no ShakeMap product yields None."""
+        assert _helpers.shakemap_raster_url({"properties": {"products": {}}}) is None
+
+    def test_shakemap_without_raster_is_none(self):
+        """A ShakeMap shipping no raster bundle yields None."""
+        detail = {"properties": {"products": {"shakemap": [{"contents": {}}]}}}
+        assert _helpers.shakemap_raster_url(detail) is None
+
+    def test_empty_document_is_none(self):
+        """A document with no properties at all yields None."""
+        assert _helpers.shakemap_raster_url({}) is None
+
+
+class TestExtractLayers:
+    """Unpacking the requested grids out of the archive."""
+
+    def test_extracts_requested_pair(self, tmp_path: Path):
+        """Each requested layer yields its .flt and .hdr on disk."""
+        archive = tmp_path / "raster.zip"
+        archive.write_bytes(_make_archive())
+        extracted = _helpers.extract_layers(archive, ["mmi_mean"], tmp_path / "out")
+        assert set(extracted) == {"mmi_mean"}
+        assert extracted["mmi_mean"].is_file()
+        assert (tmp_path / "out" / "mmi_mean.hdr").is_file()
+
+    def test_missing_layer_is_skipped(self, tmp_path: Path):
+        """A layer the archive lacks is skipped, not raised."""
+        archive = tmp_path / "raster.zip"
+        archive.write_bytes(_make_archive(layers=("mmi_mean",)))
+        extracted = _helpers.extract_layers(
+            archive, ["mmi_mean", "pgv_std"], tmp_path / "out"
+        )
+        assert set(extracted) == {"mmi_mean"}
+
+
+class TestFltToGeotiff:
+    """Converting one ESRI float grid to a georeferenced GeoTIFF."""
+
+    def test_writes_georeferenced_tif(self, tmp_path: Path):
+        """The GeoTIFF carries EPSG:4326 and the grid's shape."""
+        from osgeo import gdal
+
+        archive = tmp_path / "raster.zip"
+        archive.write_bytes(_make_archive(layers=("mmi_mean",)))
+        extracted = _helpers.extract_layers(archive, ["mmi_mean"], tmp_path)
+        dest = _helpers.flt_to_geotiff(extracted["mmi_mean"], tmp_path / "mmi_mean.tif")
+
+        assert dest.is_file()
+        dataset = gdal.Open(str(dest))
+        assert dataset.GetDriver().ShortName == "GTiff"
+        assert dataset.RasterXSize == _COLS
+        assert dataset.RasterYSize == _ROWS
+        assert "4326" in dataset.GetProjection()
+
+
+class TestBackendConstruction:
+    """The constructor's ShakeMap surface."""
+
+    def test_default_output_kind_is_vector(self, tmp_path: Path):
+        """Without the flag the backend stays a vector backend."""
+        assert _backend(tmp_path).OUTPUT_KIND == "vector"
+
+    def test_shakemap_makes_output_kind_mixed(self, tmp_path: Path):
+        """With the flag the instance emits rasters too."""
+        assert _backend(tmp_path, with_shakemap=True).OUTPUT_KIND == "mixed"
+
+    def test_bad_layer_rejected_even_when_flag_off(self, tmp_path: Path):
+        """A typo'd layer name fails at construction, flag or not."""
+        with pytest.raises(ValueError, match="unknown ShakeMap layer"):
+            _backend(tmp_path, shakemap_layers=["nope"])
+
+    def test_aggregate_still_refused_when_mixed(self, tmp_path: Path):
+        """A mixed-output instance still refuses the aggregator."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        with pytest.raises(NotImplementedError, match="aggregate="):
+            backend.download(aggregate=object())
+
+
+class TestBackendShakemapDownload:
+    """The side-output as driven through `download()`."""
+
+    def test_writes_geotiff_per_event(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """Each USGS event gets its requested grid as a GeoTIFF."""
+        backend = _backend(
+            tmp_path, with_shakemap=True, shakemap_layers=["mmi_mean", "pga_mean"]
+        )
+        fc = backend.download(progress_bar=False)
+
+        assert len(fc) == 1, "the event table is unchanged by the side-output"
+        written = sorted(p.name for p in (tmp_path / "shakemap").rglob("*.tif"))
+        assert written == ["mmi_mean.tif", "pga_mean.tif"]
+
+    def test_intermediates_are_cleaned_up(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """The archive and extracted grids do not survive conversion."""
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        leftovers = [
+            p.name
+            for p in (tmp_path / "shakemap").rglob("*")
+            if p.suffix in {".zip", ".flt", ".hdr"}
+        ]
+        assert leftovers == []
+
+    def test_skips_network_on_rerun(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A second run reuses the GeoTIFFs already on disk."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend.download(progress_bar=False)
+        first = len(fake_http.downloads)
+        backend.download(progress_bar=False)
+        assert len(fake_http.downloads) == first, "no second archive fetch"
+
+    def test_no_shakemap_product_writes_nothing(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """An event publishing no ShakeMap yields no raster and no error."""
+        fake_http.detail = {"properties": {"products": {}}}
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        assert list((tmp_path / "shakemap").rglob("*.tif")) == []
+
+    def test_flag_off_makes_no_http_call(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """Without the flag the ComCat path is never touched."""
+        _backend(tmp_path).download(progress_bar=False)
+        assert fake_http.json_urls == []
+        assert not (tmp_path / "shakemap").exists()
+
+    def test_non_usgs_network_is_skipped(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A non-USGS network contributes events but no rasters."""
+        backend = _backend(tmp_path, variables=["EMSC"], with_shakemap=True)
+        fc = backend.download(progress_bar=False)
+
+        assert len(fc) == 1, "the events themselves still arrive"
+        assert fake_http.json_urls == [], "ShakeMap is a USGS-only product"
+
+    def test_detail_url_uses_parsed_comcat_id(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """The detail request is keyed by the event's ComCat id."""
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        assert fake_http.json_urls == [_helpers.detail_url("us6000jlqa")]

--- a/libs/providers/hazards/tests/fdsn/test_shakemap.py
+++ b/libs/providers/hazards/tests/fdsn/test_shakemap.py
@@ -128,6 +128,11 @@ class _FakeHttp:
             raise RuntimeError(f"archive transfer died mid-stream for {url}")
         if any(marker in str(dest) for marker in self.fail_download_for):
             raise RuntimeError(f"archive transfer failed for {url}")
+        magic = kwargs.get("expect_magic")
+        if magic is not None and not self.archive.startswith(magic):
+            # The real client discards the body and raises rather than letting
+            # an HTML error page land as a .zip.
+            raise ValueError(f"body for {url} does not start with {magic!r}")
         dest.write_bytes(self.archive)
         return dest
 
@@ -287,7 +292,7 @@ class TestFltToGeotiff:
 
     def test_writes_georeferenced_tif(self, tmp_path: Path):
         """The GeoTIFF carries EPSG:4326 and the grid's shape."""
-        from osgeo import gdal
+        from osgeo import gdal, osr
 
         archive = tmp_path / "raster.zip"
         archive.write_bytes(_make_archive(layers=("mmi_mean",)))
@@ -296,10 +301,17 @@ class TestFltToGeotiff:
 
         assert dest.is_file()
         dataset = gdal.Open(str(dest))
-        assert dataset.GetDriver().ShortName == "GTiff"
-        assert dataset.RasterXSize == _COLS
-        assert dataset.RasterYSize == _ROWS
-        assert "4326" in dataset.GetProjection()
+        try:
+            assert dataset.GetDriver().ShortName == "GTiff"
+            assert dataset.RasterXSize == _COLS
+            assert dataset.RasterYSize == _ROWS
+            spatial_ref = osr.SpatialReference(wkt=dataset.GetProjection())
+            assert spatial_ref.GetAuthorityCode(None) == "4326", (
+                "the CRS should carry an EPSG authority code, not merely the "
+                "digits 4326 somewhere in its WKT"
+            )
+        finally:
+            dataset = None
 
 
 class TestBackendConstruction:
@@ -353,7 +365,10 @@ class TestBackendShakemapDownload:
         _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
 
         event_dir = tmp_path / "shakemap" / "us6000jlqa"
-        assert sorted(p.name for p in event_dir.iterdir()) == ["mmi_mean.tif"]
+        assert sorted(p.name for p in event_dir.iterdir()) == [
+            _helpers.MANIFEST_NAME,
+            "mmi_mean.tif",
+        ]
 
     def test_skips_network_on_rerun(
         self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
@@ -806,3 +821,225 @@ class TestShakemapDefenceInDepth:
         assert list((tmp_path / "shakemap").rglob("*.tif")) == [], (
             "an over-large member must not be written"
         )
+
+
+class TestShakemapManifestReuse:
+    """A rerun distinguishes 'not fetched' from 'not published upstream'."""
+
+    def test_partial_archive_is_not_refetched(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """An archive permanently missing a layer stops re-downloading."""
+        fake_http.archive = _make_archive(layers=("mmi_mean",))
+        backend = _backend(
+            tmp_path, with_shakemap=True, shakemap_layers=["mmi_mean", "pga_mean"]
+        )
+        backend.download(progress_bar=False)
+        first = len(fake_http.downloads)
+
+        backend.download(progress_bar=False)
+        assert len(fake_http.downloads) == first, (
+            "the missing layer does not exist upstream, so a rerun must not refetch"
+        )
+
+    def test_event_without_shakemap_is_not_re_requested(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """An event publishing no ShakeMap is not asked about twice."""
+        fake_http.detail = {"properties": {"products": {}}}
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend.download(progress_bar=False)
+        first = len(fake_http.json_urls)
+
+        backend.download(progress_bar=False)
+        assert len(fake_http.json_urls) == first, "the negative result is cached"
+
+    def test_widening_the_request_refetches(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """Asking for more layers than last time fetches again."""
+        _backend(tmp_path, with_shakemap=True, shakemap_layers=["mmi_mean"]).download(
+            progress_bar=False
+        )
+        first = len(fake_http.downloads)
+
+        _backend(
+            tmp_path, with_shakemap=True, shakemap_layers=["mmi_mean", "pga_mean"]
+        ).download(progress_bar=False)
+        assert len(fake_http.downloads) == first + 1, "a wider request must refetch"
+
+    def test_unreadable_manifest_refetches(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A corrupt manifest is treated as absent rather than trusted."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend.download(progress_bar=False)
+        first = len(fake_http.downloads)
+
+        manifest = tmp_path / "shakemap" / "us6000jlqa" / _helpers.MANIFEST_NAME
+        manifest.write_text("{not json", encoding="utf-8")
+        backend.download(progress_bar=False)
+        assert len(fake_http.downloads) == first + 1, "a corrupt manifest refetches"
+
+
+class TestShakemapConversionFailure:
+    """The atomic-write failure path, which the success path cannot reach."""
+
+    def test_failed_conversion_publishes_nothing(
+        self,
+        tmp_path: Path,
+        usgs_events: _FakeFdsn,
+        fake_http: _FakeHttp,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A conversion that dies leaves no raster and no staged partial."""
+
+        def _boom(self, path, *args, **kwargs):
+            Path(path).write_bytes(b"partial")
+            raise RuntimeError("conversion failed")
+
+        monkeypatch.setattr("pyramids.dataset.Dataset.to_file", _boom, raising=True)
+
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert list(tmp_path.rglob("*.tif")) == [], "nothing should be published"
+        assert list(tmp_path.rglob("*.partial.tif")) == [], "no staged partial"
+
+    def test_failed_conversion_leaves_no_staging_directory(
+        self,
+        tmp_path: Path,
+        usgs_events: _FakeFdsn,
+        fake_http: _FakeHttp,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """The scratch directory is gone even when the conversion raised.
+
+        The GDAL handle on the extracted grid must be released before the
+        caller cleans up, or Windows refuses to unlink it and the scratch
+        directory survives inside the user's output.
+        """
+
+        def _boom(self, path, *args, **kwargs):
+            raise RuntimeError("conversion failed")
+
+        monkeypatch.setattr("pyramids.dataset.Dataset.to_file", _boom, raising=True)
+
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        staging = list(tmp_path.rglob("_staging"))
+        assert staging == [], f"the scratch directory must not survive: {staging}"
+
+    def test_missing_output_is_refused(self, tmp_path: Path, monkeypatch):
+        """A conversion that writes nothing raises instead of renaming."""
+
+        def _silent(self, path, *args, **kwargs):
+            return None
+
+        archive = tmp_path / "raster.zip"
+        archive.write_bytes(_make_archive(layers=("mmi_mean",)))
+        extracted = _helpers.extract_layers(archive, ["mmi_mean"], tmp_path / "in")
+        monkeypatch.setattr("pyramids.dataset.Dataset.to_file", _silent, raising=True)
+
+        with pytest.raises(RuntimeError, match="produced no output"):
+            _helpers.flt_to_geotiff(extracted["mmi_mean"], tmp_path / "out.tif")
+
+
+class TestShakemapMagicGuard:
+    """The zip-magic guard the real client applies."""
+
+    def test_html_error_page_is_refused(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A 200 carrying an HTML error page never lands as an archive."""
+        fake_http.archive = b"<!DOCTYPE html><html>error</html>"
+
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert list(tmp_path.rglob("*.tif")) == [], "no raster from an HTML body"
+
+
+class TestSearchDeduplication:
+    """A repeated network key must not be queried twice."""
+
+    def test_repeated_network_yields_one_product(self, tmp_path: Path):
+        """Duplicate keys collapse to a single product."""
+        backend = _backend(tmp_path, variables=["USGS", "USGS", "EMSC"])
+        assert [p.id for p in backend._search()] == ["USGS", "EMSC"]
+
+
+class TestShakemapErrorsIgnore:
+    """The third partial-failure policy on the ShakeMap loop."""
+
+    def test_ignore_continues_without_warning(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """errors='ignore' skips a failed event and keeps the healthy one."""
+        fake_fdsn.default_result = _usgs_catalog(make_event, "us1111", "us2222")
+        fake_http.fail_json_for = {"us1111"}
+
+        fc = _backend(tmp_path, with_shakemap=True).download(
+            progress_bar=False, errors="ignore"
+        )
+
+        assert len(fc) == 2, "the event table is unaffected"
+        rastered = sorted(p.name for p in (tmp_path / "shakemap").iterdir())
+        assert rastered == ["us2222"], f"only the healthy event: {rastered}"
+
+
+class TestShakemapStagingLeakIsReported:
+    """A scratch directory that cannot be removed is announced, not hidden."""
+
+    def test_unremovable_staging_is_logged(
+        self,
+        tmp_path: Path,
+        usgs_events: _FakeFdsn,
+        fake_http: _FakeHttp,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A failed rmtree produces a warning naming the directory."""
+        from loguru import logger as loguru_logger
+
+        monkeypatch.setattr(fdsn_backend.shutil, "rmtree", lambda *a, **k: None)
+
+        messages: list[str] = []
+        sink_id = loguru_logger.add(lambda message: messages.append(str(message)))
+        try:
+            _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert any("staging directory" in m for m in messages), (
+            f"a surviving scratch directory should be reported, got: {messages}"
+        )
+
+
+class _CloselessSession:
+    """A session-like object with no `close`, as `RequestsGet` is."""
+
+
+class TestShakemapCloselessSession:
+    """Closing must tolerate a transport that cannot be closed."""
+
+    def test_session_without_close_is_survived(
+        self,
+        tmp_path: Path,
+        usgs_events: _FakeFdsn,
+        fake_http: _FakeHttp,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A RequestsGet-style session does not break the download.
+
+        `earthlens.testing` swaps `HttpClient`'s default transport for
+        `RequestsGet`, which has no `close()`, so this is the shape the whole
+        suite and any backend using that adapter actually sees.
+        """
+        monkeypatch.setattr(fake_http, "session", _CloselessSession())
+
+        fc = _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert len(fc) == 1, "the download should complete regardless"
+        assert list((tmp_path / "shakemap").rglob("*.tif")), "rasters still written"

--- a/libs/providers/hazards/tests/fdsn/test_shakemap.py
+++ b/libs/providers/hazards/tests/fdsn/test_shakemap.py
@@ -8,12 +8,14 @@ runs offline.
 from __future__ import annotations
 
 import io
+import json
 import zipfile
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pytest
+import requests
 
 import earthlens.fdsn.backend as fdsn_backend
 from earthlens.fdsn import _helpers
@@ -108,6 +110,7 @@ class _FakeHttp:
         self.fail_json_for: set[str] = set()
         self.fail_download_for: set[str] = set()
         self.partial_download_for: set[str] = set()
+        self.builds = 0
         self.session = _FakeSession()
 
     def get_json(self, url: str, **_kwargs: Any) -> dict[str, Any]:
@@ -140,6 +143,7 @@ class _FakeHttp:
 def _build_fake_http(fake: _FakeHttp, **kwargs: Any) -> _FakeHttp:
     """Record the kwargs the backend built its client with, then serve it."""
     fake.init_kwargs = kwargs
+    fake.builds += 1
     return fake
 
 
@@ -458,6 +462,9 @@ class TestClientLifecycle:
         """Two events in one download share a single client."""
         fake_fdsn.default_result = _usgs_catalog(make_event, "us1111", "us2222")
         _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        assert fake_http.builds == 1, (
+            f"the client should be built once for the batch, got {fake_http.builds}"
+        )
         assert fake_http.session.closed == 1, "one client for the whole batch"
 
 
@@ -874,8 +881,8 @@ class TestShakemapFanOutCeiling:
             loguru_logger.remove(sink_id)
 
         assert any(
-            "max_shakemap_events" in m and "skipping 1" in m for m in messages
-        ), f"the dropped count should be announced, got: {messages}"
+            "max_shakemap_events" in m and "deferring 1" in m for m in messages
+        ), f"the deferred count should be announced, got: {messages}"
 
     def test_ceiling_rejects_non_positive(self, tmp_path: Path):
         """A zero or negative ceiling is refused at construction."""
@@ -903,9 +910,13 @@ class TestShakemapClientWiring:
         """The client is built with a politeness interval and transport retries."""
         _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
 
-        assert fake_http.init_kwargs.get("min_interval"), "expected a throttle"
-        assert fake_http.init_kwargs.get("retry_on_exceptions"), (
-            "expected transport-exception retries, as flodis/hanze do"
+        assert fake_http.init_kwargs.get("min_interval") > 0, "expected a throttle"
+        assert fake_http.init_kwargs.get("timeout"), "expected an explicit timeout"
+        retried = fake_http.init_kwargs.get("retry_on_exceptions") or ()
+        assert requests.ConnectionError in retried, "a dropped connection retries"
+        assert requests.Timeout in retried, "a timeout retries"
+        assert requests.exceptions.ChunkedEncodingError in retried, (
+            "a multi-megabyte body dies mid-stream, which is neither of the above"
         )
 
     def test_progress_flag_reaches_the_archive_fetch(
@@ -1128,13 +1139,25 @@ class TestShakemapErrorsIgnore:
         fake_fdsn.default_result = _usgs_catalog(make_event, "us1111", "us2222")
         fake_http.fail_json_for = {"us1111"}
 
-        fc = _backend(tmp_path, with_shakemap=True).download(
-            progress_bar=False, errors="ignore"
+        from loguru import logger as loguru_logger
+
+        messages: list[str] = []
+        sink_id = loguru_logger.add(
+            lambda message: messages.append(str(message)), level="WARNING"
         )
+        try:
+            fc = _backend(tmp_path, with_shakemap=True).download(
+                progress_bar=False, errors="ignore"
+            )
+        finally:
+            loguru_logger.remove(sink_id)
 
         assert len(fc) == 2, "the event table is unaffected"
         rastered = sorted(p.name for p in (tmp_path / "shakemap").iterdir())
         assert rastered == ["us2222"], f"only the healthy event: {rastered}"
+        assert not [m for m in messages if "us1111" in m], (
+            f"errors='ignore' should not warn about the skipped event: {messages}"
+        )
 
 
 class TestShakemapStagingLeakIsReported:
@@ -1190,3 +1213,247 @@ class TestShakemapCloselessSession:
 
         assert len(fc) == 1, "the download should complete regardless"
         assert list((tmp_path / "shakemap").rglob("*.tif")), "rasters still written"
+
+
+class TestCeilingAdvancesAcrossRuns:
+    """The ceiling bounds work, so a re-run reaches events it deferred."""
+
+    def test_rerun_walks_further_through_the_list(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """Three events under a ceiling of two are all reached in two runs."""
+        fake_fdsn.default_result = _usgs_catalog(
+            make_event, "us1111", "us2222", "us3333"
+        )
+        backend = _backend(tmp_path, with_shakemap=True, max_shakemap_events=2)
+
+        backend.download(progress_bar=False)
+        first = sorted(p.name for p in (tmp_path / "shakemap").iterdir())
+        assert first == ["us1111", "us2222"], f"first run takes two: {first}"
+
+        backend.download(progress_bar=False)
+        second = sorted(p.name for p in (tmp_path / "shakemap").iterdir())
+        assert second == ["us1111", "us2222", "us3333"], (
+            f"the re-run must reach the deferred event, got {second}"
+        )
+
+    def test_cached_events_do_not_consume_budget(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """An event already on disk costs no ceiling budget."""
+        fake_fdsn.default_result = _usgs_catalog(make_event, "us1111", "us2222")
+        _backend(tmp_path, with_shakemap=True, max_shakemap_events=1).download(
+            progress_bar=False
+        )
+        _backend(tmp_path, with_shakemap=True, max_shakemap_events=1).download(
+            progress_bar=False
+        )
+
+        fetched = sorted(p.name for p in (tmp_path / "shakemap").iterdir())
+        assert fetched == ["us1111", "us2222"], f"both reached in two runs: {fetched}"
+
+
+class TestNegativeCacheExpiry:
+    """A no-ShakeMap answer ages out rather than sticking forever."""
+
+    def test_fresh_negative_is_reused(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A recent negative result still skips the detail request."""
+        fake_http.detail = {"properties": {"products": {}}}
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend.download(progress_bar=False)
+        first = len(fake_http.json_urls)
+
+        backend.download(progress_bar=False)
+        assert len(fake_http.json_urls) == first, "a fresh negative is cached"
+
+    def test_stale_negative_is_rechecked(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """An aged negative result is checked again, so a late grid is found."""
+        fake_http.detail = {"properties": {"products": {}}}
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend.download(progress_bar=False)
+
+        manifest_path = tmp_path / "shakemap" / "us6000jlqa" / _helpers.MANIFEST_NAME
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        payload["checked"] -= fdsn_backend._NEGATIVE_CACHE_SECONDS + 1
+        manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        fake_http.detail = _detail()
+        backend.download(progress_bar=False)
+
+        assert list((tmp_path / "shakemap").rglob("*.tif")), (
+            "the grid published since the last run should now be fetched"
+        )
+
+    def test_positive_result_does_not_expire(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """Rasters on disk are reused however old the manifest is."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend.download(progress_bar=False)
+        first = len(fake_http.downloads)
+
+        manifest_path = tmp_path / "shakemap" / "us6000jlqa" / _helpers.MANIFEST_NAME
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        payload["checked"] = 0.0
+        manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        backend.download(progress_bar=False)
+        assert len(fake_http.downloads) == first, "a present raster is still reused"
+
+
+class TestManifestMerge:
+    """Narrowing the requested layers must not lose what is on disk."""
+
+    def test_narrowing_then_widening_does_not_refetch(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """mmi, then pga, then mmi again costs two fetches, not three."""
+        for layers in (["mmi_mean"], ["pga_mean"], ["mmi_mean"]):
+            _backend(tmp_path, with_shakemap=True, shakemap_layers=layers).download(
+                progress_bar=False
+            )
+
+        assert len(fake_http.downloads) == 2, (
+            "the third run repeats the first, which is already on disk: "
+            f"{len(fake_http.downloads)} fetches"
+        )
+
+    def test_manifest_describes_everything_on_disk(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """After two narrow runs the manifest lists both rasters."""
+        for layers in (["mmi_mean"], ["pga_mean"]):
+            _backend(tmp_path, with_shakemap=True, shakemap_layers=layers).download(
+                progress_bar=False
+            )
+
+        event_dir = tmp_path / "shakemap" / "us6000jlqa"
+        manifest = _helpers.read_manifest(event_dir)
+        on_disk = sorted(p.stem for p in event_dir.glob("*.tif"))
+        assert manifest["produced"] == on_disk, (
+            f"manifest should describe disk, got {manifest['produced']} vs {on_disk}"
+        )
+
+
+class TestManifestValidation:
+    """A structurally invalid manifest refetches instead of raising."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"schema": 1, "requested": 5, "produced": [], "checked": 0.0},
+            {"schema": 1, "requested": [], "produced": "no", "checked": 0.0},
+            {"schema": 1, "requested": [1], "produced": [], "checked": 0.0},
+            {"schema": 99, "requested": [], "produced": [], "checked": 0.0},
+            {"requested": [], "produced": [], "checked": 0.0},
+            {"schema": 1, "requested": [], "produced": [], "checked": "soon"},
+        ],
+    )
+    def test_invalid_payload_reads_as_absent(self, tmp_path: Path, payload: dict):
+        """Any wrong field type or schema reads as no manifest at all."""
+        (tmp_path / _helpers.MANIFEST_NAME).write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+        assert _helpers.read_manifest(tmp_path) is None
+
+    def test_invalid_manifest_refetches_and_self_heals(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A bad manifest causes a refetch and is rewritten valid."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend.download(progress_bar=False)
+        first = len(fake_http.downloads)
+
+        manifest_path = tmp_path / "shakemap" / "us6000jlqa" / _helpers.MANIFEST_NAME
+        manifest_path.write_text('{"requested": 5}', encoding="utf-8")
+
+        backend.download(progress_bar=False)
+        assert len(fake_http.downloads) == first + 1, "a bad manifest refetches"
+        assert _helpers.read_manifest(manifest_path.parent) is not None, (
+            "the rewrite should repair the manifest"
+        )
+
+
+class TestCorruptArchiveIsBadZip:
+    """A body that passes the magic check but is not a usable zip."""
+
+    def test_truncated_zip_is_skipped(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A PK-prefixed but truncated archive is skipped, not raised."""
+        fake_http.archive = _make_archive()[:40]
+
+        fc = _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert len(fc) == 1, "the event table is unaffected"
+        assert list(tmp_path.rglob("*.tif")) == [], "no raster from a broken zip"
+
+
+class TestShakemapProductVersion:
+    """Reading the ShakeMap product's updateTime off a detail document."""
+
+    def test_reads_update_time(self):
+        """A product carrying updateTime yields it as a string."""
+        detail = {
+            "properties": {"products": {"shakemap": [{"updateTime": 1756575631263}]}}
+        }
+        assert _helpers.shakemap_product_version(detail) == "1756575631263"
+
+    def test_missing_update_time_is_none(self):
+        """A product without updateTime yields None rather than raising."""
+        detail = {"properties": {"products": {"shakemap": [{}]}}}
+        assert _helpers.shakemap_product_version(detail) is None
+
+    def test_null_entry_is_none(self):
+        """A null first product entry yields None."""
+        detail = {"properties": {"products": {"shakemap": [None]}}}
+        assert _helpers.shakemap_product_version(detail) is None
+
+    def test_no_product_is_none(self):
+        """An event with no ShakeMap yields None."""
+        assert (
+            _helpers.shakemap_product_version({"properties": {"products": {}}}) is None
+        )
+
+
+class TestManifestWriteFailure:
+    """A manifest that cannot be saved must not cost the rasters."""
+
+    def test_unwritable_manifest_warns_but_keeps_rasters(
+        self,
+        tmp_path: Path,
+        usgs_events: _FakeFdsn,
+        fake_http: _FakeHttp,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """The raster survives and the failure is reported."""
+        from loguru import logger as loguru_logger
+
+        def _refuse(*_args: Any, **_kwargs: Any) -> None:
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(fdsn_backend._helpers, "write_manifest", _refuse)
+
+        messages: list[str] = []
+        sink_id = loguru_logger.add(lambda message: messages.append(str(message)))
+        try:
+            _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert list(tmp_path.rglob("*.tif")), "the raster must still be written"
+        assert any("could not record the ShakeMap manifest" in m for m in messages), (
+            f"the failure should be reported, got: {messages}"
+        )

--- a/libs/providers/hazards/tests/fdsn/test_shakemap.py
+++ b/libs/providers/hazards/tests/fdsn/test_shakemap.py
@@ -1887,3 +1887,63 @@ class TestRecordIsStale:
         """A stamp from the future fails towards refetching."""
         backend = _backend(tmp_path, with_shakemap=True)
         assert backend._record_is_stale({"checked": time.time() + 86400}) is True
+
+
+class TestSurvivorGuards:
+    """Guards a mutation pass found unpinned by the round-4 tests."""
+
+    def test_duplicate_ids_do_not_consume_extra_ceiling(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """A repeated event must not spend the ceiling twice.
+
+        Counting the duplicate would defer a distinct event that the run had
+        budget for. The download count alone cannot show this — the manifest
+        already stops the second copy being fetched — so the assertion is on
+        which events were reached.
+        """
+        from obspy.core.event import Catalog
+
+        first = make_event(lon=139.0, lat=35.0)
+        first.resource_id = _quakeml_id("us1111")
+        duplicate = make_event(lon=139.5, lat=35.5)
+        duplicate.resource_id = _quakeml_id("us1111")
+        other = make_event(lon=141.0, lat=37.0)
+        other.resource_id = _quakeml_id("us2222")
+        fake_fdsn.default_result = Catalog(events=[first, duplicate, other])
+
+        _backend(tmp_path, with_shakemap=True, max_shakemap_events=2).download(
+            progress_bar=False
+        )
+
+        reached = sorted(p.name for p in (tmp_path / "shakemap").iterdir())
+        assert reached == ["us1111", "us2222"], (
+            f"the duplicate must not push us2222 past the ceiling, got {reached}"
+        )
+
+    def test_staged_manifest_name_is_process_unique(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The manifest is staged under a name carrying this process id.
+
+        Two runs sharing an output root would otherwise stage the same path and
+        rename each other half-written file into place.
+        """
+        staged_names: list[str] = []
+        original_replace = Path.replace
+
+        def _record(self, target):
+            staged_names.append(self.name)
+            return original_replace(self, target)
+
+        monkeypatch.setattr(Path, "replace", _record)
+        _helpers.write_manifest(tmp_path, ["mmi_mean"], ["mmi_mean"], checked=1.0)
+
+        assert staged_names, "the manifest should be staged then renamed"
+        assert str(os.getpid()) in staged_names[0], (
+            f"the staged name should carry the pid, got {staged_names[0]}"
+        )

--- a/libs/providers/hazards/tests/fdsn/test_shakemap.py
+++ b/libs/providers/hazards/tests/fdsn/test_shakemap.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import time
 import zipfile
 from pathlib import Path
 from typing import Any
@@ -1456,4 +1458,93 @@ class TestManifestWriteFailure:
         assert list(tmp_path.rglob("*.tif")), "the raster must still be written"
         assert any("could not record the ShakeMap manifest" in m for m in messages), (
             f"the failure should be reported, got: {messages}"
+        )
+
+
+class TestForceAndCeiling:
+    """force= makes every event pending, so the ceiling applies to all."""
+
+    def test_force_makes_cached_events_spend_budget(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """Under force= a cached event counts against the ceiling again."""
+        fake_fdsn.default_result = _usgs_catalog(make_event, "us1111", "us2222")
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        before = len(fake_http.downloads)
+
+        _backend(tmp_path, with_shakemap=True, max_shakemap_events=1).download(
+            progress_bar=False, force=True
+        )
+        assert len(fake_http.downloads) == before + 1, (
+            "force= should refetch exactly one event under a ceiling of one"
+        )
+
+
+class TestCachedRastersSemantics:
+    """`None` means fetch; an empty list means nothing to fetch."""
+
+    def test_absent_manifest_is_none(self, tmp_path: Path):
+        """An event never seen before must be fetched."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        assert backend._cached_rasters(tmp_path / "nope") is None
+
+    def test_known_empty_is_an_empty_list(self, tmp_path: Path):
+        """A fresh no-ShakeMap record is a hit that yields no rasters."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        _helpers.write_manifest(tmp_path, ["mmi_mean"], [], checked=time.time())
+        assert backend._cached_rasters(tmp_path) == []
+
+    def test_force_overrides_a_hit(self, tmp_path: Path):
+        """force= turns any hit back into a fetch."""
+        _helpers.write_manifest(tmp_path, ["mmi_mean"], [], checked=time.time())
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend._force = True
+        assert backend._cached_rasters(tmp_path) is None
+
+    def test_is_cached_matches_the_decision(self, tmp_path: Path):
+        """`_is_cached` agrees with `_cached_rasters` for both hit kinds."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        event_id = _quakeml_id("us6000jlqa")
+        assert backend._is_cached(event_id) is False
+
+        event_dir = backend._event_dir("us6000jlqa")
+        _helpers.write_manifest(event_dir, ["mmi_mean"], [], checked=time.time())
+        assert backend._is_cached(event_id) is True
+
+    def test_unparseable_id_is_not_cached(self, tmp_path: Path):
+        """An id yielding no ComCat id counts as work, not as a hit."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        assert backend._is_cached("smi:local/whatever") is False
+
+
+class TestStagingIsProcessUnique:
+    """Two runs over one output root must not share scratch space."""
+
+    def test_staging_directory_carries_the_pid(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """The scratch directory name includes the process id."""
+        seen: list[str] = []
+
+        original = _helpers.extract_layers
+
+        def _record(archive: Path, layers: Any, dest_dir: Path):
+            seen.append(dest_dir.name)
+            return original(archive, layers, dest_dir)
+
+        fake_http.detail = _detail()
+        backend = _backend(tmp_path, with_shakemap=True)
+        import pytest as _pytest
+
+        with _pytest.MonkeyPatch.context() as patch:
+            patch.setattr(fdsn_backend._helpers, "extract_layers", _record)
+            backend.download(progress_bar=False)
+
+        assert seen, "the archive should have been extracted"
+        assert seen[0] == f"_staging-{os.getpid()}", (
+            f"the scratch directory should be process-unique, got {seen[0]}"
         )

--- a/libs/providers/hazards/tests/fdsn/test_shakemap.py
+++ b/libs/providers/hazards/tests/fdsn/test_shakemap.py
@@ -1288,7 +1288,9 @@ class TestNegativeCacheExpiry:
 
         manifest_path = tmp_path / "shakemap" / "us6000jlqa" / _helpers.MANIFEST_NAME
         payload = json.loads(manifest_path.read_text(encoding="utf-8"))
-        payload["checked"] -= fdsn_backend._NEGATIVE_CACHE_SECONDS + 1
+        # A fixed epoch value, not one derived from the constant under test:
+        # deriving it means the test passes for any TTL, including an absurd one.
+        payload["checked"] = 1.0
         manifest_path.write_text(json.dumps(payload), encoding="utf-8")
 
         fake_http.detail = _detail()
@@ -1515,10 +1517,14 @@ class TestCachedRastersSemantics:
         _helpers.write_manifest(event_dir, ["mmi_mean"], [], checked=time.time())
         assert backend._is_cached(event_id) is True
 
-    def test_unparseable_id_is_not_cached(self, tmp_path: Path):
-        """An id yielding no ComCat id counts as work, not as a hit."""
+    def test_unparseable_id_is_not_fetchable(self, tmp_path: Path):
+        """An id yielding no ComCat id is dropped before the ceiling counts it.
+
+        It can never become cached, so treating it as pending work would let it
+        occupy the ceiling on every run and starve the events behind it.
+        """
         backend = _backend(tmp_path, with_shakemap=True)
-        assert backend._is_cached("smi:local/whatever") is False
+        assert backend._is_fetchable("smi:local/whatever") is False
 
 
 class TestStagingIsProcessUnique:
@@ -1548,3 +1554,336 @@ class TestStagingIsProcessUnique:
         assert seen[0] == f"_staging-{os.getpid()}", (
             f"the scratch directory should be process-unique, got {seen[0]}"
         )
+
+
+class TestCeilingIsNotStarved:
+    """Events that can never be fetched must not occupy the ceiling."""
+
+    def test_unparseable_ids_do_not_consume_budget(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """Three dead ids plus one good event still fetches the good one."""
+        from obspy.core.event import Catalog
+
+        events = []
+        for index in range(3):
+            event = make_event(lon=139.0 + index, lat=35.0 + index)
+            event.resource_id = f"smi:local/dead-{index}"
+            events.append(event)
+        good = make_event(lon=150.0, lat=40.0)
+        good.resource_id = _quakeml_id("us6000jlqa")
+        events.append(good)
+        fake_fdsn.default_result = Catalog(events=events)
+
+        _backend(tmp_path, with_shakemap=True, max_shakemap_events=2).download(
+            progress_bar=False
+        )
+
+        assert fake_http.json_urls, "the fetchable event must not be starved out"
+        assert list((tmp_path / "shakemap").rglob("*.tif")), "its raster is written"
+
+    def test_permanent_failures_are_retried_not_cached(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """An event failing every run is retried rather than cached as dead."""
+        fake_fdsn.default_result = _usgs_catalog(make_event, "us1111", "us2222")
+        fake_http.fail_json_for = {"us1111", "us2222"}
+
+        backend = _backend(tmp_path, with_shakemap=True, max_shakemap_events=2)
+        backend.download(progress_bar=False)
+        backend.download(progress_bar=False)
+
+        assert len(fake_http.json_urls) == 4, (
+            "a transient failure must not become a permanent negative"
+        )
+
+
+class TestPartialProductionExpires:
+    """The TTL applies per requested layer, not only to a total blank."""
+
+    def test_missing_layer_is_rechecked_after_the_window(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A layer published upstream later is picked up once the record ages."""
+        fake_http.archive = _make_archive(layers=("mmi_mean",))
+        backend = _backend(
+            tmp_path, with_shakemap=True, shakemap_layers=["mmi_mean", "pga_mean"]
+        )
+        backend.download(progress_bar=False)
+
+        manifest_path = tmp_path / "shakemap" / "us6000jlqa" / _helpers.MANIFEST_NAME
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        payload["checked"] = 1.0
+        manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        fake_http.archive = _make_archive(layers=("mmi_mean", "pga_mean"))
+        backend.download(progress_bar=False)
+
+        event_dir = tmp_path / "shakemap" / "us6000jlqa"
+        written = sorted(p.name for p in event_dir.glob("*.tif"))
+        assert written == ["mmi_mean.tif", "pga_mean.tif"], (
+            f"the late-published layer should be picked up, got {written}"
+        )
+
+    def test_short_result_is_warned_about(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """Returning fewer layers than requested is announced."""
+        from loguru import logger as loguru_logger
+
+        fake_http.archive = _make_archive(layers=("mmi_mean",))
+        backend = _backend(
+            tmp_path, with_shakemap=True, shakemap_layers=["mmi_mean", "pga_mean"]
+        )
+        backend.download(progress_bar=False)
+
+        messages: list[str] = []
+        sink_id = loguru_logger.add(lambda message: messages.append(str(message)))
+        try:
+            backend.download(progress_bar=False)
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert any("are not available for this event" in m for m in messages), (
+            f"a short result should be reported, got: {messages}"
+        )
+
+    @pytest.mark.parametrize("stamp", [4102444800.0, "soon", None])
+    def test_untrustworthy_timestamp_refetches(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp, stamp: Any
+    ):
+        """A future or unusable stamp fails towards refetching."""
+        fake_http.detail = {"properties": {"products": {}}}
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend.download(progress_bar=False)
+        first = len(fake_http.json_urls)
+
+        manifest_path = tmp_path / "shakemap" / "us6000jlqa" / _helpers.MANIFEST_NAME
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        payload["checked"] = stamp
+        manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        backend.download(progress_bar=False)
+        assert len(fake_http.json_urls) > first, (
+            f"a {stamp!r} timestamp must not cache the answer forever"
+        )
+
+
+class TestRoundFourHardening:
+    """The remaining round-4 guards."""
+
+    def test_non_https_archive_url_is_refused(self):
+        """An archive URL that is not https is not handed to the downloader."""
+        detail = {
+            "properties": {
+                "products": {
+                    "shakemap": [
+                        {"contents": {"download/raster.zip": {"url": "http://x/r.zip"}}}
+                    ]
+                }
+            }
+        }
+        assert _helpers.shakemap_raster_url(detail) is None
+
+    def test_product_version_must_be_a_string(self, tmp_path: Path):
+        """A non-string product_version invalidates the manifest."""
+        (tmp_path / _helpers.MANIFEST_NAME).write_text(
+            json.dumps(
+                {
+                    "schema": _helpers.MANIFEST_SCHEMA,
+                    "requested": [],
+                    "produced": [],
+                    "checked": 0.0,
+                    "product_version": 12,
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert _helpers.read_manifest(tmp_path) is None
+
+    def test_product_version_is_recorded(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """The ShakeMap updateTime reaches the manifest."""
+        detail = _detail()
+        detail["properties"]["products"]["shakemap"][0]["updateTime"] = 1756575631263
+        fake_http.detail = detail
+
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        manifest = _helpers.read_manifest(tmp_path / "shakemap" / "us6000jlqa")
+        assert manifest["product_version"] == "1756575631263"
+
+    def test_manifest_write_is_atomic(self, tmp_path: Path):
+        """The staged manifest is process-unique and does not survive."""
+        _helpers.write_manifest(tmp_path, ["mmi_mean"], ["mmi_mean"], checked=1.0)
+        leftovers = [p.name for p in tmp_path.iterdir() if "partial" in p.name]
+        assert leftovers == [], f"no staged manifest should survive: {leftovers}"
+        assert (tmp_path / _helpers.MANIFEST_NAME).is_file()
+
+    def test_write_does_not_warn_about_refetching(self, tmp_path: Path):
+        """Repairing a malformed manifest is not a read, so it does not warn."""
+        from loguru import logger as loguru_logger
+
+        (tmp_path / _helpers.MANIFEST_NAME).write_text("{oops", encoding="utf-8")
+
+        messages: list[str] = []
+        sink_id = loguru_logger.add(lambda message: messages.append(str(message)))
+        try:
+            _helpers.write_manifest(tmp_path, ["mmi_mean"], [], checked=1.0)
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert not [m for m in messages if "refetching" in m], (
+            f"a write should not log a reader remedy: {messages}"
+        )
+
+    def test_empty_shakemap_root_is_removed(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A run that produced nothing leaves no shakemap directory."""
+        fake_http.archive = b"not a zip at all"
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        assert not (tmp_path / "shakemap").exists(), (
+            "an unproductive run should not leave an empty root behind"
+        )
+
+    def test_orphaned_staging_is_reported(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A scratch directory from another process is announced, not deleted."""
+        from loguru import logger as loguru_logger
+
+        event_dir = tmp_path / "shakemap" / "us6000jlqa"
+        orphan = event_dir / "_staging-999999"
+        orphan.mkdir(parents=True)
+        (orphan / "leftover.flt").write_bytes(b"x")
+        fake_http.archive = b"not a zip at all"
+
+        messages: list[str] = []
+        sink_id = loguru_logger.add(lambda message: messages.append(str(message)))
+        try:
+            _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert orphan.exists(), "another process scratch space is not ours to delete"
+        assert any("orphaned scratch" in m for m in messages), (
+            f"the orphan should be reported, got: {messages}"
+        )
+
+    def test_repeated_event_id_is_fetched_once(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """The same ComCat event reported twice costs one fetch."""
+        from obspy.core.event import Catalog
+
+        first = make_event()
+        first.resource_id = _quakeml_id("us6000jlqa")
+        second = make_event(lon=140.0, lat=36.0)
+        second.resource_id = _quakeml_id("us6000jlqa")
+        fake_fdsn.default_result = Catalog(events=[first, second])
+
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        assert len(fake_http.downloads) == 1, "a duplicate id should not refetch"
+
+    @pytest.mark.parametrize("bad", ["ten", 3.5, None])
+    def test_ceiling_rejects_non_integer(self, tmp_path: Path, bad: Any):
+        """A non-integer ceiling is refused with a TypeError."""
+        with pytest.raises(TypeError, match="must be an integer"):
+            _backend(tmp_path, with_shakemap=True, max_shakemap_events=bad)
+
+
+class TestDefensiveGuardsDirectly:
+    """Guards `_is_fetchable` now shields, exercised on their own.
+
+    The filter added for the ceiling means these branches are unreachable
+    through `download()`, but both methods are callable directly and keep the
+    checks, so they are pinned here rather than left untested.
+    """
+
+    def test_is_cached_refuses_an_unparseable_id(self, tmp_path: Path):
+        """`_is_cached` still declines an id it cannot resolve."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        assert backend._is_cached("smi:local/whatever") is False
+
+    def test_is_cached_refuses_an_escaping_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """`_is_cached` declines an id whose directory escapes the root."""
+        monkeypatch.setattr(fdsn_backend._helpers, "parse_comcat_id", lambda _id: "..")
+        backend = _backend(tmp_path, with_shakemap=True)
+        assert backend._is_cached(_quakeml_id("us6000jlqa")) is False
+
+    def test_shakemap_for_event_refuses_an_unparseable_id(self, tmp_path: Path):
+        """Called directly, the fetch still declines an unresolvable id."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        assert backend._shakemap_for_event("smi:local/whatever") == []
+
+    def test_shakemap_for_event_refuses_an_escaping_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Called directly, the fetch still declines an escaping directory."""
+        monkeypatch.setattr(fdsn_backend._helpers, "parse_comcat_id", lambda _id: "..")
+        backend = _backend(tmp_path, with_shakemap=True)
+        assert backend._shakemap_for_event(_quakeml_id("us6000jlqa")) == []
+
+    def test_event_directory_with_real_leftovers_is_kept_quietly(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A directory holding a real file is neither removed nor reported."""
+        from loguru import logger as loguru_logger
+
+        event_dir = tmp_path / "shakemap" / "us6000jlqa"
+        event_dir.mkdir(parents=True)
+        (event_dir / "notes.txt").write_text("keep me", encoding="utf-8")
+        fake_http.archive = b"not a zip at all"
+
+        messages: list[str] = []
+        sink_id = loguru_logger.add(lambda message: messages.append(str(message)))
+        try:
+            _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert (event_dir / "notes.txt").is_file(), "an unrelated file must survive"
+        assert not [m for m in messages if "orphaned scratch" in m], (
+            "a real file is not an orphaned scratch directory"
+        )
+
+
+class TestRecordIsStale:
+    """The staleness predicate, exercised directly.
+
+    read_manifest rejects a non-numeric `checked`, so these shapes cannot
+    reach the predicate through a manifest; it keeps the check anyway and it
+    is pinned here.
+    """
+
+    @pytest.mark.parametrize("stamp", ["soon", None, True, [1]])
+    def test_unusable_stamp_is_stale(self, tmp_path: Path, stamp: Any):
+        """A stamp that is not a real number reads as stale."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        assert backend._record_is_stale({"checked": stamp}) is True
+
+    def test_recent_stamp_is_fresh(self, tmp_path: Path):
+        """A stamp from a moment ago is not stale."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        assert backend._record_is_stale({"checked": time.time()}) is False
+
+    def test_future_stamp_is_stale(self, tmp_path: Path):
+        """A stamp from the future fails towards refetching."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        assert backend._record_is_stale({"checked": time.time() + 86400}) is True

--- a/libs/providers/hazards/tests/fdsn/test_shakemap.py
+++ b/libs/providers/hazards/tests/fdsn/test_shakemap.py
@@ -76,6 +76,16 @@ def _quakeml_id(comcat_id: str) -> str:
     )
 
 
+class _FakeSession:
+    """Stand-in for the `requests.Session` an `HttpClient` owns."""
+
+    def __init__(self) -> None:
+        self.closed = 0
+
+    def close(self) -> None:
+        self.closed += 1
+
+
 class _FakeHttp:
     """Stand-in for `HttpClient` serving one detail document and archive.
 
@@ -93,8 +103,12 @@ class _FakeHttp:
         self.archive = _make_archive() if archive is None else archive
         self.json_urls: list[str] = []
         self.downloads: list[tuple[str, Path]] = []
+        self.download_kwargs: list[dict[str, Any]] = []
+        self.init_kwargs: dict[str, Any] = {}
         self.fail_json_for: set[str] = set()
         self.fail_download_for: set[str] = set()
+        self.partial_download_for: set[str] = set()
+        self.session = _FakeSession()
 
     def get_json(self, url: str, **_kwargs: Any) -> dict[str, Any]:
         self.json_urls.append(url)
@@ -102,21 +116,35 @@ class _FakeHttp:
             raise RuntimeError(f"ComCat detail unavailable for {url}")
         return self.detail
 
-    def download(self, url: str, dest: str | Path, **_kwargs: Any) -> Path:
+    def download(self, url: str, dest: str | Path, **kwargs: Any) -> Path:
         dest = Path(dest)
         self.downloads.append((url, dest))
+        self.download_kwargs.append(kwargs)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if any(marker in str(dest) for marker in self.partial_download_for):
+            # Mirror a non-atomic transport dying mid-stream: bytes on disk,
+            # but not a usable archive.
+            dest.write_bytes(self.archive[: len(self.archive) // 2])
+            raise RuntimeError(f"archive transfer died mid-stream for {url}")
         if any(marker in str(dest) for marker in self.fail_download_for):
             raise RuntimeError(f"archive transfer failed for {url}")
-        dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(self.archive)
         return dest
+
+
+def _build_fake_http(fake: _FakeHttp, **kwargs: Any) -> _FakeHttp:
+    """Record the kwargs the backend built its client with, then serve it."""
+    fake.init_kwargs = kwargs
+    return fake
 
 
 @pytest.fixture
 def fake_http(monkeypatch: pytest.MonkeyPatch) -> _FakeHttp:
     """Patch the backend's `HttpClient` with the canned fake."""
     fake = _FakeHttp()
-    monkeypatch.setattr(fdsn_backend, "HttpClient", lambda **_kwargs: fake)
+    monkeypatch.setattr(
+        fdsn_backend, "HttpClient", lambda **kwargs: _build_fake_http(fake, **kwargs)
+    )
     return fake
 
 
@@ -281,17 +309,17 @@ class TestBackendConstruction:
         """Without the flag the backend stays a vector backend."""
         assert _backend(tmp_path).OUTPUT_KIND == "vector"
 
-    def test_shakemap_makes_output_kind_mixed(self, tmp_path: Path):
-        """With the flag the instance emits rasters too."""
-        assert _backend(tmp_path, with_shakemap=True).OUTPUT_KIND == "mixed"
+    def test_shakemap_keeps_output_kind_vector(self, tmp_path: Path):
+        """The rasters are a side effect, so the return shape is unchanged."""
+        assert _backend(tmp_path, with_shakemap=True).OUTPUT_KIND == "vector"
 
     def test_bad_layer_rejected_even_when_flag_off(self, tmp_path: Path):
         """A typo'd layer name fails at construction, flag or not."""
         with pytest.raises(ValueError, match="unknown ShakeMap layer"):
             _backend(tmp_path, shakemap_layers=["nope"])
 
-    def test_aggregate_still_refused_when_mixed(self, tmp_path: Path):
-        """A mixed-output instance still refuses the aggregator."""
+    def test_aggregate_still_refused_with_shakemap(self, tmp_path: Path):
+        """A ShakeMap instance still refuses the aggregator."""
         backend = _backend(tmp_path, with_shakemap=True)
         with pytest.raises(NotImplementedError, match="aggregate="):
             backend.download(aggregate=object())
@@ -313,17 +341,19 @@ class TestBackendShakemapDownload:
         written = sorted(p.name for p in (tmp_path / "shakemap").rglob("*.tif"))
         assert written == ["mmi_mean.tif", "pga_mean.tif"]
 
-    def test_intermediates_are_cleaned_up(
+    def test_event_directory_holds_exactly_the_rasters(
         self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
     ):
-        """The archive and extracted grids do not survive conversion."""
+        """Nothing but the requested GeoTIFFs survives in the output folder.
+
+        Asserts the exact directory listing rather than the absence of a few
+        suffixes: GDAL writes a `.prj` beside the grid when its CRS is
+        assigned, which an allowlist of forbidden extensions would miss.
+        """
         _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
-        leftovers = [
-            p.name
-            for p in (tmp_path / "shakemap").rglob("*")
-            if p.suffix in {".zip", ".flt", ".hdr"}
-        ]
-        assert leftovers == []
+
+        event_dir = tmp_path / "shakemap" / "us6000jlqa"
+        assert sorted(p.name for p in event_dir.iterdir()) == ["mmi_mean.tif"]
 
     def test_skips_network_on_rerun(
         self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
@@ -433,15 +463,22 @@ class TestShakemapFailurePolicy:
         assert len(fc) == 1, "the event table survives a failed transfer"
         assert list((tmp_path / "shakemap").rglob("*.tif")) == []
 
-    def test_failed_download_leaves_no_partial_archive(
+    def test_partially_written_archive_is_cleaned_up(
         self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
     ):
-        """A failed transfer cleans up rather than leaving an archive behind."""
-        fake_http.fail_download_for = {"us6000jlqa"}
+        """A transfer that dies mid-stream leaves no half-archive behind.
+
+        The fake writes real bytes before raising, so the cleanup has
+        something to actually remove.
+        """
+        fake_http.partial_download_for = {"us6000jlqa"}
         _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
 
-        leftovers = [p.name for p in tmp_path.rglob("raster.zip")]
+        leftovers = [str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*.zip")]
         assert leftovers == [], f"no archive should survive: {leftovers}"
+        assert not (tmp_path / "shakemap" / "us6000jlqa").exists(), (
+            "an event that produced no raster should leave no directory"
+        )
 
 
 class TestShakemapArchiveProblems:
@@ -562,3 +599,210 @@ class TestShakemapUnresolvableId:
         assert len(fc) == 1, "the event itself still arrives"
         assert fake_http.json_urls == [], "no detail request without a ComCat id"
         assert list((tmp_path / "shakemap").rglob("*.tif")) == []
+
+
+class TestShakemapPathSafety:
+    """The ComCat id becomes a directory name, so it is constrained."""
+
+    @pytest.mark.parametrize("degenerate", ["..", ".", "../../etc"])
+    def test_traversing_id_is_not_parsed(self, degenerate: str):
+        """An id that would escape the output directory is refused outright."""
+        assert _helpers.parse_comcat_id(f"quakeml:x?eventid={degenerate}&f=q") is None
+
+    def test_traversing_id_deletes_nothing(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """A traversing id leaves files in the output root untouched."""
+        from obspy.core.event import Catalog
+
+        event = make_event()
+        event.resource_id = "quakeml:x?eventid=..&format=quakeml"
+        fake_fdsn.default_result = Catalog(events=[event])
+
+        keep_flt = tmp_path / "keepme.flt"
+        keep_hdr = tmp_path / "keepme.hdr"
+        keep_flt.write_bytes(b"keep")
+        keep_hdr.write_text("keep")
+
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert keep_flt.is_file(), "an unrelated .flt must not be deleted"
+        assert keep_hdr.is_file(), "an unrelated .hdr must not be deleted"
+
+
+class TestShakemapAtomicWrite:
+    """A GeoTIFF on disk is a finished one."""
+
+    def test_no_partial_file_survives(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """The staged partial name is never left in the output directory."""
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        event_dir = tmp_path / "shakemap" / "us6000jlqa"
+        partials = [p.name for p in event_dir.iterdir() if "partial" in p.name]
+        assert partials == [], f"staged partials should be renamed away: {partials}"
+
+    def test_force_refetches_an_existing_raster(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """force=True re-fetches instead of trusting what is on disk."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend.download(progress_bar=False)
+        first = len(fake_http.downloads)
+
+        backend.download(progress_bar=False, force=True)
+        assert len(fake_http.downloads) == first + 1, "force should refetch"
+
+    def test_without_force_a_present_raster_is_reused(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """The default still reuses a finished raster."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend.download(progress_bar=False)
+        first = len(fake_http.downloads)
+
+        backend.download(progress_bar=False)
+        assert len(fake_http.downloads) == first, "no refetch without force"
+
+
+class TestShakemapFanOutCeiling:
+    """The per-event fan-out is bounded rather than merely documented."""
+
+    def test_events_beyond_the_ceiling_are_skipped(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """Only up to max_shakemap_events events are fetched."""
+        fake_fdsn.default_result = _usgs_catalog(
+            make_event, "us1111", "us2222", "us3333"
+        )
+        backend = _backend(tmp_path, with_shakemap=True, max_shakemap_events=2)
+        fc = backend.download(progress_bar=False)
+
+        assert len(fc) == 3, "every event still reaches the table"
+        fetched = sorted(p.name for p in (tmp_path / "shakemap").iterdir())
+        assert fetched == ["us1111", "us2222"], f"ceiling not applied: {fetched}"
+
+    def test_the_skip_is_announced(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """Dropping events past the ceiling is logged, never silent."""
+        from loguru import logger as loguru_logger
+
+        messages: list[str] = []
+        sink_id = loguru_logger.add(lambda message: messages.append(str(message)))
+        try:
+            fake_fdsn.default_result = _usgs_catalog(make_event, "us1111", "us2222")
+            _backend(tmp_path, with_shakemap=True, max_shakemap_events=1).download(
+                progress_bar=False
+            )
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert any(
+            "max_shakemap_events" in m and "skipping 1" in m for m in messages
+        ), f"the dropped count should be announced, got: {messages}"
+
+    def test_ceiling_rejects_non_positive(self, tmp_path: Path):
+        """A zero or negative ceiling is refused at construction."""
+        with pytest.raises(ValueError):
+            _backend(tmp_path, with_shakemap=True, max_shakemap_events=0)
+
+
+class TestShakemapClientWiring:
+    """The real HttpClient contract the fake stands in for."""
+
+    def test_archive_fetch_asserts_zip_magic(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """The archive download demands a zip magic prefix."""
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert fake_http.download_kwargs, "the archive should have been fetched"
+        assert fake_http.download_kwargs[0]["expect_magic"] == b"PK", (
+            "an HTML error page served with a 200 must not land as a .zip"
+        )
+
+    def test_client_is_throttled_and_retries_transport_errors(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """The client is built with a politeness interval and transport retries."""
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert fake_http.init_kwargs.get("min_interval"), "expected a throttle"
+        assert fake_http.init_kwargs.get("retry_on_exceptions"), (
+            "expected transport-exception retries, as flodis/hanze do"
+        )
+
+    def test_progress_flag_reaches_the_archive_fetch(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """progress_bar governs the long part of the call."""
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=True)
+        assert fake_http.download_kwargs[0]["progress"] is True
+
+    def test_client_is_closed_after_the_loop(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """The pooled session is released once the ShakeMap work is done."""
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        assert fake_http.session.closed == 1, "the session should close once"
+
+
+class TestShakemapLayersTypeGuard:
+    """A bare string is a sequence of characters, not a layer list."""
+
+    def test_bare_string_is_refused(self, tmp_path: Path):
+        """Passing one layer as a bare string raises a legible TypeError."""
+        with pytest.raises(TypeError, match="not the bare string"):
+            _backend(tmp_path, shakemap_layers="mmi_mean")
+
+
+class TestShakemapDefenceInDepth:
+    """Guards that a tightened parser should already make unreachable."""
+
+    def test_containment_guard_refuses_an_escaping_id(
+        self,
+        tmp_path: Path,
+        usgs_events: _FakeFdsn,
+        fake_http: _FakeHttp,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """An id that escapes the shakemap root is refused before any fetch.
+
+        Forces the guard by making the parser hand back a traversing id, which
+        the tightened pattern would otherwise never produce.
+        """
+        monkeypatch.setattr(fdsn_backend._helpers, "parse_comcat_id", lambda _id: "..")
+
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert fake_http.json_urls == [], "no request should be made for a bad id"
+
+    def test_oversized_member_is_refused(
+        self,
+        tmp_path: Path,
+        usgs_events: _FakeFdsn,
+        fake_http: _FakeHttp,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A member whose declared size is absurd is skipped, not expanded."""
+        monkeypatch.setattr(fdsn_backend._helpers, "MAX_MEMBER_BYTES", 1)
+
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert list((tmp_path / "shakemap").rglob("*.tif")) == [], (
+            "an over-large member must not be written"
+        )

--- a/libs/providers/hazards/tests/fdsn/test_shakemap.py
+++ b/libs/providers/hazards/tests/fdsn/test_shakemap.py
@@ -77,7 +77,12 @@ def _quakeml_id(comcat_id: str) -> str:
 
 
 class _FakeHttp:
-    """Stand-in for `HttpClient` serving one detail document and archive."""
+    """Stand-in for `HttpClient` serving one detail document and archive.
+
+    Failures are injectable: `fail_json_for` / `fail_download_for` raise for
+    any request whose URL mentions one of the given ComCat ids, so a
+    multi-event run can fail one event and keep another healthy.
+    """
 
     def __init__(
         self,
@@ -88,16 +93,22 @@ class _FakeHttp:
         self.archive = _make_archive() if archive is None else archive
         self.json_urls: list[str] = []
         self.downloads: list[tuple[str, Path]] = []
+        self.fail_json_for: set[str] = set()
+        self.fail_download_for: set[str] = set()
 
     def get_json(self, url: str, **_kwargs: Any) -> dict[str, Any]:
         self.json_urls.append(url)
+        if any(marker in url for marker in self.fail_json_for):
+            raise RuntimeError(f"ComCat detail unavailable for {url}")
         return self.detail
 
     def download(self, url: str, dest: str | Path, **_kwargs: Any) -> Path:
         dest = Path(dest)
+        self.downloads.append((url, dest))
+        if any(marker in str(dest) for marker in self.fail_download_for):
+            raise RuntimeError(f"archive transfer failed for {url}")
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(self.archive)
-        self.downloads.append((url, dest))
         return dest
 
 
@@ -107,6 +118,18 @@ def fake_http(monkeypatch: pytest.MonkeyPatch) -> _FakeHttp:
     fake = _FakeHttp()
     monkeypatch.setattr(fdsn_backend, "HttpClient", lambda **_kwargs: fake)
     return fake
+
+
+def _usgs_catalog(make_event: Any, *comcat_ids: str) -> Any:
+    """Build a catalog whose events carry the given ComCat ids."""
+    from obspy.core.event import Catalog
+
+    events = []
+    for index, comcat_id in enumerate(comcat_ids):
+        event = make_event(lon=139.0 + index, lat=35.0 + index)
+        event.resource_id = _quakeml_id(comcat_id)
+        events.append(event)
+    return Catalog(events=events)
 
 
 @pytest.fixture
@@ -344,3 +367,198 @@ class TestBackendShakemapDownload:
         """The detail request is keyed by the event's ComCat id."""
         _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
         assert fake_http.json_urls == [_helpers.detail_url("us6000jlqa")]
+
+
+class TestShakemapFailurePolicy:
+    """Partial failure across the per-event ShakeMap loop."""
+
+    def test_one_failed_event_does_not_lose_the_others(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """A failing event is skipped while healthy ones still land."""
+        fake_fdsn.default_result = _usgs_catalog(make_event, "us1111", "us2222")
+        fake_http.fail_json_for = {"us1111"}
+
+        fc = _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert len(fc) == 2, "both events stay in the table"
+        written = sorted(p.parent.name for p in (tmp_path / "shakemap").rglob("*.tif"))
+        assert written == ["us2222"], (
+            f"only the healthy event yields a raster: {written}"
+        )
+
+    def test_failed_event_does_not_lose_the_event_table(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """Every ShakeMap failing still returns the events themselves."""
+        fake_fdsn.default_result = _usgs_catalog(make_event, "us1111", "us2222")
+        fake_http.fail_json_for = {"us1111", "us2222"}
+
+        fc = _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert len(fc) == 2, "the vector output is independent of the side-output"
+        assert list((tmp_path / "shakemap").rglob("*.tif")) == []
+
+    def test_raise_policy_propagates(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """errors='raise' surfaces the first ShakeMap failure."""
+        fake_fdsn.default_result = _usgs_catalog(make_event, "us1111")
+        fake_http.fail_json_for = {"us1111"}
+
+        backend = _backend(tmp_path, with_shakemap=True)
+        with pytest.raises(RuntimeError, match="ComCat detail unavailable"):
+            backend.download(progress_bar=False, errors="raise")
+
+    def test_download_failure_is_skipped_under_warn(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """An archive transfer that fails mid-way skips the event."""
+        fake_http.fail_download_for = {"us6000jlqa"}
+
+        fc = _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert len(fc) == 1, "the event table survives a failed transfer"
+        assert list((tmp_path / "shakemap").rglob("*.tif")) == []
+
+    def test_failed_download_leaves_no_partial_archive(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A failed transfer cleans up rather than leaving an archive behind."""
+        fake_http.fail_download_for = {"us6000jlqa"}
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        leftovers = [p.name for p in tmp_path.rglob("raster.zip")]
+        assert leftovers == [], f"no archive should survive: {leftovers}"
+
+
+class TestShakemapArchiveProblems:
+    """Archives that are unusable or missing the requested grids."""
+
+    def test_corrupt_archive_is_skipped(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A body that is not a zip is skipped, not raised."""
+        fake_http.archive = b"this is not a zip file"
+
+        fc = _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert len(fc) == 1, "the event table is unaffected"
+        assert list((tmp_path / "shakemap").rglob("*.tif")) == []
+
+    def test_archive_missing_every_requested_layer(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """An archive carrying none of the requested grids writes nothing."""
+        fake_http.archive = _make_archive(layers=("pgv_std",))
+
+        backend = _backend(tmp_path, with_shakemap=True, shakemap_layers=["mmi_mean"])
+        fc = backend.download(progress_bar=False)
+
+        assert len(fc) == 1
+        assert list((tmp_path / "shakemap").rglob("*.tif")) == []
+
+    def test_archive_missing_one_of_several_layers(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """The grids the archive does carry are still written."""
+        fake_http.archive = _make_archive(layers=("mmi_mean",))
+
+        backend = _backend(
+            tmp_path, with_shakemap=True, shakemap_layers=["mmi_mean", "pga_mean"]
+        )
+        backend.download(progress_bar=False)
+
+        written = sorted(p.name for p in (tmp_path / "shakemap").rglob("*.tif"))
+        assert written == ["mmi_mean.tif"], (
+            f"partial archive still yields what it has: {written}"
+        )
+
+
+class TestShakemapRerun:
+    """Skip-if-present behaviour across repeated runs."""
+
+    def test_partially_present_layers_are_refetched(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A run missing one of its GeoTIFFs refetches rather than half-skipping."""
+        backend = _backend(
+            tmp_path, with_shakemap=True, shakemap_layers=["mmi_mean", "pga_mean"]
+        )
+        backend.download(progress_bar=False)
+        first = len(fake_http.downloads)
+
+        next((tmp_path / "shakemap").rglob("pga_mean.tif")).unlink()
+        backend.download(progress_bar=False)
+
+        assert len(fake_http.downloads) == first + 1, "the incomplete event refetches"
+        written = sorted(p.name for p in (tmp_path / "shakemap").rglob("*.tif"))
+        assert written == ["mmi_mean.tif", "pga_mean.tif"], "both grids present again"
+
+
+class TestShakemapMultiNetwork:
+    """Requests mixing USGS with another network."""
+
+    def test_only_usgs_events_yield_rasters(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """A mixed request keeps every event but rasters only USGS."""
+        fake_fdsn.set_result("USGS", _usgs_catalog(make_event, "us1111"))
+        fake_fdsn.set_result("EMSC", _usgs_catalog(make_event, "em9999"))
+
+        backend = _backend(tmp_path, variables=["USGS", "EMSC"], with_shakemap=True)
+        fc = backend.download(progress_bar=False)
+
+        assert len(fc) == 2, "both networks contribute events"
+        rastered = sorted(p.parent.name for p in (tmp_path / "shakemap").rglob("*.tif"))
+        assert rastered == ["us1111"], f"only USGS is rastered: {rastered}"
+
+    def test_empty_non_usgs_network_is_quiet(
+        self,
+        tmp_path: Path,
+        fake_fdsn: _FakeFdsn,
+        fake_http: _FakeHttp,
+        make_event: Any,
+    ):
+        """A non-USGS network that matched nothing needs no warning."""
+        from obspy.core.event import Catalog
+
+        fake_fdsn.set_result("USGS", _usgs_catalog(make_event, "us1111"))
+        fake_fdsn.set_result("EMSC", Catalog(events=[]))
+
+        backend = _backend(tmp_path, variables=["USGS", "EMSC"], with_shakemap=True)
+        fc = backend.download(progress_bar=False)
+
+        assert len(fc) == 1, "only USGS matched"
+        rastered = sorted(p.parent.name for p in (tmp_path / "shakemap").rglob("*.tif"))
+        assert rastered == ["us1111"]
+
+
+class TestShakemapUnresolvableId:
+    """Events whose identifier carries no ComCat id."""
+
+    def test_unparseable_event_id_is_skipped(
+        self, tmp_path: Path, fake_fdsn: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A USGS row with a local identifier is skipped without erroring."""
+        fc = _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+
+        assert len(fc) == 1, "the event itself still arrives"
+        assert fake_http.json_urls == [], "no detail request without a ComCat id"
+        assert list((tmp_path / "shakemap").rglob("*.tif")) == []

--- a/libs/providers/hazards/tests/fdsn/test_shakemap.py
+++ b/libs/providers/hazards/tests/fdsn/test_shakemap.py
@@ -212,6 +212,35 @@ class TestParseComcatId:
         """An empty or missing identifier yields None."""
         assert _helpers.parse_comcat_id(value) is None
 
+    @pytest.mark.parametrize("length", [1, 63, 64])
+    def test_ids_up_to_the_bound_are_accepted(self, length: int):
+        """An id at or under the length bound parses."""
+        comcat_id = "a" * length
+        assert _helpers.parse_comcat_id(f"q?eventid={comcat_id}&f=q") == comcat_id
+
+    @pytest.mark.parametrize("length", [65, 200])
+    def test_ids_past_the_bound_are_refused(self, length: int):
+        """An overlong id is refused rather than handed to the filesystem."""
+        assert _helpers.parse_comcat_id(f"q?eventid={'a' * length}&f=q") is None
+
+    def test_id_at_the_end_of_the_identifier(self):
+        """An id terminating the string, with no trailing separator, parses."""
+        assert _helpers.parse_comcat_id("q?eventid=us6000jlqa") == "us6000jlqa"
+
+    def test_id_as_a_later_parameter(self):
+        """The id is found when it is not the first query parameter."""
+        assert (
+            _helpers.parse_comcat_id("q?format=quakeml&eventid=us6000jlqa")
+            == "us6000jlqa"
+        )
+
+    @pytest.mark.parametrize(
+        "encoded", ["%2e%2e", "..%2fetc", "us/evil", "C:", "us evil"]
+    )
+    def test_encoded_and_separator_forms_are_refused(self, encoded: str):
+        """Percent-encoded dots and path separators never survive the parse."""
+        assert _helpers.parse_comcat_id(f"q?eventid={encoded}&f=q") is None
+
 
 class TestNormalizeLayers:
     """Validating and de-duplicating a requested layer selection."""
@@ -241,6 +270,16 @@ class TestNormalizeLayers:
             _helpers.SHAKEMAP_LAYERS
         )
 
+    @pytest.mark.parametrize("bad", [[None], [1], [object()]])
+    def test_non_string_members_are_refused(self, bad: list):
+        """A non-string layer name is refused rather than stringified."""
+        with pytest.raises(ValueError, match="unknown ShakeMap layer"):
+            _helpers.normalize_layers(bad)
+
+    def test_accepts_any_iterable(self):
+        """A tuple works as well as a list."""
+        assert _helpers.normalize_layers(("pga_mean",)) == ("pga_mean",)
+
 
 class TestShakemapRasterUrl:
     """Walking a detail document to the raster archive URL."""
@@ -264,6 +303,25 @@ class TestShakemapRasterUrl:
         """A document with no properties at all yields None."""
         assert _helpers.shakemap_raster_url({}) is None
 
+    def test_empty_shakemap_list_is_none(self):
+        """A shakemap key holding no entries yields None."""
+        detail = {"properties": {"products": {"shakemap": []}}}
+        assert _helpers.shakemap_raster_url(detail) is None
+
+    def test_null_shakemap_entry_is_none(self):
+        """A null first entry does not raise."""
+        detail = {"properties": {"products": {"shakemap": [None]}}}
+        assert _helpers.shakemap_raster_url(detail) is None
+
+    def test_raster_entry_without_url_is_none(self):
+        """A raster entry carrying no url yields None."""
+        detail = {
+            "properties": {
+                "products": {"shakemap": [{"contents": {"download/raster.zip": {}}}]}
+            }
+        }
+        assert _helpers.shakemap_raster_url(detail) is None
+
 
 class TestExtractLayers:
     """Unpacking the requested grids out of the archive."""
@@ -276,6 +334,26 @@ class TestExtractLayers:
         assert set(extracted) == {"mmi_mean"}
         assert extracted["mmi_mean"].is_file()
         assert (tmp_path / "out" / "mmi_mean.hdr").is_file()
+
+    def test_traversing_member_is_never_extracted(self, tmp_path: Path):
+        """A member named to escape the destination is not read at all.
+
+        Only member names built from the requested layers are opened, so a
+        hostile archive cannot place a file outside dest_dir.
+        """
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as bundle:
+            bundle.writestr("../evil.flt", b"xxxx")
+            bundle.writestr("../evil.hdr", "NROWS 1")
+            bundle.writestr("mmi_mean.flt", b"xxxx")
+            bundle.writestr("mmi_mean.hdr", "NROWS 1")
+        archive = tmp_path / "raster.zip"
+        archive.write_bytes(buffer.getvalue())
+
+        extracted = _helpers.extract_layers(archive, ["mmi_mean"], tmp_path / "out")
+
+        assert sorted(extracted) == ["mmi_mean"]
+        assert not (tmp_path / "evil.flt").exists(), "nothing may escape dest_dir"
 
     def test_missing_layer_is_skipped(self, tmp_path: Path):
         """A layer the archive lacks is skipped, not raised."""
@@ -312,6 +390,75 @@ class TestFltToGeotiff:
             )
         finally:
             dataset = None
+
+
+class TestFltToGeotiffFailures:
+    """Conversion inputs that cannot produce a raster."""
+
+    def test_missing_header_raises_and_publishes_nothing(self, tmp_path: Path):
+        """A .flt with no .hdr sibling fails without leaving an output."""
+        grid = tmp_path / "mmi_mean.flt"
+        grid.write_bytes(bytes(16))
+
+        with pytest.raises(RuntimeError):
+            _helpers.flt_to_geotiff(grid, tmp_path / "mmi_mean.tif")
+
+        assert not (tmp_path / "mmi_mean.tif").exists(), "no raster may be published"
+        assert list(tmp_path.glob("*.partial.tif")) == [], "no staged partial"
+
+
+class TestManifestRoundTrip:
+    """The per-event manifest read/write pair."""
+
+    def test_absent_manifest_reads_as_none(self, tmp_path: Path):
+        """A directory with no manifest reads as None."""
+        assert _helpers.read_manifest(tmp_path) is None
+
+    def test_round_trip(self, tmp_path: Path):
+        """What is written is read back, sorted and de-duplicated."""
+        _helpers.write_manifest(
+            tmp_path, ["pga_mean", "mmi_mean", "mmi_mean"], ["mmi_mean"]
+        )
+        manifest = _helpers.read_manifest(tmp_path)
+        assert manifest["requested"] == ["mmi_mean", "pga_mean"]
+        assert manifest["produced"] == ["mmi_mean"]
+
+    def test_write_creates_the_directory(self, tmp_path: Path):
+        """The event directory is created if it does not exist yet."""
+        target = tmp_path / "us6000jlqa"
+        _helpers.write_manifest(target, ["mmi_mean"], [])
+        assert (target / _helpers.MANIFEST_NAME).is_file()
+
+    def test_non_dict_json_reads_as_none(self, tmp_path: Path):
+        """A manifest holding a JSON list is treated as absent."""
+        (tmp_path / _helpers.MANIFEST_NAME).write_text("[1, 2]", encoding="utf-8")
+        assert _helpers.read_manifest(tmp_path) is None
+
+
+class TestClientLifecycle:
+    """Building and releasing the pooled ComCat client."""
+
+    def test_close_without_a_client_is_a_no_op(self, tmp_path: Path):
+        """Closing before any client was built does not raise."""
+        backend = _backend(tmp_path)
+        backend._close_client()
+
+    def test_close_is_idempotent(
+        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+    ):
+        """A second close after a download does not raise or double-close."""
+        backend = _backend(tmp_path, with_shakemap=True)
+        backend.download(progress_bar=False)
+        backend._close_client()
+        assert fake_http.session.closed == 1, "the session closes exactly once"
+
+    def test_client_is_reused_within_one_call(
+        self, tmp_path: Path, fake_fdsn: _FakeFdsn, fake_http: _FakeHttp, make_event
+    ):
+        """Two events in one download share a single client."""
+        fake_fdsn.default_result = _usgs_catalog(make_event, "us1111", "us2222")
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
+        assert fake_http.session.closed == 1, "one client for the whole batch"
 
 
 class TestBackendConstruction:

--- a/libs/providers/hazards/tests/fdsn/test_shakemap.py
+++ b/libs/providers/hazards/tests/fdsn/test_shakemap.py
@@ -202,6 +202,61 @@ def _backend(tmp_path: Path, **overrides: Any) -> FDSN:
     return FDSN(**params)
 
 
+def _to_file_writes_then_raises(self, path, *args, **kwargs):
+    """Write bytes then fail, as an interrupted conversion would."""
+    Path(path).write_bytes(b"partial")
+    raise RuntimeError("conversion failed")
+
+
+def _to_file_raises(self, path, *args, **kwargs):
+    """Fail before writing anything."""
+    raise RuntimeError("conversion failed")
+
+
+def _to_file_writes_nothing(self, path, *args, **kwargs):
+    """Return without producing an output file."""
+    return None
+
+
+def _write_manifest_refuses(*_args, **_kwargs):
+    """Fail as an unwritable filesystem would."""
+    raise OSError("read-only file system")
+
+
+def _backend_fixture_marker() -> None:
+    """Anchor for the module-scope helpers above."""
+
+
+class _ExtractRecorder:
+    """Records each destination directory `extract_layers` is given."""
+
+    def __init__(self, wrapped, seen: list[str]) -> None:
+        self._wrapped = wrapped
+        self._seen = seen
+
+    def __call__(self, archive, layers, dest_dir):
+        self._seen.append(dest_dir.name)
+        return self._wrapped(archive, layers, dest_dir)
+
+
+#: Names captured by `_recording_replace`; a test clears it before acting.
+_REPLACE_CALLS: list[str] = []
+
+#: Bound once at import so the recorder cannot wrap itself on a second patch.
+_ORIGINAL_REPLACE = Path.replace
+
+
+def _recording_replace(source, target):
+    """Record the staged name, then perform the real rename.
+
+    A plain function rather than a callable object: `Path.replace` is looked
+    up on the class, and only a function is a descriptor, so an instance
+    would be called without the path it was invoked on.
+    """
+    _REPLACE_CALLS.append(source.name)
+    return _ORIGINAL_REPLACE(source, target)
+
+
 class TestParseComcatId:
     """Recovering a ComCat id from a QuakeML resource identifier."""
 
@@ -1054,11 +1109,11 @@ class TestShakemapConversionFailure:
     ):
         """A conversion that dies leaves no raster and no staged partial."""
 
-        def _boom(self, path, *args, **kwargs):
-            Path(path).write_bytes(b"partial")
-            raise RuntimeError("conversion failed")
-
-        monkeypatch.setattr("pyramids.dataset.Dataset.to_file", _boom, raising=True)
+        monkeypatch.setattr(
+            "pyramids.dataset.Dataset.to_file",
+            _to_file_writes_then_raises,
+            raising=True,
+        )
 
         _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
 
@@ -1079,10 +1134,9 @@ class TestShakemapConversionFailure:
         directory survives inside the user's output.
         """
 
-        def _boom(self, path, *args, **kwargs):
-            raise RuntimeError("conversion failed")
-
-        monkeypatch.setattr("pyramids.dataset.Dataset.to_file", _boom, raising=True)
+        monkeypatch.setattr(
+            "pyramids.dataset.Dataset.to_file", _to_file_raises, raising=True
+        )
 
         _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
 
@@ -1092,13 +1146,12 @@ class TestShakemapConversionFailure:
     def test_missing_output_is_refused(self, tmp_path: Path, monkeypatch):
         """A conversion that writes nothing raises instead of renaming."""
 
-        def _silent(self, path, *args, **kwargs):
-            return None
-
         archive = tmp_path / "raster.zip"
         archive.write_bytes(_make_archive(layers=("mmi_mean",)))
         extracted = _helpers.extract_layers(archive, ["mmi_mean"], tmp_path / "in")
-        monkeypatch.setattr("pyramids.dataset.Dataset.to_file", _silent, raising=True)
+        monkeypatch.setattr(
+            "pyramids.dataset.Dataset.to_file", _to_file_writes_nothing, raising=True
+        )
 
         with pytest.raises(RuntimeError, match="produced no output"):
             _helpers.flt_to_geotiff(extracted["mmi_mean"], tmp_path / "out.tif")
@@ -1445,10 +1498,9 @@ class TestManifestWriteFailure:
         """The raster survives and the failure is reported."""
         from loguru import logger as loguru_logger
 
-        def _refuse(*_args: Any, **_kwargs: Any) -> None:
-            raise OSError("read-only file system")
-
-        monkeypatch.setattr(fdsn_backend._helpers, "write_manifest", _refuse)
+        monkeypatch.setattr(
+            fdsn_backend._helpers, "write_manifest", _write_manifest_refuses
+        )
 
         messages: list[str] = []
         sink_id = loguru_logger.add(lambda message: messages.append(str(message)))
@@ -1531,24 +1583,18 @@ class TestStagingIsProcessUnique:
     """Two runs over one output root must not share scratch space."""
 
     def test_staging_directory_carries_the_pid(
-        self, tmp_path: Path, usgs_events: _FakeFdsn, fake_http: _FakeHttp
+        self,
+        tmp_path: Path,
+        usgs_events: _FakeFdsn,
+        fake_http: _FakeHttp,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """The scratch directory name includes the process id."""
         seen: list[str] = []
+        recorder = _ExtractRecorder(_helpers.extract_layers, seen)
+        monkeypatch.setattr(fdsn_backend._helpers, "extract_layers", recorder)
 
-        original = _helpers.extract_layers
-
-        def _record(archive: Path, layers: Any, dest_dir: Path):
-            seen.append(dest_dir.name)
-            return original(archive, layers, dest_dir)
-
-        fake_http.detail = _detail()
-        backend = _backend(tmp_path, with_shakemap=True)
-        import pytest as _pytest
-
-        with _pytest.MonkeyPatch.context() as patch:
-            patch.setattr(fdsn_backend._helpers, "extract_layers", _record)
-            backend.download(progress_bar=False)
+        _backend(tmp_path, with_shakemap=True).download(progress_bar=False)
 
         assert seen, "the archive should have been extracted"
         assert seen[0] == f"_staging-{os.getpid()}", (
@@ -1933,17 +1979,11 @@ class TestSurvivorGuards:
         Two runs sharing an output root would otherwise stage the same path and
         rename each other half-written file into place.
         """
-        staged_names: list[str] = []
-        original_replace = Path.replace
-
-        def _record(self, target):
-            staged_names.append(self.name)
-            return original_replace(self, target)
-
-        monkeypatch.setattr(Path, "replace", _record)
+        _REPLACE_CALLS.clear()
+        monkeypatch.setattr(Path, "replace", _recording_replace)
         _helpers.write_manifest(tmp_path, ["mmi_mean"], ["mmi_mean"], checked=1.0)
 
-        assert staged_names, "the manifest should be staged then renamed"
-        assert str(os.getpid()) in staged_names[0], (
-            f"the staged name should carry the pid, got {staged_names[0]}"
+        assert _REPLACE_CALLS, "the manifest should be staged then renamed"
+        assert str(os.getpid()) in _REPLACE_CALLS[0], (
+            f"the staged name should carry the pid, got {_REPLACE_CALLS[0]}"
         )


### PR DESCRIPTION
# Description

Adds the deferred M2 item on the FDSN backend: an opt-in **ShakeMap raster side-output** for USGS events, plus
corrections to three stale claims the FDSN docs and docstrings have been carrying since the backend shipped.

`earthlens.fdsn` returns seismic events as a `vector` FeatureCollection. USGS ComCat additionally publishes a
gridded ShakeMap per event, which the FDSN event standard does not expose at all — obspy's `get_events` returns
QuakeML, and QuakeML stops at origins and magnitudes. `with_shakemap=True` fetches those grids and writes them as
GeoTIFFs alongside the event table:

```python
events = EarthLens(
    variables=["USGS"], data_source="fdsn",
    start="2023-02-06", end="2023-02-07",
    lat_lim=[35.0, 39.0], lon_lim=[35.0, 39.0],
    path="out", min_magnitude=7.0,
    with_shakemap=True,
).download()
# out/usgs.gpkg                              <- unchanged event table (still the return value)
# out/shakemap/us6000jlqa/mmi_mean.tif       <- new raster side-output
```

### No `libcomcat` — and why

Issue #89 originally specified `libcomcat`. That route is not implementable here:

- `libcomcat` is **not published on PyPI** (`https://pypi.org/pypi/libcomcat/json` → 404); it exists only on
  conda-forge and GitHub. Since the workspace moved to uv the dependency set is PyPI-only, so it cannot be
  declared as an extra.
- Upstream `usgs/libcomcat` has had no commit since 2023-03-02.

ComCat's event-detail GeoJSON exposes the product download URLs directly, so the whole path runs on the existing
`HttpClient` with **no new dependency**. The issue was rewritten to match before this PR.

### The archive is not a GeoTIFF

`download/raster.zip` holds **fourteen ESRI float grids** — a `.flt` payload plus a `.hdr` header per layer, read
through GDAL's `EHdr` driver — covering seven intensity measures (`mmi`, `pga`, `pgv`, and PSA at 0.3 / 0.6 / 1.0
/ 3.0 s), each as a `_mean` and a `_std`. Consequences, all handled:

- **Only `mmi_mean` is written by default.** Writing all fourteen would mean a multi-megabyte download and
  fourteen rasters *per event* (measured live: 8 MB and 20 MB for the two Kahramanmaraş events — it scales with
  the footprint). `shakemap_layers=` opts into any subset, and `max_shakemap_events` (default 100) caps how many
  events one call fetches, skipping the rest with a warning naming the count rather than silently.
- **The headers carry no projection.** The conversion assigns `EPSG:4326` explicitly — verified: without it the
  GeoTIFF comes out with an empty CRS.
- **The conversion goes through pyramids**, not raw GDAL, per the porting policy. pyramids 0.53.0 reads `EHdr`
  as-is, so no `PY-` task was needed.
- **Intermediates are confined to a `_staging/` subdirectory** removed wholesale, so nothing GDAL writes
  alongside the grid (notably the `.prj` it drops when the CRS is assigned) reaches the output folder.
- **The GeoTIFF is written atomically** — staged to a sibling and renamed — so a present file is a finished one.
  `download(force=True)` refetches anyway.
- **A per-event manifest records what the archive actually carried**, so a re-run costs nothing even for an event
  whose archive permanently lacks a requested layer. It is versioned, timestamped, structurally validated, merged
  rather than replaced, and written atomically. A "this event publishes no ShakeMap" answer ages out after a week
  — ShakeMap is generated minutes to hours after an event, so caching that permanently would make a query over a
  recent window return nothing forever.
- **`max_shakemap_events` bounds *work*, not events**, so an event already on disk costs no budget and a re-run
  advances further through the list instead of re-taking the same batch.

### Scope notes

- **USGS only.** A non-USGS network in the same request still contributes events, and is logged once.
- **PAGER is not included.** Its ComCat product ships PDFs, PNGs, and JSON summaries with **no raster grid**, so
  it is a tabular side-output and a separate decision, not part of this raster path.
- **`OUTPUT_KIND` stays `"vector"`.** An earlier revision flipped it to `"mixed"` per instance; that was wrong.
  `"mixed"` is defined as the case where the returned format is only known at download time *and* the backend
  honours `aggregate=` itself. FDSN always returns a FeatureCollection and always refuses `aggregate=`, and the
  wrong value also fed bad advice to an unrelated base-class branch (`_apply_polygon_mask` suggested
  `Dataset.crop` for a GeoDataFrame).

### Stale claims corrected

Independent of the feature, three things in the FDSN docs were wrong:

- `catalog.py` and `docs/reference/fdsn/introduction.md` both claimed FDSN has *"no refresh / probe / audit
  tooling"*. It has shipped `refresh` and `validate` handlers in `earthlens.fdsn.cli` since the CLI entry-point
  refactor (#1021); `audit` works too, derived from the refresher's drift axis rather than an FDSN-owned handler.
- `backend.py` and `introduction.md` said the **facade** rejects `aggregate=`. The refusal moved into
  `AbstractDataSource._refuse_unsupported_aggregate`, so a direct `FDSN(...).download(aggregate=...)` is refused
  identically.
- `test_fdsn_e2e.py` documented a `pixi run` command and a pre-monorepo test path.

`docs/reference/fdsn/fdsn.md` now also renders `earthlens.fdsn.cli`.

A fourth, pre-existing defect was found and fixed during the docstring pass: `FDSN._fetch` carried **two `Args:`
sections**, the second documenting `progress_bar` and `errors` — parameters `_fetch` does not accept (they belong
to `download()`). Google-style parsers would render a bogus second block from it.

### Two review rounds

Four adversarial review passes ran against this branch (92 findings, all resolved; files under
`planning/fdsn/`). The ones worth calling out, each reproduced against running code before being fixed:

- An event id of `..` was used raw as a directory name **and** as the root of a cleanup glob, so it **deleted
  unrelated `.flt` / `.hdr` files** in the caller's output root.
- A truncated GeoTIFF was cached forever, because the skip-on-rerun check could only ask "non-empty?".
- On Windows, a failed conversion left the scratch directory behind: GDAL's handle on the grid outlived the call
  via the exception traceback, `shutil.rmtree(..., ignore_errors=True)` swallowed the `PermissionError`, and
  nothing was logged. Invisible to Linux CI.
- An archive permanently missing a requested layer re-downloaded itself on **every** run.
- `session.close()` was called unconditionally, but `RequestsGet` — the transport `earthlens.testing` installs
  for the whole suite — has no `close()`. **Only the live e2e test caught this**; every unit test passed because
  the fake supplied a session that had one.
- Round 3 caught a fix from round 2 that had been closed by **adding a docstring claim the code did not
  implement**: the fan-out ceiling truncated the raw event list, so a re-run re-took the same batch and later
  events were unreachable forever. The ceiling now counts pending work, and a regression test pins it.
- The manifest cached "no ShakeMap published" permanently, and USGS republishes grids for years (the 2023
  Kahramanmaraş ShakeMap is on its twelfth version, updated in 2025). Round 4 then found the window was
  consulted only when *no* requested layer was on disk, so a partially published event still cached its missing
  grids forever.
- The fan-out ceiling was fixed twice. Round 3 made it count pending work; round 4 found events that can *never*
  be fetched still occupied it, so three dead ids ahead of a good event made a run issue zero requests, forever.

# Issues

- Closes #89 — Optional ShakeMap/PAGER side-output from ComCat products (USGS only) (M2)

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

**240 fdsn tests**. `_helpers.py` is at 100% line and branch; `backend.py` is at 100% line and 99% branch (one
defensive guard reachable only if `mkdir` itself fails). Coverage is not the interesting number here — every
guard was verified by **targeted mutation**, which repeatedly found guards that 100% coverage left unpinned. The ComCat archive is reproduced
synthetically — a tiny ESRI float grid plus its header, zipped the way ComCat ships one — so the whole path runs
offline.

Covered: the helpers (ComCat id parsing, layer validation, product-URL resolution, archive extraction, `EHdr` →
GeoTIFF conversion); the backend wiring (per-instance `OUTPUT_KIND`, USGS-only skip, no-ShakeMap-product,
intermediate cleanup, flag-off making no HTTP call); the partial-failure matrix (one event failing while another
succeeds, every event failing without costing the event table, `errors="raise"` propagating, a transfer dying
mid-download leaving no partial archive); the archive edge cases (a body that is not a zip, an archive carrying
none of the requested grids, one carrying only some); the rerun case where a single missing GeoTIFF forces a
refetch rather than a half-skip; and the mixed USGS/non-USGS request.

One `e2e`-marked live test (`TestShakemapLiveSideOutput`) exercises the real path against USGS ComCat using the
2023 Kahramanmaraş M7.5 sequence, asserting the GeoTIFF is georeferenced and the intermediates are cleaned up.

```bash
uv run pytest libs/providers/hazards/tests/fdsn -m "not e2e"   # 240 passed
uv run pytest libs/providers/hazards/tests/fdsn -m e2e -k shakemap   # 1 passed (live, re-run on final HEAD)
uv run pytest --doctest-modules libs/providers/hazards/src/earthlens/fdsn   # 16 passed
uv run pytest -m "not e2e"     # 9807 passed, 15 skipped
uv run mypy            # Success: no issues found in 406 source files
uvx ruff@0.15.22 check && uvx ruff@0.15.22 format --check
```

- [x] Test A — full non-e2e suite green (9807 passed)
- [x] Test B — live e2e ShakeMap fetch green, re-run on the final HEAD
- [x] Test C — targeted mutation passes each round; the final pass reports **0 survivors of 11 guards**

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

