### PR TITLE
fix(aggregate): stop op="auto" over-counting pre-aggregated CDS datasets

### DIFF
--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -32,7 +32,7 @@ rather than silently using the default.
 | Field | Type | Default | Purpose |
 |---|---|---|---|
 | `freq` | `str` (required) | — | Pandas offset alias defining the window. |
-| `op` | `Literal["mean","sum","min","max","std","auto"]` | `"auto"` | Reduction within each window. `"auto"` reads `Variable.is_flux`. |
+| `op` | `Literal["mean","sum","min","max","std","auto"]` | `"auto"` | Reduction within each window. `"auto"` reads `Variable.is_pre_aggregated` then `Variable.is_flux`. |
 | `out_dir` | `Path \| None` | `None` | Where per-window GeoTIFFs are written. `None` skips the write step. |
 | `cell_size` | `float` | `0.125` | Pixel size in degrees (informational; the geotransform is read off the NetCDF). |
 | `level` | `int \| float \| None` | `None` | Pin a pressure level for 4-D inputs. |
@@ -54,7 +54,7 @@ Arguments:
 
 - `nc_path` — path to the NetCDF on disk.
 - `var_info` — :class:`earthlens.ecmwf.Variable` row (resolves
-  `op="auto"` via `is_flux`, drives the output filename via
+  `op="auto"` via `is_pre_aggregated` / `is_flux`, drives the output filename via
   `cds_variable`, picks the variable from the NetCDF via
   `nc_variable`).
 - `config` — :class:`AggregationConfig` describing the window,
@@ -112,7 +112,7 @@ a single bad variable does not abort the rest of the loop.
 | `"min"` | `np.nanmin` | `np.min` |
 | `"max"` | `np.nanmax` | `np.max` |
 | `"std"` | `np.nanstd` | `np.std` |
-| `"auto"` | resolves to `"mean"` (state) or `"sum"` (flux) | same |
+| `"auto"` | `"mean"` (pre-aggregated or state) or `"sum"` (flux) | same |
 
 ## Supported `freq` values
 
@@ -140,13 +140,20 @@ catalog. The resolver is `_resolve_op` in `earthlens.aggregate`:
 def _resolve_op(op, var_info):
     if op != "auto":
         return op
