### PR TITLE
fix(ecmwf): broaden pre-aggregated detection to flux monthly/daily families

### DIFF
--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
@@ -443,14 +443,16 @@ def _validate_grid_resolution(value: float | None) -> float | None:
     return value
 
 
-#: Tokens in a `time_aggregation` / `temporal_resolution` value that mark the
-#: samples as a server-side temporal aggregate (a daily-or-coarser mean / statistic).
+# Tokens in a `time_aggregation` / `temporal_resolution` value that mark the
+# samples as a server-side temporal aggregate (a daily-or-coarser mean). Both the
+# `day` and `daily` spellings appear in the catalog, so both are listed.
 _TEMPORAL_AGGREGATE_TOKENS = (
     "mean",
     "average",
     "avg",
     "climatolog",
     "daily",
+    "day",
     "dekad",
     "pentad",
     "week",

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
@@ -449,7 +449,6 @@ _TEMPORAL_AGGREGATE_TOKENS = (
     "mean",
     "average",
     "avg",
-    "sum",
     "climatolog",
     "daily",
     "day",

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
@@ -451,7 +451,6 @@ _TEMPORAL_AGGREGATE_TOKENS = (
     "avg",
     "climatolog",
     "daily",
-    "day",
     "dekad",
     "pentad",
     "week",
@@ -498,7 +497,10 @@ def _denotes_temporal_aggregate(value: Any) -> bool:
         return False
     items = value if isinstance(value, (list, tuple)) else [value]
     text = " ".join(str(item).lower() for item in items)
-    if "instant" in text or "hour" in text:
+    # Sub-daily / instantaneous samples are raw, not aggregates. This veto must
+    # run before the token match — a `sub-daily` value contains the `daily`
+    # token — and any new sub-daily spelling must be added here.
+    if any(marker in text for marker in ("instant", "hour", "sub")):
         return False
     return any(token in text for token in _TEMPORAL_AGGREGATE_TOKENS)
 

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
@@ -650,6 +650,62 @@ class Variable(FluxableLeaf):
         variables with `"mean"` rather than `"sum"` — a plain `sum` over samples
         that are themselves daily/monthly aggregates multiplies by the number of
         samples per window (e.g. ~30× for monthly windows over daily statistics).
+
+        Returns:
+            `True` when each sample is a server-side temporal aggregate — so
+            `op="auto"` should average rather than sum — and `False` otherwise.
+
+        Examples:
+            - An ERA5 monthly-means flux variable is pre-aggregated (its product
+              type is `monthly_averaged_*`):
+
+                ```python
+                >>> from earthlens.ecmwf.catalog import Variable
+                >>> monthly = Variable(
+                ...     cds_dataset="reanalysis-era5-single-levels-monthly-means",
+                ...     cds_variable="total_precipitation",
+                ...     nc_variable="tp",
+                ...     units="m",
+                ...     product_type=["monthly_averaged_reanalysis"],
+                ...     types="flux",
+                ... )
+                >>> monthly.is_pre_aggregated
+                True
+
+                ```
+            - A CARRA-means variable is flagged via its `time_aggregation` extra,
+              even though its product type is not `monthly_averaged_*`:
+
+                ```python
+                >>> from earthlens.ecmwf.catalog import Variable
+                >>> carra = Variable(
+                ...     cds_dataset="reanalysis-carra-means",
+                ...     cds_variable="10m_wind_gust",
+                ...     nc_variable="fg10",
+                ...     units="m s**-1",
+                ...     types="flux",
+                ...     extras={"time_aggregation": "daily"},
+                ... )
+                >>> carra.is_pre_aggregated
+                True
+
+                ```
+            - A raw hourly ERA5 flux variable is not, so `op="auto"` still sums it:
+
+                ```python
+                >>> from earthlens.ecmwf.catalog import Variable
+                >>> raw = Variable(
+                ...     cds_dataset="reanalysis-era5-single-levels",
+                ...     cds_variable="total_precipitation",
+                ...     nc_variable="tp",
+                ...     units="m",
+                ...     product_type=["reanalysis"],
+                ...     types="flux",
+                ... )
+                >>> raw.is_pre_aggregated
+                False
+
+                ```
         """
         if self.extras.get("daily_statistic"):
             return True

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
@@ -464,10 +464,12 @@ _TEMPORAL_AGGREGATE_TOKENS = (
 def _denotes_temporal_aggregate(value: Any) -> bool:
     """Whether a `time_aggregation` / `temporal_resolution` value marks an aggregate.
 
-    Returns `True` for a daily-or-coarser statistic (`"daily"`, `"1_month_mean"`,
+    Returns `True` for a daily-or-coarser mean (`"daily"`, `"1_month_mean"`,
     `"monthly_mean"`, ...) and `False` for a raw / sub-daily / instantaneous value
-    (`"instantaneous"`, `"1_hour"`, ...) or an empty one. Accepts a scalar or a
-    list (CDS spells these both ways).
+    (`"instantaneous"`, `"1_hour"`, `"sub-daily"`, ...) or an empty one. Accepts a
+    scalar or a list (CDS spells these both ways). Cadence-only values (`"daily"`,
+    `"monthly"`) are assumed to name a mean — sum tokens are deliberately excluded,
+    since the flag routes `op="auto"` to `"mean"` (see `is_pre_aggregated`).
 
     Args:
         value: The `time_aggregation` / `temporal_resolution` extra, or `None`.
@@ -647,6 +649,17 @@ class Variable(FluxableLeaf):
         (or the dataset id), not the `product_type` field, which stays
         `[reanalysis]` on these rows — hence the extra checks below.
 
+        Every flagged family is treated as a temporal **mean**, mirroring the
+        established `reanalysis-era5-*-monthly-means` convention: the flagged
+        flux families are all mean products — `ecv-for-climate-change`
+        (`1_month_mean`), `-cordex-` (`monthly_mean`), CMIP5 monthly
+        (`mean-*-flux` variables) and CARRA / pan-CARRA (the `*-means` datasets).
+        A family whose samples were pre-aggregated as a *total* (accumulation)
+        would need `sum`, not `mean`, and so must not be flagged here; none
+        exists in the shipped catalog. The extra-based branch additionally flags
+        many non-flux (`state`) satellite / in-situ / CMIP6 rows, where the flag
+        is a functional no-op (`_resolve_op` maps `state` to `mean` regardless).
+
         `earthlens.aggregate._resolve_op` reads this so `op="auto"` reduces such
         variables with `"mean"` rather than `"sum"` — a plain `sum` over samples
         that are themselves daily/monthly aggregates multiplies by the number of
@@ -716,8 +729,11 @@ class Variable(FluxableLeaf):
             return True
         if _denotes_temporal_aggregate(self.extras.get("temporal_resolution")):
             return True
-        # Monthly-projection datasets (CMIP5) carry no in-row aggregation marker;
-        # their only signal is the `-monthly` dataset id.
+        # CMIP5 monthly projections carry no in-row aggregation marker, so fall
+        # back to the `-monthly` dataset-id suffix. Validated against the shipped
+        # catalog: every `-monthly` id is a genuine monthly aggregate (no raw /
+        # sub-monthly dataset id contains `-monthly`); a future id that did would
+        # need an explicit `time_aggregation` / `temporal_resolution` marker.
         return "-monthly" in self.cds_dataset
 
 

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
@@ -503,8 +503,11 @@ def _denotes_temporal_aggregate(value: Any) -> bool:
     text = " ".join(str(item).lower() for item in items)
     # Sub-daily / instantaneous samples are raw, not aggregates. This veto must
     # run before the token match — a `sub-daily` value contains the `daily`
-    # token — and any new sub-daily spelling must be added here.
-    if any(marker in text for marker in ("instant", "hour", "sub")):
+    # token. Match the sub-daily spellings specifically (compacting separators)
+    # so a coarser-than-daily `subseasonal` value is not swallowed; any new
+    # sub-daily spelling must be added here.
+    compact = text.replace("-", "").replace("_", "")
+    if "instant" in text or "hour" in text or "subdaily" in compact:
         return False
     return any(token in text for token in _TEMPORAL_AGGREGATE_TOKENS)
 

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
@@ -443,6 +443,67 @@ def _validate_grid_resolution(value: float | None) -> float | None:
     return value
 
 
+#: Tokens in a `time_aggregation` / `temporal_resolution` value that mark the
+#: samples as a server-side temporal aggregate (a daily-or-coarser mean / statistic).
+_TEMPORAL_AGGREGATE_TOKENS = (
+    "mean",
+    "average",
+    "avg",
+    "sum",
+    "climatolog",
+    "daily",
+    "day",
+    "dekad",
+    "pentad",
+    "week",
+    "month",
+    "season",
+    "annual",
+    "year",
+)
+
+
+def _denotes_temporal_aggregate(value: Any) -> bool:
+    """Whether a `time_aggregation` / `temporal_resolution` value marks an aggregate.
+
+    Returns `True` for a daily-or-coarser statistic (`"daily"`, `"1_month_mean"`,
+    `"monthly_mean"`, ...) and `False` for a raw / sub-daily / instantaneous value
+    (`"instantaneous"`, `"1_hour"`, ...) or an empty one. Accepts a scalar or a
+    list (CDS spells these both ways).
+
+    Args:
+        value: The `time_aggregation` / `temporal_resolution` extra, or `None`.
+
+    Returns:
+        `True` when the value denotes a temporal aggregate.
+
+    Examples:
+        - Daily-or-coarser means are aggregates; raw / sub-daily values are not:
+
+            ```python
+            >>> from earthlens.ecmwf.catalog import _denotes_temporal_aggregate
+            >>> _denotes_temporal_aggregate("1_month_mean")
+            True
+            >>> _denotes_temporal_aggregate("daily")
+            True
+            >>> _denotes_temporal_aggregate("instantaneous")
+            False
+            >>> _denotes_temporal_aggregate("1_hour")
+            False
+            >>> _denotes_temporal_aggregate(None)
+            False
+
+            ```
+    """
+    if not value:
+        return False
+    items = value if isinstance(value, (list, tuple)) else [value]
+    text = " ".join(str(item).lower() for item in items)
+    if "instant" in text or "hour" in text:
+        return False
+    return any(token in text for token in _TEMPORAL_AGGREGATE_TOKENS)
+
+
 class Variable(FluxableLeaf):
     """Per-variable catalog entry consumed by :class:`ECMWF`.
 
@@ -566,14 +627,24 @@ class Variable(FluxableLeaf):
     def is_pre_aggregated(self) -> bool:
         """Whether each NetCDF sample is already a server-side temporal aggregate.
 
-        `True` for the two CDS families whose samples are aggregated on the
-        server, so re-accumulating them over a coarser window over-counts:
+        `True` for the CDS families whose samples are aggregated on the server,
+        so re-accumulating them over a coarser window over-counts:
 
         * the daily-statistics family (`derived-era5-*-daily-statistics`), whose
           dataset-level `daily_statistic` request extra is merged into every
-          child variable's `extras`; and
+          child variable's `extras`;
         * the ERA5 monthly-means family (`reanalysis-era5-*-monthly-means`),
-          whose product type is `monthly_averaged_*`.
+          whose product type is `monthly_averaged_*`;
+        * families carrying a `time_aggregation` / `temporal_resolution` extra
+          that denotes a daily-or-coarser mean (`ecv-for-climate-change`,
+          `reanalysis-carra-means` / `-pan-carra-means`,
+          `projections-cordex-domains-single-levels`); and
+        * monthly-projection datasets whose only marker is a `-monthly` dataset
+          id (`projections-cmip5-monthly-*`).
+
+        The `time_aggregation` / `temporal_resolution` markers live in `extras`
+        (or the dataset id), not the `product_type` field, which stays
+        `[reanalysis]` on these rows — hence the extra checks below.
 
         `earthlens.aggregate._resolve_op` reads this so `op="auto"` reduces such
         variables with `"mean"` rather than `"sum"` — a plain `sum` over samples
@@ -582,7 +653,15 @@ class Variable(FluxableLeaf):
         """
         if self.extras.get("daily_statistic"):
             return True
-        return any(pt.startswith("monthly_averaged") for pt in self.product_type)
+        if any(pt.startswith("monthly_averaged") for pt in self.product_type):
+            return True
+        if _denotes_temporal_aggregate(self.extras.get("time_aggregation")):
+            return True
+        if _denotes_temporal_aggregate(self.extras.get("temporal_resolution")):
+            return True
+        # Monthly-projection datasets (CMIP5) carry no in-row aggregation marker;
+        # their only signal is the `-monthly` dataset id.
+        return "-monthly" in self.cds_dataset
 
 
 class Dataset(BaseModel):

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog.py
@@ -642,8 +642,10 @@ class Variable(FluxableLeaf):
           that denotes a daily-or-coarser mean (`ecv-for-climate-change`,
           `reanalysis-carra-means` / `-pan-carra-means`,
           `projections-cordex-domains-single-levels`); and
-        * monthly-projection datasets whose only marker is a `-monthly` dataset
-          id (`projections-cmip5-monthly-*`).
+        * monthly datasets whose only marker is a `-monthly` dataset id — the
+          CMIP5 monthly projections (`projections-cmip5-monthly-*`) and the
+          seasonal monthly-mean forecasts (`seasonal-monthly-single-levels`,
+          whose `monthly_mean` lives in `extras["product_type"]`).
 
         The `time_aggregation` / `temporal_resolution` markers live in `extras`
         (or the dataset id), not the `product_type` field, which stays
@@ -653,7 +655,9 @@ class Variable(FluxableLeaf):
         established `reanalysis-era5-*-monthly-means` convention: the flagged
         flux families are all mean products — `ecv-for-climate-change`
         (`1_month_mean`), `-cordex-` (`monthly_mean`), CMIP5 monthly
-        (`mean-*-flux` variables) and CARRA / pan-CARRA (the `*-means` datasets).
+        (`mean-*-flux` variables), CARRA / pan-CARRA (the `*-means` datasets) and
+        `seasonal-monthly-single-levels` (`extras["product_type"] ==
+        ["monthly_mean"]`).
         A family whose samples were pre-aggregated as a *total* (accumulation)
         would need `sum`, not `mean`, and so must not be flagged here; none
         exists in the shipped catalog. The extra-based branch additionally flags
@@ -729,11 +733,12 @@ class Variable(FluxableLeaf):
             return True
         if _denotes_temporal_aggregate(self.extras.get("temporal_resolution")):
             return True
-        # CMIP5 monthly projections carry no in-row aggregation marker, so fall
-        # back to the `-monthly` dataset-id suffix. Validated against the shipped
-        # catalog: every `-monthly` id is a genuine monthly aggregate (no raw /
-        # sub-monthly dataset id contains `-monthly`); a future id that did would
-        # need an explicit `time_aggregation` / `temporal_resolution` marker.
+        # CMIP5 monthly projections and seasonal monthly-mean forecasts carry no
+        # in-row time_aggregation marker (the seasonal family's `monthly_mean`
+        # lives in extras["product_type"]), so fall back to the `-monthly`
+        # dataset-id suffix. Validated against the shipped catalog: every
+        # `-monthly` id is a genuine monthly aggregate (no raw / sub-monthly id
+        # contains `-monthly`); a future id that did would need an explicit marker.
         return "-monthly" in self.cds_dataset
 
 

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
@@ -1113,7 +1113,17 @@ class TestDenotesTemporalAggregate:
 
     @pytest.mark.parametrize(
         "value",
-        ["instantaneous", "instant", "1_hour", "hourly", "6_hourly", "3-hourly"],
+        [
+            "instantaneous",
+            "instant",
+            "1_hour",
+            "hourly",
+            "6_hourly",
+            "3-hourly",
+            "sub-daily",
+            "sub_daily",
+            "subdaily",
+        ],
     )
     def test_sub_daily_and_instantaneous_values_are_not_aggregates(self, value):
         """Instantaneous / sub-daily (hourly) values are treated as raw.

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
@@ -410,13 +410,7 @@ class TestCatalog:
         ],
     )
     def test_is_pre_aggregated_flags_extra_and_monthly_id_families(self, dataset, code):
-        """Flux vars whose pre-aggregation marker is a time_aggregation /
-        temporal_resolution extra or a `-monthly` dataset id are flagged (#1097).
-
-        Args:
-            dataset: The pre-aggregated dataset key.
-            code: A `types: flux` variable code within it.
-        """
+        """Flux vars flagged via a temporal-aggregate extra or a -monthly id (#1097)."""
         var = Catalog().datasets[dataset].variables[code]
         assert var.is_flux, f"{dataset}::{code} should be flux"
         assert var.is_pre_aggregated is True, (
@@ -434,16 +428,7 @@ class TestCatalog:
         ],
     )
     def test_is_pre_aggregated_does_not_flag_raw_flux_datasets(self, dataset, code):
-        """Raw (non-aggregated) flux datasets stay unflagged so `op="auto"` still sums.
-
-        Guards against the detection widening onto raw hourly / sub-daily / forecast
-        flux datasets (WFDE5, raw CARRA/CERRA, seasonal-original, raw ERA5), where a
-        `sum` is the correct window total.
-
-        Args:
-            dataset: A raw flux dataset key.
-            code: A `types: flux` variable code within it.
-        """
+        """Raw flux datasets stay unflagged so `op="auto"` still sums them."""
         var = Catalog().datasets[dataset].variables[code]
         assert var.is_flux, f"{dataset}::{code} should be flux"
         assert var.is_pre_aggregated is False, (
@@ -1067,46 +1052,21 @@ class TestDenotesTemporalAggregate:
         ],
     )
     def test_daily_or_coarser_values_are_aggregates(self, value):
-        """Daily-or-coarser mean / statistic strings are detected as aggregates.
-
-        Args:
-            value: A `time_aggregation` / `temporal_resolution` string naming a
-                daily-or-coarser temporal reduction.
-
-        Test scenario:
-            Real-world CDS values that reduce over a day or longer window
-            (`1_month_mean`, `daily`, `seasonal`, ...) return True.
-        """
+        """Daily-or-coarser mean strings are detected as aggregates."""
         assert _denotes_temporal_aggregate(value) is True, (
             f"{value!r} should count as a temporal aggregate"
         )
 
     @pytest.mark.parametrize("token", _TEMPORAL_AGGREGATE_TOKENS)
     def test_every_declared_token_triggers_detection(self, token):
-        """Each token in the module list independently marks a value as an aggregate.
-
-        Args:
-            token: One entry of `_TEMPORAL_AGGREGATE_TOKENS`.
-
-        Test scenario:
-            The helper's positive signal is exactly membership of the declared
-            token list, so every token alone must resolve to True.
-        """
+        """Each declared token, on its own, marks a value as an aggregate."""
         assert _denotes_temporal_aggregate(token) is True, (
             f"declared token {token!r} should be detected"
         )
 
     @pytest.mark.parametrize("value", [None, "", [], (), 0, False])
     def test_empty_values_are_not_aggregates(self, value):