+    if getattr(var_info, "is_pre_aggregated", False):
+        return "mean"
     return "sum" if var_info.is_flux else "mean"
 ```
 
-Two-line decision:
+Decision order (first match wins):
 
 - An **explicit** `op` (`"mean"`, `"sum"`, `"min"`, `"max"`, `"std"`)
   is returned unchanged. User choice always wins.
+- `op="auto"` + `var_info.is_pre_aggregated` → `"mean"`. The
+  `derived-era5-*-daily-statistics` and `reanalysis-era5-*-monthly-means`
+  families are already server-side daily / monthly aggregates, so a
+  `"sum"` would re-accumulate them (~30× for a monthly window over daily
+  statistics). This wins over the flux rule below.
 - `op="auto"` reads `var_info.is_flux`:
   - `True` → `"sum"`
   - `False` → `"mean"`
@@ -227,7 +234,7 @@ different semantics:
 | Reproduce the legacy buggy daily-flux output | `"mean"` |
 | Daily *max* / *min* temperature | `"max"` / `"min"` |
 | Per-window standard deviation | `"std"` |
-| Pre-aggregated CDS datasets like `derived-era5-*-daily-statistics` (each NetCDF sample is *already* a daily aggregate; summing 4 of them would multiply by 4) | `"mean"` |
+| A monthly *sum* from a pre-aggregated dataset — `op="auto"` already resolves the `derived-era5-*-daily-statistics` / `reanalysis-era5-*-monthly-means` families to `"mean"` via `is_pre_aggregated`, so you only override to force a total | `"sum"` |
 
 ## Pressure-level support (`level=`)
 

--- a/libs/core/src/earthlens/aggregate.py
+++ b/libs/core/src/earthlens/aggregate.py
@@ -426,11 +426,20 @@ def _resolve_op(op: OperationLiteral, var_info: Variable) -> str:
     accumulations — and `False` for state variables (temperature,
     pressure, humidity, ...).
 
-    Resolution rules:
+    Resolution rules (first match wins):
 
+    * `op="auto"` + `var_info.is_pre_aggregated=True` → `"mean"`
     * `op="auto"` + `var_info.is_flux=True` → `"sum"`
     * `op="auto"` + `var_info.is_flux=False` → `"mean"`
     * any explicit op → returned unchanged
+
+    `is_pre_aggregated` wins over `is_flux`: a flux variable from a
+    `derived-era5-*-daily-statistics` / `reanalysis-era5-*-monthly-means`
+    dataset is already a server-side daily / monthly aggregate, so `"auto"`
+    resolves to `"mean"` — a plain `"sum"` would re-accumulate the aggregates
+    and multiply by the number of samples per window (~30× for a monthly
+    window over daily statistics). `is_pre_aggregated` is read defensively
+    (`getattr`, default `False`) so a `var_info` without it behaves as before.
 
     This **replaces** the legacy `mean × days_later` scaling that
     `examples/post_process_ecmwf_netcdf.py:226` (pre-rewrite) used.
@@ -442,7 +451,8 @@ def _resolve_op(op: OperationLiteral, var_info: Variable) -> str:
     Args:
         op: The :attr:`AggregationConfig.op` value, possibly `"auto"`.
         var_info: Catalog entry for the variable being aggregated.
-            Only `is_flux` is consulted; the rest is ignored.
+            Only `is_pre_aggregated` (if present) and `is_flux` are
+            consulted; the rest is ignored.
 
     Returns:
         str: The concrete operator name (`"mean"`, `"sum"`, `"min"`,
@@ -467,6 +477,18 @@ def _resolve_op(op: OperationLiteral, var_info: Variable) -> str:
             'sum'
 
             ```