-        """Falsy / empty inputs short-circuit to False.
-
-        Args:
-            value: An empty or falsy `time_aggregation` value.
-
-        Test scenario:
-            A missing extra (`None`), an empty string, and empty containers all
-            return False without inspecting tokens.
-        """
+        """Falsy / empty inputs short-circuit to False."""
         assert _denotes_temporal_aggregate(value) is False, (
             f"empty value {value!r} should not be an aggregate"
         )
@@ -1126,15 +1086,7 @@ class TestDenotesTemporalAggregate:
         ],
     )
     def test_sub_daily_and_instantaneous_values_are_not_aggregates(self, value):
-        """Instantaneous / sub-daily (hourly) values are treated as raw.
-
-        Args:
-            value: A raw sub-daily or instantaneous string.
-
-        Test scenario:
-            Values carrying `instant` or `hour` are raw samples that `op="auto"`
-            should still sum, so the helper returns False.
-        """
+        """Instantaneous / sub-daily values are treated as raw, not aggregates."""
         assert _denotes_temporal_aggregate(value) is False, (
             f"sub-daily/instant value {value!r} should not be an aggregate"
         )
@@ -1144,41 +1096,21 @@ class TestDenotesTemporalAggregate:
         ["hourly_mean", "6_hourly_mean", "instantaneous_mean"],
     )
     def test_sub_daily_veto_wins_over_an_aggregate_token(self, value):
-        """The hour / instant veto takes precedence even when a mean token co-occurs.
-
-        Args:
-            value: A value carrying both a sub-daily marker and a mean token.
-
-        Test scenario:
-            A sub-daily mean is still sub-daily; the helper returns False despite
-            the `mean` token being present, so `op="auto"` sums it.
-        """
+        """The sub-daily veto wins even when a mean token co-occurs."""
         assert _denotes_temporal_aggregate(value) is False, (
             f"{value!r} is sub-daily; the hour/instant veto must win"
         )
 
     @pytest.mark.parametrize("value", ["raw", "forecast", "analysis", "reanalysis"])
     def test_values_without_a_token_are_not_aggregates(self, value):
-        """Strings carrying none of the tokens are not aggregates.
-
-        Args:
-            value: A string with no temporal-aggregate token.
-
-        Test scenario:
-            Provider / product words that do not name a temporal reduction return
-            False.
-        """
+        """Strings carrying none of the tokens are not aggregates."""
         assert _denotes_temporal_aggregate(value) is False, (
             f"{value!r} carries no aggregate token"
         )
 
     @pytest.mark.parametrize("value", ["sum", "running_sum", "accumulated_sum"])
     def test_sum_type_values_are_not_aggregates(self, value):
-        """A value whose only signal is `sum` is not flagged, since the flag forces mean.
-
-        Args:
-            value: A value naming a temporal sum / accumulation.
-        """
+        """A value whose only signal is a sum is not flagged (the flag forces mean)."""
         assert _denotes_temporal_aggregate(value) is False, (
             f"{value!r} is a sum, not a mean; it must not be flagged as pre-aggregated"
         )