+        - A pre-aggregated flux variable resolves to `"mean"`, not `"sum"`:
+
+            ```python
+            >>> from types import SimpleNamespace
+            >>> from earthlens.aggregate import _resolve_op
+            >>> _resolve_op(
+            ...     "auto",
+            ...     SimpleNamespace(is_flux=True, is_pre_aggregated=True),
+            ... )
+            'mean'
+
+            ```
         - Explicit ops pass through verbatim:
 
             ```python
@@ -479,6 +501,8 @@ def _resolve_op(op: OperationLiteral, var_info: Variable) -> str:
     """
     if op != "auto":
         return op
+    if getattr(var_info, "is_pre_aggregated", False):
+        return "mean"
     return "sum" if var_info.is_flux else "mean"
 
 

--- a/libs/core/tests/test_aggregate.py
+++ b/libs/core/tests/test_aggregate.py
@@ -782,8 +782,9 @@ class _FakeNetCDF:
 class _RealVariable(SimpleNamespace):
     """Lightweight stand-in for `earthlens.ecmwf.Variable` in tests.
 
-    Exposes only the four attributes `aggregate_netcdf` reads
-    (`is_flux`, `cds_variable`, `nc_variable`, `units`) so the
+    Exposes the attributes `aggregate_netcdf` reads (`is_flux`,
+    `cds_variable`, `nc_variable`, `units`, and the optional
+    `is_pre_aggregated` that `_resolve_op` consults via `getattr`) so the
     round-trip tests don't have to construct a full pydantic model.
     """
 
@@ -943,6 +944,39 @@ class TestAggregateNetcdfRoundTrip:
         _, arr, _ = results[0]
         assert arr[0, 0] == pytest.approx(10.0), (
             f"Auto on flux var should sum to 1+2+3+4=10.0, got {arr[0, 0]}"
+        )
+
+    def test_op_auto_routes_pre_aggregated_flux_to_mean(self, monkeypatch, tmp_path):
+        """`op="auto"` + pre-aggregated flux → mean, not sum (#43, end-to-end).
+
+        A flux var from a daily-statistics / monthly-means dataset is already a
+        server-side aggregate; `op="auto"` must reduce it with `"mean"` (2.5),
+        not re-sum it (10.0) as a raw flux var would.
+        """
+        pre_aggregated_flux_var = _RealVariable(
+            is_flux=True,
+            is_pre_aggregated=True,
+            cds_variable="total_precipitation",
+            nc_variable="tp",
+            units="m",
+        )
+        cube = self._daily_six_hourly_array(n_days=1)
+        nc = _FakeNetCDF(
+            array=cube,
+            time_strs_by_var={"time": self._date_strings_six_hourly(1)},
+            dimension_names=["time", "lat", "lon"],
+        )
+        _patch_netcdf_read(monkeypatch, nc)
+        _patch_geotiff_write(monkeypatch)
+
+        results = aggregate_netcdf(
+            tmp_path / "fake.nc",
+            pre_aggregated_flux_var,
+            AggregationConfig(freq="1D", op="auto", out_dir=None),
+        )
+        _, arr, _ = results[0]
+        assert arr[0, 0] == pytest.approx(2.5), (
+            f"Auto on pre-aggregated flux should mean to 2.5, not sum; got {arr[0, 0]}"
         )
 
     def test_min_count_emits_nan_for_partial_windows(

--- a/libs/core/tests/test_aggregate.py
+++ b/libs/core/tests/test_aggregate.py
@@ -632,6 +632,43 @@ class TestResolveOp:
         result = _resolve_op("auto", SimpleNamespace(is_flux=False))
         assert result == "mean", f"Expected 'mean', got {result!r}"
 
+    def test_auto_with_pre_aggregated_flux_returns_mean(self):
+        """`op="auto"` + pre-aggregated flux resolves to `"mean"`, not `"sum"` (#43).
+
+        A flux variable from a daily-statistics / monthly-means dataset is
+        already a server-side aggregate; summing it over a window over-counts,
+        so pre-aggregation wins over the flux rule.
+        """
+        result = _resolve_op(
+            "auto", SimpleNamespace(is_flux=True, is_pre_aggregated=True)
+        )
+        assert result == "mean", (
+            f"Expected 'mean' for pre-aggregated flux, got {result!r}"
+        )
+
+    def test_auto_with_pre_aggregated_state_stays_mean(self):
+        """`op="auto"` + pre-aggregated state stays `"mean"`."""
+        result = _resolve_op(
+            "auto", SimpleNamespace(is_flux=False, is_pre_aggregated=True)
+        )
+        assert result == "mean", f"Expected 'mean', got {result!r}"
+
+    def test_auto_without_is_pre_aggregated_attr_falls_back_to_flux(self):
+        """A `var_info` lacking `is_pre_aggregated` keeps the flux rule.
+
+        `is_pre_aggregated` is read defensively (`getattr`, default `False`), so
+        a stub without it resolves purely on `is_flux`.
+        """
+        result = _resolve_op("auto", SimpleNamespace(is_flux=True))
+        assert result == "sum", f"Expected 'sum' fallback, got {result!r}"
+
+    def test_explicit_op_ignores_pre_aggregated(self):
+        """An explicit op passes through even for a pre-aggregated variable."""
+        result = _resolve_op(
+            "sum", SimpleNamespace(is_flux=False, is_pre_aggregated=True)
+        )
+        assert result == "sum", f"Expected 'sum' passthrough, got {result!r}"
+
     @pytest.mark.parametrize("explicit_op", ["mean", "sum", "min", "max", "std"])
     def test_explicit_op_passthrough(self, explicit_op):
         """Any non-`auto` op is returned verbatim regardless of `is_flux`.

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/backend.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/backend.py
@@ -983,14 +983,19 @@ class ECMWF(LazyClientMixin, AbstractDataSource):
                 `0.003 m` (the average 6-hour accumulation, **not**
                 a daily total).
 
+                * **Pre-aggregated** (`Variable.is_pre_aggregated` —
+                  the `derived-era5-*-daily-statistics` and
+                  `reanalysis-era5-*-monthly-means` families, where
+                  each NetCDF sample is already a server-side daily /
+                  monthly aggregate). `auto` → `"mean"`, overriding
+                  the flux rule: a `"sum"` would re-accumulate the
+                  aggregates and multiply by the number of samples in
+                  the window (~30× for a monthly window over daily
+                  statistics).
+
                 Pass an explicit `op="mean"` / `"sum"` / `"min"` /
-                `"max"` / `"std"` to bypass auto-routing — for
-                example, on pre-aggregated CDS datasets like
-                `derived-era5-single-levels-daily-statistics` where
-                each NetCDF sample is already a daily aggregate and
-                summing four of them would multiply by 4. See
-                `docs/reference/aggregation.md` for the full
-                walkthrough.
+                `"max"` / `"std"` to bypass auto-routing entirely. See
+                `docs/aggregation.md` for the full walkthrough.
         Returns:
             list[Path]: The written output paths — one per-variable
             NetCDF at `<self.root_dir>/<cds_variable>_<dataset_id>.nc`

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
@@ -562,6 +562,28 @@ class Variable(FluxableLeaf):
     # `is_flux` property is inherited from `FluxableLeaf` (N1 in
     # the cross-backend catalog comparison).
 
+    @property
+    def is_pre_aggregated(self) -> bool:
+        """Whether each NetCDF sample is already a server-side temporal aggregate.
+
+        `True` for the two CDS families whose samples are aggregated on the
+        server, so re-accumulating them over a coarser window over-counts:
+
+        * the daily-statistics family (`derived-era5-*-daily-statistics`), whose
+          dataset-level `daily_statistic` request extra is merged into every
+          child variable's `extras`; and
+        * the ERA5 monthly-means family (`reanalysis-era5-*-monthly-means`),
+          whose product type is `monthly_averaged_*`.
+
+        `earthlens.aggregate._resolve_op` reads this so `op="auto"` reduces such
+        variables with `"mean"` rather than `"sum"` — a plain `sum` over samples
+        that are themselves daily/monthly aggregates multiplies by the number of
+        samples per window (e.g. ~30× for monthly windows over daily statistics).
+        """
+        if self.extras.get("daily_statistic"):
+            return True
+        return any(pt.startswith("monthly_averaged") for pt in self.product_type)
+
 
 class Dataset(BaseModel):
     """One CDS dataset's section in the catalog.

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
@@ -382,7 +382,9 @@ class TestCatalog:
             "total-precipitation"
         ]
         # All three are flux; only the pre-aggregated two must flag.
-        assert daily_tp.is_flux and monthly_tp.is_flux and raw_tp.is_flux
+        assert daily_tp.is_flux, "daily-statistics tp should be flux"
+        assert monthly_tp.is_flux, "monthly-means tp should be flux"
+        assert raw_tp.is_flux, "raw ERA5 tp should be flux"
         assert daily_tp.is_pre_aggregated is True, "daily-statistics flux var"
         assert monthly_tp.is_pre_aggregated is True, "monthly-means flux var"
         assert raw_tp.is_pre_aggregated is False, "raw hourly ERA5 flux var"

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
@@ -363,6 +363,30 @@ class TestCatalog:
         assert spec.nc_variable == "t"
         assert spec.cds_pressure_level == ["1000"]
 
+    def test_is_pre_aggregated_flags_daily_statistics_and_monthly_means(self):
+        """`Variable.is_pre_aggregated` is True for the two pre-aggregated families (#43).
+
+        Daily-statistics variables carry a `daily_statistic` extra and monthly-means
+        variables a `monthly_averaged_*` product type; a raw hourly ERA5 variable
+        (same physical quantity, same `types: flux`) is not pre-aggregated, so
+        `op="auto"` still sums it.
+        """
+        cat = Catalog()
+        daily_tp = cat.datasets[
+            "derived-era5-single-levels-daily-statistics"
+        ].variables["total-precipitation-daily"]
+        monthly_tp = cat.datasets[
+            "reanalysis-era5-single-levels-monthly-means"
+        ].variables["total-precipitation"]
+        raw_tp = cat.datasets["reanalysis-era5-single-levels"].variables[
+            "total-precipitation"
+        ]
+        # All three are flux; only the pre-aggregated two must flag.
+        assert daily_tp.is_flux and monthly_tp.is_flux and raw_tp.is_flux
+        assert daily_tp.is_pre_aggregated is True, "daily-statistics flux var"
+        assert monthly_tp.is_pre_aggregated is True, "monthly-means flux var"
+        assert raw_tp.is_pre_aggregated is False, "raw hourly ERA5 flux var"
+
     def test_minimal_valid_request_picks_entry_with_variable(self, monkeypatch):
         """`minimal_valid_request` returns a known-valid request dict."""
         from earthlens.ecmwf import constraints as constraints_module


### PR DESCRIPTION
# Description

`op="auto"` resolved **flux** variables to `"sum"` purely on `Variable.is_flux`, regardless of whether the
dataset's samples were already a server-side temporal aggregate. So aggregating a flux variable from a
`derived-era5-*-daily-statistics` or `reanalysis-era5-*-monthly-means` dataset re-summed the already
daily/monthly samples — e.g. `aggregate_netcdf(freq="1MS", op="auto")` on `total-precipitation` from
`derived-era5-single-levels-daily-statistics` produced monthly values ~30× too large.

Fix — detect pre-aggregation from signals already present on the loaded catalog rows and route `auto` to
`"mean"` for those variables:

- **`Variable.is_pre_aggregated`** (ECMWF catalog): `True` when a variable carries a `daily_statistic` request
  extra (the daily-statistics family) or a `monthly_averaged*` product type (the monthly-means family).
- **`_resolve_op`**: `op="auto"` + `is_pre_aggregated` → `"mean"`, ahead of the `is_flux` rule; read via
  `getattr(..., default False)` so a non-ECMWF `var_info` is unaffected. State variables already resolved to
  `"mean"`, so only pre-aggregated **flux** variables change behaviour (`"sum"`→`"mean"`).
- ECMWF backend `op="auto"` docstring and `docs/aggregation.md` updated (auto now handles these datasets; the
  manual `op="mean"` workaround note is gone).

**No new `types` value and no per-row YAML edits.** The detection uses signals the loader already produces
(`extras.daily_statistic` merged from the dataset; `product_type` set by monthly-means synthesis). This also
covers the ~338 `*-monthly-means` rows, which are auto-synthesized and have no YAML to edit. Superseding the
issue's original "add a `pre_aggregated` type + edit ~30 rows" plan (see the updated analysis on #43).

Out of scope (tracked as follow-up on #43): other pre-aggregated families with heterogeneous signals — CAMS
`*-monthly`, satellite CDR monthly, `derived-drought-historical-monthly`, `derived-utci-historical`, and the
seasonal / cmip5 / cordex / `sis-*` indicator families.

# Issues
- Closes #43

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit tests — `_resolve_op` routes `op="auto"` + pre-aggregated flux → `"mean"` (the #43 pre-fix failure /
      post-fix success), pre-aggregated state stays `"mean"`, a `var_info` lacking `is_pre_aggregated` falls
      back to the flux rule, and explicit ops still pass through.
- [x] Catalog test — `Variable.is_pre_aggregated` is `True` for `total-precipitation-daily`
      (daily-statistics) and `total-precipitation` (monthly-means), and `False` for raw
      `reanalysis-era5-single-levels` `total-precipitation` (all three are `types: flux`).
- [x] End-to-end round-trip — `aggregate_netcdf(op="auto")` on a pre-aggregated flux var reduces the
      window with `"mean"` (2.5), not `"sum"` (10.0), exercising the full read → resolve → reduce path.
- [x] Doctests on the changed modules pass (incl. the new pre-aggregated `_resolve_op` example).
- [x] Full non-e2e suites green on the two affected distributions: core 2526, atmosphere 2597. `mypy` clean
      (405 files); `ruff` check + format clean.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