@@ -1196,39 +1128,19 @@ class TestDenotesTemporalAggregate:
         ],
     )
     def test_accepts_list_and_tuple_values(self, value, expected):
-        """CDS spells `time_aggregation` as a scalar or a list; both are handled.
-
-        Args:
-            value: A list / tuple form of the extra.
-            expected: Whether it denotes an aggregate.
-
-        Test scenario:
-            List and tuple members are joined and matched as one lowercased text,
-            so a token anywhere in the sequence is detected and the veto still
-            applies.
-        """
+        """Scalar, list, and tuple forms of the extra are all handled."""
         assert _denotes_temporal_aggregate(value) is expected, (
             f"{value!r} should resolve to {expected}"
         )
 
     def test_detection_is_case_insensitive(self):
-        """Values are lower-cased before matching, so casing does not matter.
-
-        Test scenario:
-            Upper- and mixed-case aggregate strings still flag, and an upper-case
-            sub-daily value is still vetoed.
-        """
+        """Detection is case-insensitive (values are lower-cased first)."""
         assert _denotes_temporal_aggregate("MONTHLY_MEAN") is True, "upper aggregate"
         assert _denotes_temporal_aggregate("Daily") is True, "mixed-case aggregate"
         assert _denotes_temporal_aggregate("1_HOUR") is False, "upper sub-daily vetoed"
 
     def test_tokens_constant_is_lowercase_tuple(self):
-        """`_TEMPORAL_AGGREGATE_TOKENS` is a non-empty tuple of lowercase tokens.
-
-        Test scenario:
-            The matcher lowercases the text, so every declared token must be
-            lowercase for the membership test to work.
-        """
+        """`_TEMPORAL_AGGREGATE_TOKENS` is a non-empty tuple of lowercase tokens."""
         assert isinstance(_TEMPORAL_AGGREGATE_TOKENS, tuple), "tokens are a tuple"
         assert _TEMPORAL_AGGREGATE_TOKENS, "tokens list is non-empty"
         assert all(t == t.lower() for t in _TEMPORAL_AGGREGATE_TOKENS), (

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
@@ -1109,6 +1109,13 @@ class TestDenotesTemporalAggregate:
             f"{value!r} carries no aggregate token"
         )
 
+    @pytest.mark.parametrize("value", ["subseasonal", "subseasonal_mean"])
+    def test_coarse_sub_cadence_is_not_vetoed(self, value):
+        """A coarser-than-daily `sub*` cadence (subseasonal) is not vetoed as sub-daily."""
+        assert _denotes_temporal_aggregate(value) is True, (
+            f"{value!r} is coarser than daily and should flag"
+        )
+
     @pytest.mark.parametrize("value", ["sum", "running_sum", "accumulated_sum"])
     def test_sum_type_values_are_not_aggregates(self, value):
         """A value whose only signal is a sum is not flagged (the flag forces mean)."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
@@ -11,6 +11,10 @@ from __future__ import annotations
 import pytest
 
 from earthlens.ecmwf import Catalog, Variable
+from earthlens.ecmwf.catalog import (
+    _TEMPORAL_AGGREGATE_TOKENS,
+    _denotes_temporal_aggregate,
+)
 
 pytestmark = [pytest.mark.unit]
 
@@ -1039,3 +1043,174 @@ class TestCatalogHealth:
         unused = Catalog().health()["unused_provider"]
         assert isinstance(unused, list)
         assert unused == sorted(unused), "unused providers are reported sorted"
+
+
+class TestDenotesTemporalAggregate:
+    """Tests for the `_denotes_temporal_aggregate` catalog helper (#1097)."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "1_month_mean",
+            "monthly_mean",
+            "monthly",
+            "daily",
+            "1_day_mean",
+            "seasonal",
+            "annual",
+            "yearly",
+            "dekadal",
+            "pentad",
+            "weekly",
+            "climatology",
+            "time-average",
+            "running_sum",
+        ],
+    )
+    def test_daily_or_coarser_values_are_aggregates(self, value):
+        """Daily-or-coarser mean / statistic strings are detected as aggregates.
+
+        Args:
+            value: A `time_aggregation` / `temporal_resolution` string naming a
+                daily-or-coarser temporal reduction.
+
+        Test scenario:
+            Real-world CDS values that reduce over a day or longer window
+            (`1_month_mean`, `daily`, `seasonal`, ...) return True.
+        """
+        assert _denotes_temporal_aggregate(value) is True, (
+            f"{value!r} should count as a temporal aggregate"
+        )
+
+    @pytest.mark.parametrize("token", _TEMPORAL_AGGREGATE_TOKENS)
+    def test_every_declared_token_triggers_detection(self, token):
+        """Each token in the module list independently marks a value as an aggregate.
+
+        Args:
+            token: One entry of `_TEMPORAL_AGGREGATE_TOKENS`.
+
+        Test scenario:
+            The helper's positive signal is exactly membership of the declared
+            token list, so every token alone must resolve to True.
+        """
+        assert _denotes_temporal_aggregate(token) is True, (
+            f"declared token {token!r} should be detected"
+        )
+
+    @pytest.mark.parametrize("value", [None, "", [], (), 0, False])
+    def test_empty_values_are_not_aggregates(self, value):
+        """Falsy / empty inputs short-circuit to False.
+
+        Args:
+            value: An empty or falsy `time_aggregation` value.
+
+        Test scenario:
+            A missing extra (`None`), an empty string, and empty containers all
+            return False without inspecting tokens.
+        """
+        assert _denotes_temporal_aggregate(value) is False, (
+            f"empty value {value!r} should not be an aggregate"
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        ["instantaneous", "instant", "1_hour", "hourly", "6_hourly", "3-hourly"],
+    )
+    def test_sub_daily_and_instantaneous_values_are_not_aggregates(self, value):
+        """Instantaneous / sub-daily (hourly) values are treated as raw.
+
+        Args:
+            value: A raw sub-daily or instantaneous string.
+
+        Test scenario:
+            Values carrying `instant` or `hour` are raw samples that `op="auto"`
+            should still sum, so the helper returns False.
+        """
+        assert _denotes_temporal_aggregate(value) is False, (
+            f"sub-daily/instant value {value!r} should not be an aggregate"
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        ["hourly_mean", "6_hourly_mean", "instantaneous_mean"],
+    )
+    def test_sub_daily_veto_wins_over_an_aggregate_token(self, value):
+        """The hour / instant veto takes precedence even when a mean token co-occurs.
+
+        Args:
+            value: A value carrying both a sub-daily marker and a mean token.
+
+        Test scenario:
+            A sub-daily mean is still sub-daily; the helper returns False despite
+            the `mean` token being present, so `op="auto"` sums it.
+        """
+        assert _denotes_temporal_aggregate(value) is False, (
+            f"{value!r} is sub-daily; the hour/instant veto must win"
+        )
+
+    @pytest.mark.parametrize("value", ["raw", "forecast", "analysis", "reanalysis"])
+    def test_values_without_a_token_are_not_aggregates(self, value):
+        """Strings carrying none of the tokens are not aggregates.
+
+        Args:
+            value: A string with no temporal-aggregate token.
+
+        Test scenario:
+            Provider / product words that do not name a temporal reduction return
+            False.
+        """
+        assert _denotes_temporal_aggregate(value) is False, (
+            f"{value!r} carries no aggregate token"
+        )
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (["monthly_mean"], True),
+            (["daily"], True),
+            (("1_month_mean",), True),
+            (["1", "daily"], True),
+            (["instantaneous"], False),
+            (["1_hour"], False),
+            (["raw"], False),
+        ],
+    )
+    def test_accepts_list_and_tuple_values(self, value, expected):
+        """CDS spells `time_aggregation` as a scalar or a list; both are handled.
+
+        Args:
+            value: A list / tuple form of the extra.
+            expected: Whether it denotes an aggregate.
+
+        Test scenario:
+            List and tuple members are joined and matched as one lowercased text,
+            so a token anywhere in the sequence is detected and the veto still
+            applies.
+        """
+        assert _denotes_temporal_aggregate(value) is expected, (
+            f"{value!r} should resolve to {expected}"
+        )
+
+    def test_detection_is_case_insensitive(self):
+        """Values are lower-cased before matching, so casing does not matter.
+
+        Test scenario:
+            Upper- and mixed-case aggregate strings still flag, and an upper-case
+            sub-daily value is still vetoed.
+        """
+        assert _denotes_temporal_aggregate("MONTHLY_MEAN") is True, "upper aggregate"
+        assert _denotes_temporal_aggregate("Daily") is True, "mixed-case aggregate"
+        assert _denotes_temporal_aggregate("1_HOUR") is False, "upper sub-daily vetoed"
+
+    def test_tokens_constant_is_lowercase_tuple(self):
+        """`_TEMPORAL_AGGREGATE_TOKENS` is a non-empty tuple of lowercase tokens.
+
+        Test scenario:
+            The matcher lowercases the text, so every declared token must be
+            lowercase for the membership test to work.
+        """
+        assert isinstance(_TEMPORAL_AGGREGATE_TOKENS, tuple), "tokens are a tuple"
+        assert _TEMPORAL_AGGREGATE_TOKENS, "tokens list is non-empty"
+        assert all(t == t.lower() for t in _TEMPORAL_AGGREGATE_TOKENS), (
+            "every token is lowercase so matching against lowercased text works"
+        )

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
@@ -407,6 +407,7 @@ class TestCatalog:
             ),
             ("reanalysis-carra-means", "10m-wind-gust-carra-means"),
             ("reanalysis-pan-carra-means", "evaporation-pancarra-means"),
+            ("seasonal-monthly-single-levels", "total-precipitation-seasonal"),
         ],
     )
     def test_is_pre_aggregated_flags_extra_and_monthly_id_families(self, dataset, code):

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
@@ -1064,7 +1064,6 @@ class TestDenotesTemporalAggregate:
             "weekly",
             "climatology",
             "time-average",
-            "running_sum",
         ],
     )
     def test_daily_or_coarser_values_are_aggregates(self, value):
@@ -1161,6 +1160,17 @@ class TestDenotesTemporalAggregate:
         """
         assert _denotes_temporal_aggregate(value) is False, (
             f"{value!r} carries no aggregate token"
+        )
+
+    @pytest.mark.parametrize("value", ["sum", "running_sum", "accumulated_sum"])
+    def test_sum_type_values_are_not_aggregates(self, value):
+        """A value whose only signal is `sum` is not flagged, since the flag forces mean.
+
+        Args:
+            value: A value naming a temporal sum / accumulation.
+        """
+        assert _denotes_temporal_aggregate(value) is False, (
+            f"{value!r} is a sum, not a mean; it must not be flagged as pre-aggregated"
         )
 
     @pytest.mark.parametrize(

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py
@@ -389,6 +389,63 @@ class TestCatalog:
         assert monthly_tp.is_pre_aggregated is True, "monthly-means flux var"
         assert raw_tp.is_pre_aggregated is False, "raw hourly ERA5 flux var"
 
+    @pytest.mark.parametrize(
+        "dataset, code",
+        [
+            ("ecv-for-climate-change", "precipitation-ecv"),
+            (
+                "projections-cmip5-monthly-single-levels",
+                "mean-precipitation-flux-cmip5m",
+            ),
+            (
+                "projections-cordex-domains-single-levels",
+                "mean-precipitation-flux-cordex",
+            ),
+            ("reanalysis-carra-means", "10m-wind-gust-carra-means"),
+            ("reanalysis-pan-carra-means", "evaporation-pancarra-means"),
+        ],
+    )
+    def test_is_pre_aggregated_flags_extra_and_monthly_id_families(self, dataset, code):
+        """Flux vars whose pre-aggregation marker is a time_aggregation /
+        temporal_resolution extra or a `-monthly` dataset id are flagged (#1097).
+
+        Args:
+            dataset: The pre-aggregated dataset key.
+            code: A `types: flux` variable code within it.
+        """
+        var = Catalog().datasets[dataset].variables[code]
+        assert var.is_flux, f"{dataset}::{code} should be flux"
+        assert var.is_pre_aggregated is True, (
+            f"{dataset}::{code} should be pre-aggregated"
+        )
+
+    @pytest.mark.parametrize(
+        "dataset, code",
+        [
+            ("derived-near-surface-meteorological-variables", "rainfall-flux-nsmv"),
+            ("reanalysis-cerra-single-levels", "evaporation-cerra"),
+            ("reanalysis-carra-single-levels", "percolation-carra"),
+            ("seasonal-original-single-levels", "evaporation-seasonal-orig"),
+            ("reanalysis-era5-single-levels", "total-precipitation"),
+        ],
+    )
+    def test_is_pre_aggregated_does_not_flag_raw_flux_datasets(self, dataset, code):
+        """Raw (non-aggregated) flux datasets stay unflagged so `op="auto"` still sums.
+
+        Guards against the detection widening onto raw hourly / sub-daily / forecast
+        flux datasets (WFDE5, raw CARRA/CERRA, seasonal-original, raw ERA5), where a
+        `sum` is the correct window total.
+
+        Args:
+            dataset: A raw flux dataset key.
+            code: A `types: flux` variable code within it.
+        """
+        var = Catalog().datasets[dataset].variables[code]
+        assert var.is_flux, f"{dataset}::{code} should be flux"
+        assert var.is_pre_aggregated is False, (
+            f"{dataset}::{code} must NOT be pre-aggregated"
+        )
+
     def test_minimal_valid_request_picks_entry_with_variable(self, monkeypatch):
         """`minimal_valid_request` returns a known-valid request dict."""
         from earthlens.ecmwf import constraints as constraints_module


### PR DESCRIPTION
# Description

Follow-up to #43. That change made `op="auto"` reduce ERA5 pre-aggregated datasets with `"mean"` instead of
`"sum"` via `Variable.is_pre_aggregated`, but scoped detection to two signals only: the `daily_statistic` request
extra and `monthly_averaged*` product types. Other flux-bearing families whose NetCDF samples are *also* already
server-side temporal aggregates slipped through, so a flux variable resolved `op="auto"` → `"sum"` and
re-accumulated already-aggregated samples — the same N-fold over-count #43 fixed for ERA5.

The crux: for the missed families the aggregation signal lives in the `time_aggregation` / `temporal_resolution`
extras (values like `1_month_mean`, `monthly_mean`, `daily`) or the `-monthly` dataset id — **not** the
`product_type` field the old property read, which stays `[reanalysis]` on these rows.

This broadens `Variable.is_pre_aggregated` to read those signals in addition to the existing two:

- A new module helper `_denotes_temporal_aggregate(value)` classifies a `time_aggregation` /
  `temporal_resolution` value: `True` for a daily-or-coarser mean/statistic, `False` for an
  `instantaneous` / sub-daily (`1_hour`) value or an empty one. Accepts a scalar or a list (CDS spells these
  both ways).
- `is_pre_aggregated` now also returns `True` when either extra denotes an aggregate, or the dataset id carries a
  `-monthly` suffix (the only marker CMIP5 monthly projections carry).

Only flux variables can over-count (a pre-aggregated state variable already resolves `auto` → `mean`), so the
newly-flagged datasets are the flux-bearing ones: `ecv-for-climate-change`,
`projections-cmip5-monthly-single-levels`, `projections-cordex-domains-single-levels`, `reanalysis-carra-means`
and `reanalysis-pan-carra-means`. Raw-flux datasets stay unflagged so their `"sum"` semantics are preserved.

No source dependency changes.

# Issues

- Closes #1097

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- **New catalog unit tests** (`libs/providers/atmosphere/tests/test_ecmwf/test_catalog.py`), both parametrized:
  - one asserts the five target families are `is_flux` **and** `is_pre_aggregated is True`;
  - one is the raw-flux regression guard — `derived-near-surface-meteorological-variables` (WFDE5),
    `reanalysis-cerra-single-levels`, `reanalysis-carra-single-levels` (raw), `seasonal-original-single-levels`
    and `reanalysis-era5-single-levels` stay `is_pre_aggregated is False`.
- **Doctest** on the `_denotes_temporal_aggregate` helper.
- **Live regression sweep** over every flux variable in the catalog: exactly nine flux datasets are flagged — the
  five targets, the three ERA5 families already handled by #43, and `seasonal-monthly-single-levels` (defensive
  monthly flag; its ensemble / lead-time structure means `aggregate_netcdf` does not practically apply). All six
  raw-flux protect-list datasets stay unflagged — no regression.
- `ruff format --check` / `ruff check`: clean. `mypy` on the changed module: clean.
- Core aggregate suite (`libs/core/tests/test_aggregate.py`): 121 passed. Catalog test file: 76 passed.

- [x] Catalog tests: new families flagged, raw-flux families not regressed
- [x] Core aggregate + ecmwf catalog suites green locally

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
