### PR TITLE
fix(ecmwf): require name evidence before the hydrator pairs a lone slug

### DIFF
--- a/docs/reference/ecmwf/catalog.md
+++ b/docs/reference/ecmwf/catalog.md
@@ -714,12 +714,13 @@ Matching is deliberately conservative. The confident rules come first: an
 exact short-name match, then a token-subset match against the variable's
 `long_name`. Only a single leftover slug facing a single unused variable
 reaches the last-resort rule, and it pairs them only when the two names
-carry evidence of describing the same quantity — a shared token, an
-initialism (`sst` for `sea-surface-temperature`), or a product prefix
-(`xco2` for `co2`). That evidence is a filter, not a proof: a single
-shared token is enough, so the last-resort rule can still be wrong where
-two names share a generic word. It is the weakest of the four and only
-ever applies to the one-slug, one-variable case. A slug that stays ambiguous keeps its
+carry evidence of describing the same quantity — a shared token, or an
+initialism (`sst` for `sea-surface-temperature`). That evidence is a
+filter, not a proof: a single shared token is enough, so on names alone
+the last-resort rule could still be wrong where two names share a generic
+word. What stops it is the reservation described above — every NetCDF
+name a hydrated row of the dataset already owns is off the table, which
+removes every such mis-pairing the shipped catalog can produce. A slug that stays ambiguous keeps its
 `unknown` placeholder, because a wrong `nc_variable` silently
 mis-extracts at `aggregate=` time, which is worse than an obvious gap.
 A NetCDF name an already-hydrated row of the same dataset claims is not

--- a/docs/reference/ecmwf/catalog.md
+++ b/docs/reference/ecmwf/catalog.md
@@ -714,13 +714,16 @@ Matching is deliberately conservative. The confident rules come first: an
 exact short-name match, then a token-subset match against the variable's
 `long_name`. Only a single leftover slug facing a single unused variable
 reaches the last-resort rule, and it pairs them only when the two names
-carry evidence of describing the same quantity — a shared token, or an
-initialism (`sst` for `sea-surface-temperature`).
+carry evidence of describing the same quantity — shared tokens covering
+at least half the slug, or an initialism (`sst` for
+`sea-surface-temperature`).
 
 Two limits of that last rule are worth knowing before you trust its
-output. Its evidence is a filter, not a proof: one shared word satisfies
-it, so it can still be wrong where two names share a generic term such as
-`sea` or `surface`. And it leans heavily on the retrieved variable's
+output. Its evidence is a filter, not a proof. The coverage bar rejects
+the single-generic-word coincidence — `land-sea-mask` shares only `sea`
+with mean sea level pressure — but it cannot police the initialism arm,
+which has no shared tokens to measure and will still read `msl` as
+m(ask) s(ea) l(and). And it leans heavily on the retrieved variable's
 `long_name` — across the curated catalog, 89% of the rows that need more
 than an exact name match would fail the check if the retrieve carried no
 `long_name` at all. A NetCDF name that an already-hydrated row of the same

--- a/docs/reference/ecmwf/catalog.md
+++ b/docs/reference/ecmwf/catalog.md
@@ -710,6 +710,17 @@ from a live tiny retrieve. Licence-gated and best-effort — a dataset
 whose licence you have not accepted is left untouched rather than
 guessed at.
 
+Matching is deliberately conservative: a slug is hydrated only when it
+confidently identifies one retrieved variable — by exact short name, by a
+token-subset match against the variable's `long_name`, or, for the lone
+leftover slug, when the two names carry evidence of describing the same
+quantity (a shared token, or an initialism such as `sst` for
+`sea-surface-temperature`). A slug that stays ambiguous keeps its
+`unknown` placeholder, because a wrong `nc_variable` silently
+mis-extracts at `aggregate=` time, which is worse than an obvious gap.
+Re-running the command after the catalog gains more context is safe and
+idempotent.
+
 ## Adding a new dataset
 
 The typical sequence to extend the catalog with a brand-new dataset

--- a/docs/reference/ecmwf/catalog.md
+++ b/docs/reference/ecmwf/catalog.md
@@ -718,8 +718,9 @@ quantity (a shared token, or an initialism such as `sst` for
 `sea-surface-temperature`). A slug that stays ambiguous keeps its
 `unknown` placeholder, because a wrong `nc_variable` silently
 mis-extracts at `aggregate=` time, which is worse than an obvious gap.
-Re-running the command after the catalog gains more context is safe and
-idempotent.
+A NetCDF name an already-hydrated row of the same dataset claims is not
+offered to a second slug by the leftover rule, so re-running the command
+cannot make two rows fight over one variable.
 
 ## Adding a new dataset
 

--- a/docs/reference/ecmwf/catalog.md
+++ b/docs/reference/ecmwf/catalog.md
@@ -710,12 +710,16 @@ from a live tiny retrieve. Licence-gated and best-effort — a dataset
 whose licence you have not accepted is left untouched rather than
 guessed at.
 
-Matching is deliberately conservative: a slug is hydrated only when it
-confidently identifies one retrieved variable — by exact short name, by a
-token-subset match against the variable's `long_name`, or, for the lone
-leftover slug, when the two names carry evidence of describing the same
-quantity (a shared token, or an initialism such as `sst` for
-`sea-surface-temperature`). A slug that stays ambiguous keeps its
+Matching is deliberately conservative. The confident rules come first: an
+exact short-name match, then a token-subset match against the variable's
+`long_name`. Only a single leftover slug facing a single unused variable
+reaches the last-resort rule, and it pairs them only when the two names
+carry evidence of describing the same quantity — a shared token, an
+initialism (`sst` for `sea-surface-temperature`), or a product prefix
+(`xco2` for `co2`). That evidence is a filter, not a proof: a single
+shared token is enough, so the last-resort rule can still be wrong where
+two names share a generic word. It is the weakest of the four and only
+ever applies to the one-slug, one-variable case. A slug that stays ambiguous keeps its
 `unknown` placeholder, because a wrong `nc_variable` silently
 mis-extracts at `aggregate=` time, which is worse than an obvious gap.
 A NetCDF name an already-hydrated row of the same dataset claims is not

--- a/docs/reference/ecmwf/catalog.md
+++ b/docs/reference/ecmwf/catalog.md
@@ -715,17 +715,23 @@ exact short-name match, then a token-subset match against the variable's
 `long_name`. Only a single leftover slug facing a single unused variable
 reaches the last-resort rule, and it pairs them only when the two names
 carry evidence of describing the same quantity — a shared token, or an
-initialism (`sst` for `sea-surface-temperature`). That evidence is a
-filter, not a proof: a single shared token is enough, so on names alone
-the last-resort rule could still be wrong where two names share a generic
-word. What stops it is the reservation described above — every NetCDF
-name a hydrated row of the dataset already owns is off the table, which
-removes every such mis-pairing the shipped catalog can produce. A slug that stays ambiguous keeps its
-`unknown` placeholder, because a wrong `nc_variable` silently
-mis-extracts at `aggregate=` time, which is worse than an obvious gap.
-A NetCDF name an already-hydrated row of the same dataset claims is not
-offered to a second slug by the leftover rule, so re-running the command
-cannot make two rows fight over one variable.
+initialism (`sst` for `sea-surface-temperature`).
+
+Two limits of that last rule are worth knowing before you trust its
+output. Its evidence is a filter, not a proof: one shared word satisfies
+it, so it can still be wrong where two names share a generic term such as
+`sea` or `surface`. And it leans heavily on the retrieved variable's
+`long_name` — across the curated catalog, 89% of the rows that need more
+than an exact name match would fail the check if the retrieve carried no
+`long_name` at all. A NetCDF name that an already-hydrated row of the same
+dataset claims is withheld from it, so a re-run cannot make two rows fight
+over one variable, but most datasets reaching this rule have no hydrated
+row yet and so withhold nothing.
+
+A slug that stays ambiguous keeps its `unknown` placeholder, because a
+wrong `nc_variable` silently mis-extracts at `aggregate=` time, which is
+worse than an obvious gap. Those rows are counted separately in the
+command's summary, so they can be curated by hand.
 
 ## Adding a new dataset
 

--- a/libs/core/src/earthlens/cli/datasets.py
+++ b/libs/core/src/earthlens/cli/datasets.py
@@ -857,7 +857,10 @@ def _curate_fill_empty(
     summary = hydrate(limit=limit, timeout=timeout or None)
 
     timed_out = summary.get("timed_out") or 0
+    unmatched = summary.get("unmatched") or 0
     tail = f", {timed_out} timed out" if timed_out else ""
+    if unmatched:
+        tail += f", {unmatched} retrieved with no confident match"
     out_console().print(
         f"[green]hydrated {summary['hydrated']}[/green] / "
         f"{summary['candidates']} placeholder rows "

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -95,6 +95,12 @@ _UNKNOWN_UNITS = re.compile(r"(?m)^ {8}units:[ \t]*unknown[ \t]*$")
 _NC_VARIABLE_LINE = re.compile(r"(?m)^( {8}nc_variable:)[^\n]*$")
 _UNITS_LINE = re.compile(r"(?m)^( {8}units:)[^\n]*$")
 
+#: Fraction of a slug's meaningful tokens the shared ones must cover before
+#: rule 4 treats the overlap as evidence. Half rejects the single-generic-word
+#: coincidence (`land-sea-mask` against `msl`, sharing only `sea`) while keeping
+#: the real one-of-two matches (`glacier-area` against `area`).
+_MIN_TOKEN_COVERAGE = 0.5
+
 #: Most retrieved variable names to name in a declined-match echo before
 #: summarising the rest, so one wide product cannot flood the sweep's output.
 _ECHO_MAX_NAMES = 8
@@ -367,10 +373,29 @@ def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
     """Return True when `slug` and `name` share evidence of being the same thing.
 
     Rule 4's guard: being the only two left over is arity, not evidence. A pair
-    qualifies on any one of three signals, cheapest first — a shared token with
-    the short name, a shared token with its `long_name`, or `name` being an
-    initialism of the slug. Slugs reduced to nothing but stopwords never
-    qualify.
+    qualifies on either of two signals — the tokens it shares with the short
+    name and `long_name` covering at least :data:`_MIN_TOKEN_COVERAGE` of the
+    slug, or `name` being an initialism of the slug. Slugs reduced to nothing
+    but stopwords never qualify.
+
+    Coverage rather than mere overlap is what keeps a single generic word from
+    passing as evidence: `land-sea-mask` shares only `sea` with mean sea level
+    pressure, one token of three, and `sub-surface-runoff` only `surface` with
+    surface net solar radiation. Measured over the curated catalog, requiring
+    half the slug's tokens cuts the pairings rule 4 would get wrong from 111 to
+    38, about two thirds.
+
+    It costs the occasional real match whose names genuinely have little in
+    common — a terrestrial water storage anomaly served as a liquid water
+    equivalent thickness shares only `water` — and those rows keep their
+    placeholder and are counted as unmatched, which is the cheaper failure.
+
+    Coverage does not govern the initialism arm, which has no shared tokens to
+    measure; that arm admits 34 of the 38 wrong pairings that remain, reading
+    `msl` as m(ask) s(ea) l(and). Requiring it to consume tokens in slug order
+    would remove some, but it also rejects `2m-temperature` -> `t2m`, so the
+    residue is accepted and rule 4 stays a last resort behind the confident
+    rules.
 
     The initialism arm needs at least two tokens. Compressing a single word
     leaves nothing but a prefix of it, which is far too weak to pair on: it
@@ -398,12 +423,32 @@ def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
             True
 
             ```
-        - So is a token shared with the variable's `long_name`:
+        - So are tokens shared with the variable's `long_name`, once they
+          cover half the slug:
 
             ```python
             >>> from earthlens.ecmwf._hydrate import _pair_is_evidenced
-            >>> meta = {"long_name": "Liquid Water Equivalent Thickness"}
-            >>> _pair_is_evidenced("terrestrial-water-storage", "lwe_thickness", meta)
+            >>> meta = {"long_name": "Total precipitation depth"}
+            >>> _pair_is_evidenced("total-precipitation", "zzz", meta)
+            True
+
+            ```
+        - One generic word in common is coincidence, not evidence — `sea` is
+          one of the slug's three tokens, short of the coverage bar:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _pair_is_evidenced
+            >>> meta = {"long_name": "Mean sea level pressure"}
+            >>> _pair_is_evidenced("land-sea-mask", "zzz", meta)
+            False
+
+            ```
+        - The initialism arm is separate, and still reads `msl` as
+          m(ask) s(ea) l(and) — coverage does not govern it:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _pair_is_evidenced
+            >>> _pair_is_evidenced("land-sea-mask", "msl", {})
             True
 
             ```
@@ -419,9 +464,9 @@ def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
     tokens = _tokens(slug) - _STOPWORDS
     if not tokens:
         return False
-    if tokens & (_tokens(name) - _STOPWORDS):
-        return True
-    if tokens & (_tokens(str(meta.get("long_name") or "")) - _STOPWORDS):
+    shared = tokens & (_tokens(name) - _STOPWORDS)
+    shared |= tokens & (_tokens(str(meta.get("long_name") or "")) - _STOPWORDS)
+    if len(shared) >= len(tokens) * _MIN_TOKEN_COVERAGE:
         return True
     return len(tokens) >= 2 and _is_initialism(name, tokens)
 

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -329,14 +329,71 @@ def _is_initialism(name: str, tokens: set[str]) -> bool:
     return bool(tokens) and _consume_initialism(name.lower(), sorted(tokens))
 
 
+#: Longest product prefix a NetCDF short name may add to a slug's own spelling
+#: and still be recognised as the same quantity (`xco2` for `co2`, `tcno2` for
+#: `no2`). Two characters covers the `x` / `tc` / `t` families the CDS serves.
+_PRODUCT_PREFIX_MAX = 2
+
+
+def _compact(text: str) -> str:
+    """Return `text` reduced to its lowercase alphanumerics, separators dropped."""
+    return "".join(char for char in text.lower() if char.isalnum())
+
+
+def _is_prefixed_form(name: str, slug: str) -> bool:
+    """Return True when `name` is the slug's own spelling behind a short product prefix.
+
+    The C3S greenhouse-gas CDRs serve a column-average mole fraction as the
+    chemical formula behind an `x` (`co2` -> `xco2`), and the whole compacted
+    slug has to survive for the pair to qualify — matching a single token as a
+    substring would pair `specific-cloud-ice-water-content` with `iicethic`.
+
+    Args:
+        name: The NetCDF short name.
+        slug: The catalog variable slug.
+
+    Returns:
+        True when one compacted spelling is the other behind at most
+        :data:`_PRODUCT_PREFIX_MAX` extra leading characters.
+
+    Examples:
+        - A product prefix in front of the slug's own spelling:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _is_prefixed_form
+            >>> _is_prefixed_form("xco2", "co2")
+            True
+            >>> _is_prefixed_form("xch4", "ch4")
+            True
+
+            ```
+        - A token buried inside an unrelated name does not qualify:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _is_prefixed_form
+            >>> _is_prefixed_form("iicethic", "specific-cloud-ice-water-content")
+            False
+
+            ```
+    """
+    short, full = _compact(slug), _compact(name)
+    if len(short) < 3 or len(full) < 3:
+        return False
+    if full.endswith(short):
+        return len(full) - len(short) <= _PRODUCT_PREFIX_MAX
+    if short.endswith(full):
+        return len(short) - len(full) <= _PRODUCT_PREFIX_MAX
+    return False
+
+
 def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
     """Return True when `slug` and `name` share evidence of being the same thing.
 
     Rule 4's guard: being the only two left over is arity, not evidence. A pair
-    qualifies on any one of three signals, cheapest first — a shared token with
-    the short name, a shared token with its `long_name`, or `name` being an
-    initialism of the slug. Slugs reduced to nothing but stopwords never
-    qualify.
+    qualifies on any one of four signals, cheapest first — a shared token with
+    the short name, a shared token with its `long_name`, `name` being an
+    initialism of the slug, or `name` being the slug's own spelling behind a
+    short product prefix. Slugs reduced to nothing but stopwords never qualify.
 
     Args:
         slug: The unmatched catalog variable slug.
@@ -380,7 +437,7 @@ def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
         return True
     if tokens & (_tokens(str(meta.get("long_name") or "")) - _STOPWORDS):
         return True
-    return _is_initialism(name, tokens)
+    return _is_initialism(name, tokens) or _is_prefixed_form(name, slug)
 
 
 def _match_variables(

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -441,7 +441,9 @@ def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
 
 
 def _match_variables(
-    placeholders: list[str], nc_meta: dict[str, dict[str, Any]]
+    placeholders: list[str],
+    nc_meta: dict[str, dict[str, Any]],
+    reserved: frozenset[str] = frozenset(),
 ) -> dict[str, tuple[str, str]]:
     """Confidently map each placeholder slug to a retrieved `(nc_name, units)`.
 
@@ -456,9 +458,10 @@ def _match_variables(
     3. Token-subset — the slug's tokens are a subset of a variable's
        `long_name` tokens.
     4. The **unambiguous** leftover case only: exactly one unmatched slug and
-       exactly one unused data variable (the single-variable retrieve), and
-       only when the two carry evidence of being the same quantity
-       (:func:`_pair_is_evidenced`) — arity alone is not a match.
+       exactly one unused data variable (the single-variable retrieve), the
+       variable not already claimed by a hydrated row, and only when the two
+       carry evidence of being the same quantity (`_pair_is_evidenced`) —
+       arity alone is not a match.
 
     Any slug that stays unmatched keeps its placeholder — there is no arbitrary
     order-based pairing among multiple candidates.
@@ -466,6 +469,11 @@ def _match_variables(
     Args:
         placeholders: The still-`unknown` variable slugs, in catalog order.
         nc_meta: The retrieved `{nc_name: {long_name, units}}` mapping.
+        reserved: NetCDF names already written into the stanza's hydrated rows.
+            Rule 4 will not hand one of these to a second slug; the confident
+            rules still may, because one short name legitimately serves several
+            rows of the same dataset (CARRA repeats a name across level
+            families).
 
     Returns:
         Mapping of slug to the `(nc_variable, units)` to write — only for the
@@ -500,6 +508,7 @@ def _match_variables(
         len(unmatched) == 1
         and len(unused) == 1
         and unmatched[0] != "all"
+        and unused[0] not in reserved
         and _pair_is_evidenced(unmatched[0], unused[0], candidates[unused[0]])
     ):
         chosen[unmatched[0]] = unused[0]
@@ -517,6 +526,32 @@ def _placeholder_slugs(block: str) -> list[str]:
         for match in _VARIABLE_BLOCK.finditer(block)
         if _UNKNOWN_UNITS.search(match.group("body"))
     ]
+
+
+def _claimed_nc_names(block: str) -> frozenset[str]:
+    """Return the `nc_variable` values already bound by the stanza's hydrated rows.
+
+    A placeholder row carries a seeded `nc_variable` too, so only sub-blocks
+    that have lost the `units: unknown` sentinel count as having claimed a name.
+
+    Args:
+        block: One dataset stanza's body text.
+
+    Returns:
+        The NetCDF short names a hydrated row of this stanza already uses.
+    """
+    claimed = set()
+    for match in _VARIABLE_BLOCK.finditer(block):
+        body = match.group("body")
+        if _UNKNOWN_UNITS.search(body):
+            continue
+        line = _NC_VARIABLE_LINE.search(body)
+        if line is None:
+            continue
+        value = body[line.start() : line.end()].split(":", 1)[1].strip()
+        if value:
+            claimed.add(value.strip("\"'"))
+    return frozenset(claimed)
 
 
 def _fill_variable(block: str, slug: str, nc_name: str, units: str) -> str:
@@ -560,7 +595,7 @@ def _rewrite_stanza(
     placeholders = _placeholder_slugs(block)
     if not placeholders:
         return text
-    assignments = _match_variables(placeholders, nc_meta)
+    assignments = _match_variables(placeholders, nc_meta, _claimed_nc_names(block))
     if not assignments:
         return text
     new_block = block

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -95,6 +95,10 @@ _UNKNOWN_UNITS = re.compile(r"(?m)^ {8}units:[ \t]*unknown[ \t]*$")
 _NC_VARIABLE_LINE = re.compile(r"(?m)^( {8}nc_variable:)[^\n]*$")
 _UNITS_LINE = re.compile(r"(?m)^( {8}units:)[^\n]*$")
 
+#: Most retrieved variable names to name in a declined-match echo before
+#: summarising the rest, so one wide product cannot flood the sweep's output.
+_ECHO_MAX_NAMES = 8
+
 #: Function words that carry no identifying signal. Dropped before the rule 4
 #: overlap tests so `number-of-wet-days` cannot pair with a variable on `of`.
 _STOPWORDS = frozenset(
@@ -473,7 +477,13 @@ def _match_variables(
             Rule 4 will not hand one of these to a second slug; the confident
             rules still may, because one short name legitimately serves several
             rows of the same dataset (CARRA repeats a name across level
-            families).
+            families). The asymmetry is deliberate: reaching a repeated name by
+            exact match or `long_name` is evidence it belongs to both rows,
+            while reaching it by the leftover rule is a guess, and a guess
+            landing on a name another row already holds is the corruption this
+            rule was tightened to stop. The cost is that a legitimately
+            repeated name reachable ONLY by rule 4 stays a placeholder, to be
+            curated by hand.
 
     Returns:
         Mapping of slug to the `(nc_variable, units)` to write — only for the
@@ -738,7 +748,13 @@ def _hydrate_one(
     new_text = _rewrite_stanza(file_text[path], dataset_id, nc_meta)
     if new_text == file_text[path]:
         offered = sorted(_data_variables(nc_meta))
-        typer.echo(f"{prefix}: retrieved, no confident match ({', '.join(offered)})")
+        if not offered:
+            detail = "no data variables, only coordinates and auxiliaries"
+        else:
+            shown = ", ".join(offered[:_ECHO_MAX_NAMES])
+            extra = len(offered) - _ECHO_MAX_NAMES
+            detail = f"{shown}, +{extra} more" if extra > 0 else shown
+        typer.echo(f"{prefix}: retrieved, no confident match ({detail})")
         return "unmatched"
     file_text[path] = new_text
     path.write_text(new_text, encoding="utf-8")

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -279,7 +279,9 @@ def _consume_initialism(
 
     `rest` is always a suffix of the original name, so `(len(rest), mask)`
     identifies a search state exactly; memoising on it bounds the work at
-    `O(2^len(tokens) * len(name))` instead of the exponential-with-no-ceiling
+    `O(2^len(tokens) * len(name) * len(tokens) * max_token_len)` — one state per
+    `(suffix, mask)` pair, each scanning the still-unused tokens' prefixes —
+    instead of the exponential-with-no-ceiling
     node count a plain backtracker walks when the tokens nest as prefixes of
     one another.
 
@@ -501,10 +503,14 @@ def _match_variables(
     # dropping the abbreviations rule 4 gets right; the initialism arm keeps
     # them (`sea-surface-temperature` -> `sst`). It resolves the common shapes,
     # not abbreviation in general — a selective contraction like `msl` or `u10`
-    # still fails it, and such a slug simply keeps its placeholder. What stops
-    # a weak shared token from mis-binding is `reserved`: every name a hydrated
-    # sibling row owns is off the table, which is where the real protection
-    # lives. Rule 4 stays a last resort behind the confident rules above.
+    # still fails it, and such a slug simply keeps its placeholder.
+    #
+    # `reserved` narrows the damage where a hydrated sibling row already owns
+    # the name, but it is not a general guard: of the stanzas this rule can
+    # reach in the shipped catalog, most have no hydrated sibling at all and so
+    # reserve nothing. The evidence check is what stands between a placeholder
+    # and a wrong name there, and one shared generic word satisfies it. Rule 4
+    # is a last resort behind the confident rules for exactly that reason.
     if (
         len(unmatched) == 1
         and len(unused) == 1

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -420,6 +420,23 @@ def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
     return len(tokens) >= 2 and _is_initialism(name, tokens)
 
 
+def _data_variables(
+    nc_meta: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Return the retrieved variables a catalog row could name, aux dropped.
+
+    The single definition of "what the matcher would consider", so the echo that
+    reports a declined pairing lists exactly the variables it weighed.
+
+    Args:
+        nc_meta: The retrieved `{nc_name: {long_name, units}}` mapping.
+
+    Returns:
+        The subset that is not a coordinate, bound, or auxiliary variable.
+    """
+    return {name: meta for name, meta in nc_meta.items() if not _is_auxiliary(name)}
+
+
 def _match_variables(
     placeholders: list[str],
     nc_meta: dict[str, dict[str, Any]],
@@ -460,9 +477,7 @@ def _match_variables(
         Mapping of slug to the `(nc_variable, units)` to write — only for the
         slugs that matched confidently.
     """
-    candidates = {
-        name: meta for name, meta in nc_meta.items() if not _is_auxiliary(name)
-    }
+    candidates = _data_variables(nc_meta)
     chosen: dict[str, str] = {}
     used: set[str] = set()
 
@@ -583,6 +598,43 @@ def _fill_variable(block: str, slug: str, nc_name: str, units: str) -> str:
     return block[: match.start()] + sub + block[match.end() :]
 
 
+def _stanza_match(text: str, dataset_id: str) -> re.Match[str] | None:
+    """Return the match spanning one dataset stanza, or None when it is absent.
+
+    Args:
+        text: The full per-family catalog shard text.
+        dataset_id: The dataset id whose stanza to isolate.
+
+    Returns:
+        The `re.Match` spanning the stanza, or `None` if `dataset_id` is absent.
+        Group 1 is the stanza body; the span is where a rewrite splices back.
+    """
+    pattern = re.compile(
+        rf"(?ms)^  {re.escape(dataset_id)}:\n(.*?)(?=^  [A-Za-z0-9/_.-]+:|\Z)"
+    )
+    return pattern.search(text)
+
+
+def _stanza_outcome(text: str, dataset_id: str) -> str | None:
+    """Return why a stanza cannot be hydrated, or None when it has work to do.
+
+    Lets the caller tell a shard that never held the dataset, or a stanza with
+    nothing left to fill, apart from one the matcher looked at and declined.
+
+    Args:
+        text: The full per-family catalog shard text.
+        dataset_id: The dataset id to inspect.
+
+    Returns:
+        `"skipped"` when the stanza is missing or holds no placeholder, else
+        `None`.
+    """
+    found = _stanza_match(text, dataset_id)
+    if found is None or not _placeholder_slugs(found.group(1)):
+        return "skipped"
+    return None
+
+
 def _rewrite_stanza(
     text: str, dataset_id: str, nc_meta: dict[str, dict[str, Any]]
 ) -> str:
@@ -598,11 +650,8 @@ def _rewrite_stanza(
         input is returned unchanged when the stanza, its placeholders, or a
         usable match are absent.
     """
-    pattern = re.compile(
-        rf"(?ms)^  {re.escape(dataset_id)}:\n(.*?)(?=^  [A-Za-z0-9/_.-]+:|\Z)"
-    )
-    match = pattern.search(text)
-    if not match:
+    match = _stanza_match(text, dataset_id)
+    if match is None:
         return text
     block = match.group(1)
     placeholders = _placeholder_slugs(block)
@@ -655,9 +704,11 @@ def _hydrate_one(
 
     Returns:
         One of `"hydrated"`, `"unmatched"`, `"timed_out"`, or `"skipped"`.
-        `"unmatched"` is the retrieve that worked and still hydrated nothing —
-        the operator can curate that row by hand, unlike a `"skipped"` licence
-        or network failure.
+        `"unmatched"` is reserved for the retrieve that worked against a stanza
+        with real placeholders and still hydrated nothing — the operator can
+        curate that row by hand. A missing stanza, or one whose placeholders
+        have all been filled already, is a `"skipped"` like a licence or network
+        failure: there was nothing for the matcher to decline.
     """
     try:
         nc_meta: dict[str, dict[str, Any]] | None = _retrieve_with_timeout(
@@ -674,9 +725,13 @@ def _hydrate_one(
         return "skipped"
     if path not in file_text:
         file_text[path] = path.read_text(encoding="utf-8")
+    blocked = _stanza_outcome(file_text[path], dataset_id)
+    if blocked is not None:
+        typer.echo(f"{prefix}: {blocked}")
+        return blocked
     new_text = _rewrite_stanza(file_text[path], dataset_id, nc_meta)
     if new_text == file_text[path]:
-        offered = sorted(name for name in nc_meta if not _is_auxiliary(name))
+        offered = sorted(_data_variables(nc_meta))
         typer.echo(f"{prefix}: retrieved, no confident match ({', '.join(offered)})")
         return "unmatched"
     file_text[path] = new_text

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -373,6 +373,11 @@ def _is_initialism(name: str, tokens: set[str]) -> bool:
     Covers the abbreviations a plain token-overlap test rejects: `sst` for
     `sea-surface-temperature`, `t2m` for `2m-temperature`.
 
+    On its own this says nothing about how many tokens are worth compressing.
+    Given one token it reduces to "is `name` a prefix of that word", which
+    reads `co` as an abbreviation of `co2`; the two-token minimum that makes
+    the arm meaningful is applied by :func:`_pair_is_evidenced`, not here.
+
     Args:
         name: The NetCDF short name.
         tokens: The slug's meaningful tokens.
@@ -399,6 +404,15 @@ def _is_initialism(name: str, tokens: set[str]) -> bool:
             False
             >>> _is_initialism("elevation", {"number", "wet", "days"})
             False
+
+            ```
+        - With a single token it is only a prefix test, which is why the
+          caller requires two:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _is_initialism
+            >>> _is_initialism("co", {"co2"})
+            True
 
             ```
     """

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -117,11 +117,6 @@ _STOPWORDS = frozenset(
     }
 )
 
-#: Longest product prefix a NetCDF short name may add to a slug's own spelling
-#: and still be recognised as the same quantity (`xco2` for `co2`, `tcno2` for
-#: `no2`). Two characters covers the `x` / `tc` / `t` families the CDS serves.
-_PRODUCT_PREFIX_MAX = 2
-
 
 def _retrieve_netcdf_vars(dataset_id: str) -> dict[str, dict[str, Any]]:
     """Retrieve a tiny NetCDF for `dataset_id` and read its variable metadata.
@@ -362,65 +357,15 @@ def _is_initialism(name: str, tokens: set[str]) -> bool:
     return _consume_initialism(name.lower(), ordered, (1 << len(ordered)) - 1, {})
 
 
-def _compact(text: str) -> str:
-    """Return `text` reduced to its lowercase alphanumerics, separators dropped."""
-    return "".join(char for char in text.lower() if char.isalnum())
-
-
-def _is_prefixed_form(name: str, slug: str) -> bool:
-    """Return True when `name` is the slug's own spelling behind a short product prefix.
-
-    The C3S greenhouse-gas CDRs serve a column-average mole fraction as the
-    chemical formula behind an `x` (`co2` -> `xco2`), and the whole compacted
-    slug has to survive for the pair to qualify — matching a single token as a
-    substring would pair `specific-cloud-ice-water-content` with `iicethic`.
-
-    Args:
-        name: The NetCDF short name.
-        slug: The catalog variable slug.
-
-    Returns:
-        True when one compacted spelling is the other behind at most
-        :data:`_PRODUCT_PREFIX_MAX` extra leading characters.
-
-    Examples:
-        - A product prefix in front of the slug's own spelling:
-
-            ```python
-            >>> from earthlens.ecmwf._hydrate import _is_prefixed_form
-            >>> _is_prefixed_form("xco2", "co2")
-            True
-            >>> _is_prefixed_form("xch4", "ch4")
-            True
-
-            ```
-        - A token buried inside an unrelated name does not qualify:
-
-            ```python
-            >>> from earthlens.ecmwf._hydrate import _is_prefixed_form
-            >>> _is_prefixed_form("iicethic", "specific-cloud-ice-water-content")
-            False
-
-            ```
-    """
-    short, full = _compact(slug), _compact(name)
-    if len(short) < 3 or len(full) < 3:
-        return False
-    if full.endswith(short):
-        return len(full) - len(short) <= _PRODUCT_PREFIX_MAX
-    if short.endswith(full):
-        return len(short) - len(full) <= _PRODUCT_PREFIX_MAX
-    return False
-
-
 def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
     """Return True when `slug` and `name` share evidence of being the same thing.
 
     Rule 4's guard: being the only two left over is arity, not evidence. A pair
-    qualifies on any one of four signals, cheapest first — a shared token with
-    the short name, a shared token with its `long_name`, `name` being an
-    initialism of the slug, or `name` being the slug's own spelling behind a
-    short product prefix. Slugs reduced to nothing but stopwords never qualify.
+    qualifies on any one of three signals, cheapest first — a shared token with
+    the short name, a shared token with its `long_name`, or `name` being an
+    initialism of the slug. Slugs reduced to nothing but stopwords never
+    qualify. The evidence is a filter, not a proof: rule 4 leans on `reserved`
+    to keep a slug off a name a hydrated sibling row already owns.
 
     Args:
         slug: The unmatched catalog variable slug.
@@ -464,7 +409,7 @@ def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
         return True
     if tokens & (_tokens(str(meta.get("long_name") or "")) - _STOPWORDS):
         return True
-    return _is_initialism(name, tokens) or _is_prefixed_form(name, slug)
+    return _is_initialism(name, tokens)
 
 
 def _match_variables(
@@ -529,12 +474,13 @@ def _match_variables(
     #
     # Being the last two standing is arity, not evidence, so the pair must also
     # look like the same quantity. A plain token-overlap test was rejected for
-    # dropping the abbreviations rule 4 gets right; the initialism and product
-    # prefix arms keep the shapes it lost (`sea-surface-temperature` -> `sst`,
-    # `co2` -> `xco2`). Those arms resolve the common shapes, not abbreviation
-    # in general — a selective contraction like `msl` or `u10` still fails
-    # them, and such a slug simply keeps its placeholder. Rule 4 stays a last
-    # resort: the confident rules above carry most of the catalog.
+    # dropping the abbreviations rule 4 gets right; the initialism arm keeps
+    # them (`sea-surface-temperature` -> `sst`). It resolves the common shapes,
+    # not abbreviation in general — a selective contraction like `msl` or `u10`
+    # still fails it, and such a slug simply keeps its placeholder. What stops
+    # a weak shared token from mis-binding is `reserved`: every name a hydrated
+    # sibling row owns is off the table, which is where the real protection
+    # lives. Rule 4 stays a last resort behind the confident rules above.
     if (
         len(unmatched) == 1
         and len(unused) == 1

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -265,30 +265,56 @@ _STOPWORDS = frozenset(
 )
 
 
-def _consume_initialism(rest: str, remaining: list[str]) -> bool:
-    """Return True when `rest` splits into a leading piece of every `remaining` token.
+def _consume_initialism(
+    rest: str,
+    tokens: tuple[str, ...],
+    mask: int,
+    memo: dict[tuple[int, int], bool],
+) -> bool:
+    """Return True when `rest` splits into a leading piece of every token left in `mask`.
 
-    Backtracking search over token order, because the compressed form need not
-    follow the slug's word order (`t2m` is `temperature` + `2m`). Succeeds only
-    when `rest` is fully consumed AND every token contributed, so a near-miss
-    prefix (`pressure` against `precipitation`) fails.
+    The search is order-free, because the compressed form need not follow the
+    slug's word order (`t2m` is `temperature` + `2m`), and succeeds only when
+    `rest` is fully consumed AND every token contributed, so a near-miss prefix
+    (`pressure` against `precipitation`) fails.
+
+    `rest` is always a suffix of the original name, so `(len(rest), mask)`
+    identifies a search state exactly; memoising on it bounds the work at
+    `O(2^len(tokens) * len(name))` instead of the exponential-with-no-ceiling
+    node count a plain backtracker walks when the tokens nest as prefixes of
+    one another.
 
     Args:
         rest: The still-unconsumed tail of the NetCDF short name.
-        remaining: The slug tokens not yet accounted for.
+        tokens: Every slug token, indexed by bit position in `mask`.
+        mask: Bits set for the tokens not yet accounted for.
+        memo: Shared `(len(rest), mask) -> bool` cache for one search.
 
     Returns:
         True when a full assignment exists.
     """
+    key = (len(rest), mask)
+    cached = memo.get(key)
+    if cached is not None:
+        return cached
     if not rest:
-        return not remaining
-    for index, token in enumerate(remaining):
-        for size in range(1, len(token) + 1):
-            if rest.startswith(token[:size]) and _consume_initialism(
-                rest[size:], remaining[:index] + remaining[index + 1 :]
-            ):
-                return True
-    return False
+        result = mask == 0
+    else:
+        result = False
+        for index, token in enumerate(tokens):
+            bit = 1 << index
+            if not mask & bit:
+                continue
+            for size in range(1, len(token) + 1):
+                if rest.startswith(token[:size]) and _consume_initialism(
+                    rest[size:], tokens, mask & ~bit, memo
+                ):
+                    result = True
+                    break
+            if result:
+                break
+    memo[key] = result
+    return result
 
 
 def _is_initialism(name: str, tokens: set[str]) -> bool:
@@ -326,7 +352,10 @@ def _is_initialism(name: str, tokens: set[str]) -> bool:
 
             ```
     """
-    return bool(tokens) and _consume_initialism(name.lower(), sorted(tokens))
+    if not tokens:
+        return False
+    ordered = tuple(sorted(tokens))
+    return _consume_initialism(name.lower(), ordered, (1 << len(ordered)) - 1, {})
 
 
 #: Longest product prefix a NetCDF short name may add to a slug's own spelling

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -242,6 +242,98 @@ def _assign_unique_subset(
                 progress = True
 
 
+#: Function words that carry no identifying signal. Dropped before the rule 4
+#: overlap tests so `number-of-wet-days` cannot pair with a variable on `of`.
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "at",
+        "by",
+        "for",
+        "from",
+        "in",
+        "of",
+        "on",
+        "or",
+        "per",
+        "the",
+        "to",
+        "with",
+    }
+)
+
+
+def _consume_initialism(rest: str, remaining: list[str]) -> bool:
+    """Return True when `rest` splits into a leading piece of every `remaining` token.
+
+    Backtracking search over token order, because the compressed form need not
+    follow the slug's word order (`t2m` is `temperature` + `2m`). Succeeds only
+    when `rest` is fully consumed AND every token contributed, so a near-miss
+    prefix (`pressure` against `precipitation`) fails.
+
+    Args:
+        rest: The still-unconsumed tail of the NetCDF short name.
+        remaining: The slug tokens not yet accounted for.
+
+    Returns:
+        True when a full assignment exists.
+    """
+    if not rest:
+        return not remaining
+    for index, token in enumerate(remaining):
+        for size in range(1, len(token) + 1):
+            if rest.startswith(token[:size]) and _consume_initialism(
+                rest[size:], remaining[:index] + remaining[index + 1 :]
+            ):
+                return True
+    return False
+
+
+def _is_initialism(name: str, tokens: set[str]) -> bool:
+    """Return True when `name` is `tokens` compressed to their leading letters.
+
+    Covers the abbreviations a plain token-overlap test rejects: `sst` for
+    `sea-surface-temperature`, `t2m` for `2m-temperature`.
+
+    Args:
+        name: The NetCDF short name.
+        tokens: The slug's meaningful tokens.
+
+    Returns:
+        True when `name` is an initialism of `tokens`.
+    """
+    return bool(tokens) and _consume_initialism(name.lower(), sorted(tokens))
+
+
+def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
+    """Return True when `slug` and `name` share evidence of being the same thing.
+
+    Rule 4's guard: being the only two left over is arity, not evidence. A pair
+    qualifies on any one of three signals, cheapest first — a shared token with
+    the short name, a shared token with its `long_name`, or `name` being an
+    initialism of the slug. Slugs reduced to nothing but stopwords never
+    qualify.
+
+    Args:
+        slug: The unmatched catalog variable slug.
+        name: The unused NetCDF short name.
+        meta: That variable's `{long_name, units}` metadata.
+
+    Returns:
+        True when the pairing is supported; False to keep the placeholder.
+    """
+    tokens = _tokens(slug) - _STOPWORDS
+    if not tokens:
+        return False
+    if tokens & (_tokens(name) - _STOPWORDS):
+        return True
+    if tokens & (_tokens(str(meta.get("long_name") or "")) - _STOPWORDS):
+        return True
+    return _is_initialism(name, tokens)
+
+
 def _match_variables(
     placeholders: list[str], nc_meta: dict[str, dict[str, Any]]
 ) -> dict[str, tuple[str, str]]:
@@ -258,7 +350,9 @@ def _match_variables(
     3. Token-subset — the slug's tokens are a subset of a variable's
        `long_name` tokens.
     4. The **unambiguous** leftover case only: exactly one unmatched slug and
-       exactly one unused data variable (the single-variable retrieve).
+       exactly one unused data variable (the single-variable retrieve), and
+       only when the two carry evidence of being the same quantity
+       (:func:`_pair_is_evidenced`) — arity alone is not a match.
 
     Any slug that stays unmatched keeps its placeholder — there is no arbitrary
     order-based pairing among multiple candidates.
@@ -292,12 +386,16 @@ def _match_variables(
     # rule 4 would pair it with whatever single variable survived the auxiliary
     # filter, which is how a precipitation CDR acquired a coverage counter.
     #
-    # Rule 4's wider weakness is untouched here: with one slug and one variable
-    # left it pairs them on arity alone, so two unrelated names still match. A
-    # token-overlap requirement was tried and rejected — it also rejects the
-    # abbreviations rule 4 gets right (`2m-temperature` -> `t2m`,
-    # `sea-surface-temperature` -> `sst`). Tracked separately.
-    if len(unmatched) == 1 and len(unused) == 1 and unmatched[0] != "all":
+    # Being the last two standing is arity, not evidence, so the pair must also
+    # look like the same quantity. A plain token-overlap test was rejected for
+    # dropping the abbreviations rule 4 gets right; `_pair_is_evidenced` keeps
+    # them via the initialism arm (`sea-surface-temperature` -> `sst`).
+    if (
+        len(unmatched) == 1
+        and len(unused) == 1
+        and unmatched[0] != "all"
+        and _pair_is_evidenced(unmatched[0], unused[0], candidates[unused[0]])
+    ):
         chosen[unmatched[0]] = unused[0]
 
     return {

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -364,8 +364,16 @@ def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
     qualifies on any one of three signals, cheapest first — a shared token with
     the short name, a shared token with its `long_name`, or `name` being an
     initialism of the slug. Slugs reduced to nothing but stopwords never
-    qualify. The evidence is a filter, not a proof: rule 4 leans on `reserved`
-    to keep a slug off a name a hydrated sibling row already owns.
+    qualify.
+
+    The initialism arm needs at least two tokens. Compressing a single word
+    leaves nothing but a prefix of it, which is far too weak to pair on: it
+    would read `co` as evidence for `co2`, and `e` for `ethene`.
+
+    The evidence is a filter, not a proof. A single shared token satisfies it,
+    so two names that share a generic word can still pair; `reserved` narrows
+    that where a hydrated sibling row already owns the name, but most stanzas
+    reaching rule 4 have no hydrated sibling at all.
 
     Args:
         slug: The unmatched catalog variable slug.
@@ -409,7 +417,7 @@ def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
         return True
     if tokens & (_tokens(str(meta.get("long_name") or "")) - _STOPWORDS):
         return True
-    return _is_initialism(name, tokens)
+    return len(tokens) >= 2 and _is_initialism(name, tokens)
 
 
 def _match_variables(

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -95,6 +95,33 @@ _UNKNOWN_UNITS = re.compile(r"(?m)^ {8}units:[ \t]*unknown[ \t]*$")
 _NC_VARIABLE_LINE = re.compile(r"(?m)^( {8}nc_variable:)[^\n]*$")
 _UNITS_LINE = re.compile(r"(?m)^( {8}units:)[^\n]*$")
 
+#: Function words that carry no identifying signal. Dropped before the rule 4
+#: overlap tests so `number-of-wet-days` cannot pair with a variable on `of`.
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "at",
+        "by",
+        "for",
+        "from",
+        "in",
+        "of",
+        "on",
+        "or",
+        "per",
+        "the",
+        "to",
+        "with",
+    }
+)
+
+#: Longest product prefix a NetCDF short name may add to a slug's own spelling
+#: and still be recognised as the same quantity (`xco2` for `co2`, `tcno2` for
+#: `no2`). Two characters covers the `x` / `tc` / `t` families the CDS serves.
+_PRODUCT_PREFIX_MAX = 2
+
 
 def _retrieve_netcdf_vars(dataset_id: str) -> dict[str, dict[str, Any]]:
     """Retrieve a tiny NetCDF for `dataset_id` and read its variable metadata.
@@ -242,29 +269,6 @@ def _assign_unique_subset(
                 progress = True
 
 
-#: Function words that carry no identifying signal. Dropped before the rule 4
-#: overlap tests so `number-of-wet-days` cannot pair with a variable on `of`.
-_STOPWORDS = frozenset(
-    {
-        "a",
-        "an",
-        "and",
-        "at",
-        "by",
-        "for",
-        "from",
-        "in",
-        "of",
-        "on",
-        "or",
-        "per",
-        "the",
-        "to",
-        "with",
-    }
-)
-
-
 def _consume_initialism(
     rest: str,
     tokens: tuple[str, ...],
@@ -356,12 +360,6 @@ def _is_initialism(name: str, tokens: set[str]) -> bool:
         return False
     ordered = tuple(sorted(tokens))
     return _consume_initialism(name.lower(), ordered, (1 << len(ordered)) - 1, {})
-
-
-#: Longest product prefix a NetCDF short name may add to a slug's own spelling
-#: and still be recognised as the same quantity (`xco2` for `co2`, `tcno2` for
-#: `no2`). Two characters covers the `x` / `tc` / `t` families the CDS serves.
-_PRODUCT_PREFIX_MAX = 2
 
 
 def _compact(text: str) -> str:
@@ -531,8 +529,12 @@ def _match_variables(
     #
     # Being the last two standing is arity, not evidence, so the pair must also
     # look like the same quantity. A plain token-overlap test was rejected for
-    # dropping the abbreviations rule 4 gets right; `_pair_is_evidenced` keeps
-    # them via the initialism arm (`sea-surface-temperature` -> `sst`).
+    # dropping the abbreviations rule 4 gets right; the initialism and product
+    # prefix arms keep the shapes it lost (`sea-surface-temperature` -> `sst`,
+    # `co2` -> `xco2`). Those arms resolve the common shapes, not abbreviation
+    # in general — a selective contraction like `msl` or `u10` still fails
+    # them, and such a slug simply keeps its placeholder. Rule 4 stays a last
+    # resort: the confident rules above carry most of the catalog.
     if (
         len(unmatched) == 1
         and len(unused) == 1

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -280,18 +280,13 @@ def _consume_initialism(
     mask: int,
     memo: dict[tuple[int, int], bool],
 ) -> bool:
-    """Return True when `rest` splits into a leading piece of every token left in `mask`.
+    """Return True when `rest` splits into a leading piece of every token in `mask`.
 
-    The search is order-free, because the compressed form need not follow the
-    slug's word order (`t2m` is `temperature` + `2m`), and succeeds only when
-    `rest` is fully consumed AND every token contributed, so a near-miss prefix
-    (`pressure` against `precipitation`) fails.
-
-    `rest` is always a suffix of the original name, so `(len(rest), mask)`
-    identifies a search state exactly; memoising on it bounds the work at
-    `O(2^len(tokens) * len(name) * len(tokens) * max_token_len)` — one state per
-    `(suffix, mask)` pair, each scanning the still-unused tokens' prefixes —
-    instead of the exponential-with-no-ceiling
+    The memo gate. `rest` is always a suffix of the original name, so
+    `(len(rest), mask)` identifies a search state exactly, and caching on it
+    bounds the work at `O(2^len(tokens) * len(name) * len(tokens) *
+    max_token_len)` — one state per `(suffix, mask)` pair, each scanning the
+    still-unused tokens' prefixes — instead of the exponential-with-no-ceiling
     node count a plain backtracker walks when the tokens nest as prefixes of
     one another.
 
@@ -306,26 +301,70 @@ def _consume_initialism(
     """
     key = (len(rest), mask)
     cached = memo.get(key)
-    if cached is not None:
-        return cached
+    if cached is None:
+        cached = _search_initialism(rest, tokens, mask, memo)
+        memo[key] = cached
+    return cached
+
+
+def _search_initialism(
+    rest: str,
+    tokens: tuple[str, ...],
+    mask: int,
+    memo: dict[tuple[int, int], bool],
+) -> bool:
+    """Try every still-unused token as the next piece of `rest`.
+
+    The search is order-free, because the compressed form need not follow the
+    slug's word order (`t2m` is `temperature` + `2m`), and succeeds only once
+    `rest` is spent with no token left over.
+
+    Args:
+        rest: The still-unconsumed tail of the NetCDF short name.
+        tokens: Every slug token, indexed by bit position in `mask`.
+        mask: Bits set for the tokens not yet accounted for.
+        memo: Shared cache threaded through the recursion.
+
+    Returns:
+        True when some assignment of the remaining tokens consumes `rest`.
+    """
     if not rest:
-        result = mask == 0
-    else:
-        result = False
-        for index, token in enumerate(tokens):
-            bit = 1 << index
-            if not mask & bit:
-                continue
-            for size in range(1, len(token) + 1):
-                if rest.startswith(token[:size]) and _consume_initialism(
-                    rest[size:], tokens, mask & ~bit, memo
-                ):
-                    result = True
-                    break
-            if result:
-                break
-    memo[key] = result
-    return result
+        return mask == 0
+    return any(
+        _consume_token(rest, token, tokens, mask & ~(1 << index), memo)
+        for index, token in enumerate(tokens)
+        if mask & (1 << index)
+    )
+
+
+def _consume_token(
+    rest: str,
+    token: str,
+    tokens: tuple[str, ...],
+    mask: int,
+    memo: dict[tuple[int, int], bool],
+) -> bool:
+    """Return True when some leading piece of `token` starts `rest` and the tail resolves.
+
+    Every prefix length is tried, so a token may contribute one letter (`s` for
+    `sea`) or all of itself (`2m`); a near-miss prefix fails because the whole
+    of `rest` still has to be consumed.
+
+    Args:
+        rest: The still-unconsumed tail of the NetCDF short name.
+        token: The slug token being tried at this position.
+        tokens: Every slug token, indexed by bit position in `mask`.
+        mask: Bits set for the tokens still unused after `token`.
+        memo: Shared cache threaded through the recursion.
+
+    Returns:
+        True when `token` can start `rest` and the remainder resolves.
+    """
+    return any(
+        rest.startswith(token[:size])
+        and _consume_initialism(rest[size:], tokens, mask, memo)
+        for size in range(1, len(token) + 1)
+    )
 
 
 def _is_initialism(name: str, tokens: set[str]) -> bool:

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -449,7 +449,8 @@ def _match_variables(
     Args:
         placeholders: The still-`unknown` variable slugs, in catalog order.
         nc_meta: The retrieved `{nc_name: {long_name, units}}` mapping.
-        reserved: NetCDF names already written into the stanza's hydrated rows.
+        reserved: Lowercased NetCDF names already written into the stanza's
+            hydrated rows.
             Rule 4 will not hand one of these to a second slug; the confident
             rules still may, because one short name legitimately serves several
             rows of the same dataset (CARRA repeats a name across level
@@ -493,7 +494,7 @@ def _match_variables(
         len(unmatched) == 1
         and len(unused) == 1
         and unmatched[0] != "all"
-        and unused[0] not in reserved
+        and unused[0].lower() not in reserved
         and _pair_is_evidenced(unmatched[0], unused[0], candidates[unused[0]])
     ):
         chosen[unmatched[0]] = unused[0]
@@ -518,12 +519,15 @@ def _claimed_nc_names(block: str) -> frozenset[str]:
 
     A placeholder row carries a seeded `nc_variable` too, so only sub-blocks
     that have lost the `units: unknown` sentinel count as having claimed a name.
+    Values are returned lowercased, because NetCDF short names vary in case
+    across products (`SST` and `sst` name one variable) and reservation has to
+    match the way the rest of this module compares names.
 
     Args:
         block: One dataset stanza's body text.
 
     Returns:
-        The NetCDF short names a hydrated row of this stanza already uses.
+        The lowercased NetCDF short names a hydrated row of this stanza uses.
     """
     claimed = set()
     for match in _VARIABLE_BLOCK.finditer(block):
@@ -533,10 +537,34 @@ def _claimed_nc_names(block: str) -> frozenset[str]:
         line = _NC_VARIABLE_LINE.search(body)
         if line is None:
             continue
-        value = body[line.start() : line.end()].split(":", 1)[1].strip()
+        value = _scalar_after_key(body[line.start() : line.end()])
         if value:
-            claimed.add(value.strip("\"'"))
+            claimed.add(value.lower())
     return frozenset(claimed)
+
+
+def _scalar_after_key(line: str) -> str:
+    """Return the plain scalar a `key: value` line carries, or `""` for none.
+
+    Handles the two shapes the catalog emits — a bare scalar with an optional
+    trailing `#` comment, and a quoted scalar — and rejects the YAML nulls, so
+    an empty or `null` `nc_variable` never reserves a name.
+
+    Args:
+        line: One `key: value` line, without its newline.
+
+    Returns:
+        The unquoted, comment-free value, or `""` when there is none.
+    """
+    raw = line.split(":", 1)[1].strip()
+    if raw[:1] in tuple('"\''):
+        quote = raw[0]
+        end = raw.find(quote, 1)
+        raw = raw[1:end] if end > 0 else raw.lstrip(quote)
+    else:
+        # A YAML inline comment needs whitespace before the `#`.
+        raw = re.split(r"\s#", raw, maxsplit=1)[0].strip()
+    return "" if raw.lower() in {"", "null", "~"} else raw
 
 
 def _fill_variable(block: str, slug: str, nc_name: str, units: str) -> str:

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -303,6 +303,28 @@ def _is_initialism(name: str, tokens: set[str]) -> bool:
 
     Returns:
         True when `name` is an initialism of `tokens`.
+
+    Examples:
+        - The compressed form need not follow the slug's word order:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _is_initialism
+            >>> _is_initialism("sst", {"sea", "surface", "temperature"})
+            True
+            >>> _is_initialism("t2m", {"2m", "temperature"})
+            True
+
+            ```
+        - Every token must contribute, so a near-miss prefix fails:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _is_initialism
+            >>> _is_initialism("pressure", {"precipitation"})
+            False
+            >>> _is_initialism("elevation", {"number", "wet", "days"})
+            False
+
+            ```
     """
     return bool(tokens) and _consume_initialism(name.lower(), sorted(tokens))
 
@@ -323,6 +345,33 @@ def _pair_is_evidenced(slug: str, name: str, meta: dict[str, Any]) -> bool:
 
     Returns:
         True when the pairing is supported; False to keep the placeholder.
+
+    Examples:
+        - An initialism is evidence even with no shared token:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _pair_is_evidenced
+            >>> _pair_is_evidenced("sea-surface-temperature", "sst", {})
+            True
+
+            ```
+        - So is a token shared with the variable's `long_name`:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _pair_is_evidenced
+            >>> meta = {"long_name": "Liquid Water Equivalent Thickness"}
+            >>> _pair_is_evidenced("terrestrial-water-storage", "lwe_thickness", meta)
+            True
+
+            ```
+        - Two unrelated names are not paired, whatever the arity:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _pair_is_evidenced
+            >>> _pair_is_evidenced("number-of-wet-days", "elevation", {"units": "m"})
+            False
+
+            ```
     """
     tokens = _tokens(slug) - _STOPWORDS
     if not tokens:

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -672,7 +672,10 @@ def _hydrate_one(
         timeout: Per-dataset retrieve deadline; `None` / `0` waits without one.
 
     Returns:
-        One of `"hydrated"`, `"timed_out"`, or `"skipped"`.
+        One of `"hydrated"`, `"unmatched"`, `"timed_out"`, or `"skipped"`.
+        `"unmatched"` is the retrieve that worked and still hydrated nothing —
+        the operator can curate that row by hand, unlike a `"skipped"` licence
+        or network failure.
     """
     try:
         nc_meta: dict[str, dict[str, Any]] | None = _retrieve_with_timeout(
@@ -691,8 +694,9 @@ def _hydrate_one(
         file_text[path] = path.read_text(encoding="utf-8")
     new_text = _rewrite_stanza(file_text[path], dataset_id, nc_meta)
     if new_text == file_text[path]:
-        typer.echo(f"{prefix}: skipped")
-        return "skipped"
+        offered = sorted(name for name in nc_meta if not _is_auxiliary(name))
+        typer.echo(f"{prefix}: retrieved, no confident match ({', '.join(offered)})")
+        return "unmatched"
     file_text[path] = new_text
     path.write_text(new_text, encoding="utf-8")
     typer.echo(f"{prefix}: hydrated -> {path.name}")
@@ -720,7 +724,10 @@ def bulk_hydrate_empty(
             without a deadline (the offline-test path).
 
     Returns:
-        A summary `{candidates, hydrated, skipped, timed_out, filled}` mapping.
+        A summary `{candidates, hydrated, skipped, timed_out, unmatched, filled}`
+        mapping. `unmatched` counts the retrieves that succeeded and still
+        hydrated nothing; those are also counted in `skipped`, which stays the
+        total of everything not hydrated.
     """
     from earthlens.ecmwf import Catalog
     from earthlens.ecmwf.catalog import CATALOG_PATH, clear_catalog_cache
@@ -740,6 +747,7 @@ def bulk_hydrate_empty(
     hydrated = 0
     skipped = 0
     timed_out = 0
+    unmatched = 0
     filled: list[str] = []
     for index, dataset_id in enumerate(empty, start=1):
         prefix = f"[{index}/{total}] {dataset_id}"
@@ -747,6 +755,9 @@ def bulk_hydrate_empty(
         if outcome == "hydrated":
             hydrated += 1
             filled.append(dataset_id)
+        elif outcome == "unmatched":
+            unmatched += 1
+            skipped += 1
         elif outcome == "timed_out":
             timed_out += 1
             skipped += 1
@@ -759,5 +770,6 @@ def bulk_hydrate_empty(
         "hydrated": hydrated,
         "skipped": skipped,
         "timed_out": timed_out,
+        "unmatched": unmatched,
         "filled": filled,
     }

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -178,11 +178,13 @@ class TestMatchVariables:
             ("total-precipitation", "tp", "", True),
             # True positives - a shared token with the short or long name.
             ("mean-uth", "uth", "", True),
+            # Only `water` of four tokens: real, but below the coverage bar, so
+            # it keeps its placeholder rather than being guessed at.
             (
                 "terrestrial-water-storage-anomaly",
                 "lwe_thickness",
                 "Liquid Water Equivalent Thickness",
-                True,
+                False,
             ),
             # True negatives - unrelated names must keep the placeholder.
             ("number-of-wet-days", "elevation", "", False),
@@ -394,22 +396,28 @@ class TestPairIsEvidenced:
         assert _pair_is_evidenced("mean-uth", "uth", {}) is True
 
     def test_long_name_token_overlap(self):
-        """A token shared with the variable's long name is evidence."""
-        meta = {"long_name": "Liquid Water Equivalent Thickness"}
-        assert _pair_is_evidenced("terrestrial-water-storage", "lwe_thickness", meta)
+        """Tokens shared with the long name are evidence once they cover the slug."""
+        meta = {"long_name": "Total precipitation depth"}
+        assert _pair_is_evidenced("total-precipitation", "zzz", meta) is True
 
     def test_initialism(self):
         """An initialism is evidence with no shared token at all."""
         assert _pair_is_evidenced("sea-surface-temperature", "sst", {}) is True
 
-    def test_a_generic_shared_token_counts_as_evidence(self):
-        """One shared generic word satisfies the long-name arm, which is weak by design."""
-        assert (
-            _pair_is_evidenced(
-                "land-sea-mask", "zzz", {"long_name": "Mean sea level pressure"}
-            )
-            is True
-        ), "the only thing in common is the word 'sea'"
+    @pytest.mark.parametrize(
+        ("slug", "long_name"),
+        [
+            ("land-sea-mask", "Mean sea level pressure"),
+            ("sub-surface-runoff", "Surface net solar radiation"),
+        ],
+    )
+    def test_one_generic_word_does_not_cover_enough_of_the_slug(self, slug, long_name):
+        """A lone generic word shared with the long name is coincidence, not evidence."""
+        assert _pair_is_evidenced(slug, "zzz", {"long_name": long_name}) is False
+
+    def test_shared_tokens_covering_half_the_slug_are_evidence(self):
+        """Half the slug's tokens is the bar, so a two-token slug needs one of them."""
+        assert _pair_is_evidenced("glacier-area", "area", {}) is True
 
     def test_reservation_declines_a_name_a_sibling_row_owns(self):
         """Where a hydrated sibling owns the name, reservation is what stops rule 4."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -171,6 +171,24 @@ class TestMatchVariables:
         if expected:
             assert assignments == {slug: (nc_name, "1")}
 
+    def test_two_leftovers_are_never_paired(self):
+        """The leftover rule needs exactly one of each, so a 2x2 residue stays unhydrated."""
+        assignments = _match_variables(
+            ["first-mystery", "second-mystery"],
+            {
+                "xx": {"long_name": "totally different", "units": "1"},
+                "yy": {"long_name": "also unrelated", "units": "1"},
+            },
+        )
+        assert assignments == {}
+
+    def test_initialism_ignores_case(self):
+        """An upper-case NetCDF short name is still recognised as an initialism."""
+        assignments = _match_variables(
+            ["sea-surface-temperature"], {"SST": {"long_name": "", "units": "K"}}
+        )
+        assert assignments == {"sea-surface-temperature": ("SST", "K")}
+
     def test_stopword_only_slug_is_never_paired(self):
         """A slug that reduces to stopwords carries no evidence to match on."""
         assignments = _match_variables(

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -238,15 +238,16 @@ class TestMatchVariables:
 
     def test_the_all_pseudo_slug_is_never_paired(self):
         """`all` means every variable, so it never stands in for one of them."""
-        assignments = _match_variables(
-            ["all"], {"num_covered_hours": {"long_name": "all hours", "units": "1"}}
+        meta = {"tp": {"long_name": "Total precipitation", "units": "m"}}
+        assert _match_variables(["total-precipitation"], meta) != {}, (
+            "a real slug pairs with this lone variable"
         )
-        assert assignments == {}
+        assert _match_variables(["all"], meta) == {}, "the pseudo-slug must not"
 
     def test_stopword_only_slug_is_never_paired(self):
-        """A slug that reduces to stopwords carries no evidence to match on."""
+        """Stripping stopwords leaves nothing to match on, so the shared `of` is ignored."""
         assignments = _match_variables(
-            ["of-the"], {"xx": {"long_name": "totally different", "units": "1"}}
+            ["of-the"], {"of": {"long_name": "totally different", "units": "1"}}
         )
         assert assignments == {}
 
@@ -386,7 +387,7 @@ class TestIsInitialism:
 
 
 class TestPairIsEvidenced:
-    """Tests for the four arms of the rule 4 evidence check."""
+    """Tests for the three arms of the rule 4 evidence check."""
 
     def test_short_name_token_overlap(self):
         """A token shared with the NetCDF short name is evidence."""
@@ -401,10 +402,18 @@ class TestPairIsEvidenced:
         """An initialism is evidence with no shared token at all."""
         assert _pair_is_evidenced("sea-surface-temperature", "sst", {}) is True
 
-    def test_a_generic_shared_token_is_weak_but_reservation_catches_it(self):
-        """Evidence alone can pass on one generic word; the reservation is the real guard."""
+    def test_a_generic_shared_token_counts_as_evidence(self):
+        """One shared generic word satisfies the long-name arm, which is weak by design."""
+        assert (
+            _pair_is_evidenced(
+                "land-sea-mask", "zzz", {"long_name": "Mean sea level pressure"}
+            )
+            is True
+        ), "the only thing in common is the word 'sea'"
+
+    def test_reservation_declines_a_name_a_sibling_row_owns(self):
+        """Where a hydrated sibling owns the name, reservation is what stops rule 4."""
         meta = {"msl": {"long_name": "Mean sea level pressure", "units": "Pa"}}
-        assert _pair_is_evidenced("land-sea-mask", "msl", meta) is True
         assert _match_variables(["land-sea-mask"], meta) != {}
         assert (
             _match_variables(["land-sea-mask"], meta, reserved=frozenset({"msl"})) == {}

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -585,6 +585,24 @@ class TestBulkHydrateEmpty:
         assert summary["unmatched"] == 1
         assert summary["skipped"] == 1, "unmatched still counts toward skipped"
 
+    def test_a_missing_stanza_is_a_skip_not_a_declined_match(
+        self, tmp_path, monkeypatch
+    ):
+        """A shard that never held the dataset had nothing for the matcher to decline."""
+        (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")
+        _patch_catalog(
+            monkeypatch,
+            tmp_path,
+            {"reanalysis-era5-single-levels": _placeholder_dataset("2m-temperature")},
+        )
+        monkeypatch.setattr(hydrate_mod, "_find_file_for_dataset", lambda *a: None)
+        monkeypatch.setattr(
+            hydrate_mod, "_retrieve_netcdf_vars", lambda ds: dict(_NC_META)
+        )
+        summary = bulk_hydrate_empty()
+        assert summary["unmatched"] == 0
+        assert summary["skipped"] == 1
+
     def test_limit_caps_candidates(self, tmp_path, monkeypatch):
         """A --limit truncates the placeholder worklist."""
         (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -154,6 +154,14 @@ class TestMatchVariables:
                 "Liquid Water Equivalent Thickness",
                 True,
             ),
+            # True positives - a chemical formula behind a product prefix.
+            (
+                "co2",
+                "xco2",
+                "column-averaged dry-air mole fraction of carbon dioxide",
+                True,
+            ),
+            ("ch4", "xch4", "column-averaged dry-air mole fraction of methane", True),
             # False positives - unrelated names must keep the placeholder.
             ("number-of-wet-days", "elevation", "", False),
             ("number-of-dry-spells", "elevation", "Surface elevation", False),
@@ -188,6 +196,14 @@ class TestMatchVariables:
             ["sea-surface-temperature"], {"SST": {"long_name": "", "units": "K"}}
         )
         assert assignments == {"sea-surface-temperature": ("SST", "K")}
+
+    def test_a_buried_token_is_not_a_prefixed_form(self):
+        """A slug token appearing inside an unrelated name is not evidence on its own."""
+        assignments = _match_variables(
+            ["specific-cloud-ice-water-content"],
+            {"iicethic": {"long_name": "", "units": "1"}},
+        )
+        assert assignments == {}
 
     def test_stopword_only_slug_is_never_paired(self):
         """A slug that reduces to stopwords carries no evidence to match on."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import textwrap
 import time
 from types import SimpleNamespace
 
@@ -98,6 +99,32 @@ class TestRewriteStanza:
     def test_no_placeholders_returns_input(self):
         """A stanza with no `units: unknown` variable is left unchanged."""
         assert _rewrite_stanza(_STANZA, "other-dataset", _NC_META) == _STANZA
+
+    def test_a_sibling_row_keeps_its_nc_variable_to_itself(self):
+        """A leftover slug is not handed a NetCDF name a hydrated row already claims."""
+        text = textwrap.dedent(
+            """
+            datasets:
+              demo-dataset:
+                variables:
+                  total-precipitation:
+                    cds_variable: total_precipitation
+                    nc_variable: tp
+                    units: m
+                  precipitation-rate:
+                    cds_variable: precipitation_rate
+                    nc_variable: precipitation_rate
+                    units: unknown
+            """
+        ).lstrip()
+        out = _rewrite_stanza(
+            text,
+            "demo-dataset",
+            {"tp": {"long_name": "Total precipitation", "units": "m"}},
+        )
+        variables = yaml.safe_load(out)["datasets"]["demo-dataset"]["variables"]
+        assert variables["precipitation-rate"]["units"] == "unknown"
+        assert [v["nc_variable"] for v in variables.values()].count("tp") == 1
 
     def test_empty_retrieve_returns_input(self):
         """No usable retrieved variable leaves the placeholders as-is."""
@@ -204,6 +231,23 @@ class TestMatchVariables:
             {"iicethic": {"long_name": "", "units": "1"}},
         )
         assert assignments == {}
+
+    def test_reserved_names_are_withheld_from_the_leftover_rule(self):
+        """A reserved NetCDF name is not offered to the lone leftover slug."""
+        meta = {"t2m": {"long_name": "", "units": "K"}}
+        assert _match_variables(["2m-temperature"], meta) != {}
+        assert (
+            _match_variables(["2m-temperature"], meta, reserved=frozenset({"t2m"}))
+            == {}
+        )
+
+    def test_reserved_names_still_reach_the_confident_rules(self):
+        """Reservation gates only the leftover guess; a long-name match still binds."""
+        meta = {"sst": {"long_name": "Sea surface temperature", "units": "K"}}
+        assignments = _match_variables(
+            ["sea-surface-temperature"], meta, reserved=frozenset({"sst"})
+        )
+        assert assignments == {"sea-surface-temperature": ("sst", "K")}
 
     def test_stopword_only_slug_is_never_paired(self):
         """A slug that reduces to stopwords carries no evidence to match on."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -12,7 +12,9 @@ import yaml
 from earthlens.ecmwf import _hydrate as hydrate_mod
 from earthlens.ecmwf._hydrate import (
     _find_file_for_dataset,
+    _is_initialism,
     _match_variables,
+    _pair_is_evidenced,
     _retrieve_with_timeout,
     _rewrite_stanza,
     _yaml_value,
@@ -189,7 +191,7 @@ class TestMatchVariables:
                 True,
             ),
             ("ch4", "xch4", "column-averaged dry-air mole fraction of methane", True),
-            # False positives - unrelated names must keep the placeholder.
+            # True negatives - unrelated names must keep the placeholder.
             ("number-of-wet-days", "elevation", "", False),
             ("number-of-dry-spells", "elevation", "Surface elevation", False),
             ("glacier-area", "elevation", "", False),
@@ -248,6 +250,13 @@ class TestMatchVariables:
             ["sea-surface-temperature"], meta, reserved=frozenset({"sst"})
         )
         assert assignments == {"sea-surface-temperature": ("sst", "K")}
+
+    def test_the_all_pseudo_slug_is_never_paired(self):
+        """`all` means every variable, so it never stands in for one of them."""
+        assignments = _match_variables(
+            ["all"], {"num_covered_hours": {"long_name": "all hours", "units": "1"}}
+        )
+        assert assignments == {}
 
     def test_stopword_only_slug_is_never_paired(self):
         """A slug that reduces to stopwords carries no evidence to match on."""
@@ -321,6 +330,58 @@ class TestMatchVariables:
         assert assignments == {"temperature": ("t", "K")}, (
             "quality-flag stays unhydrated"
         )
+
+
+class TestIsInitialism:
+    """Tests for the order-free initialism predicate."""
+
+    @pytest.mark.parametrize(
+        ("name", "tokens", "expected"),
+        [
+            ("sst", {"sea", "surface", "temperature"}, True),
+            ("t2m", {"2m", "temperature"}, True),
+            ("tp", {"total", "precipitation"}, True),
+            ("pressure", {"precipitation"}, False),
+            ("elevation", {"number", "wet", "days"}, False),
+            ("sst", {"sea", "surface"}, False),
+        ],
+    )
+    def test_recognises_compressed_spellings(self, name, tokens, expected):
+        """A name qualifies only when every token contributes and none is left over."""
+        assert _is_initialism(name, tokens) is expected
+
+    def test_no_tokens_is_never_an_initialism(self):
+        """An empty token set carries nothing to compress."""
+        assert _is_initialism("sst", set()) is False
+
+
+class TestPairIsEvidenced:
+    """Tests for the four arms of the rule 4 evidence check."""
+
+    def test_short_name_token_overlap(self):
+        """A token shared with the NetCDF short name is evidence."""
+        assert _pair_is_evidenced("mean-uth", "uth", {}) is True
+
+    def test_long_name_token_overlap(self):
+        """A token shared with the variable's long name is evidence."""
+        meta = {"long_name": "Liquid Water Equivalent Thickness"}
+        assert _pair_is_evidenced("terrestrial-water-storage", "lwe_thickness", meta)
+
+    def test_initialism(self):
+        """An initialism is evidence with no shared token at all."""
+        assert _pair_is_evidenced("sea-surface-temperature", "sst", {}) is True
+
+    def test_product_prefix(self):
+        """The slug's own spelling behind a short product prefix is evidence."""
+        assert _pair_is_evidenced("co2", "xco2", {}) is True
+
+    def test_unrelated_names_carry_no_evidence(self):
+        """Two names with nothing in common are not paired."""
+        assert _pair_is_evidenced("number-of-wet-days", "elevation", {}) is False
+
+    def test_a_stopword_only_slug_carries_no_evidence(self):
+        """A slug that reduces to stopwords has nothing left to match on."""
+        assert _pair_is_evidenced("of-the", "xx", {"long_name": "of the"}) is False
 
 
 class TestRetrieveWithTimeout:

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -123,13 +123,60 @@ class TestMatchVariables:
         )
         assert assignments == {}
 
-    def test_order_fallback_pairs_leftovers(self):
-        """One unmatched slug + one leftover variable is the unambiguous 1:1 case."""
+    def test_unrelated_leftovers_are_not_paired(self):
+        """A lone slug and a lone variable that share no evidence keep the placeholder."""
         assignments = _match_variables(
             ["mystery-variable"],
             {"xx": {"long_name": "totally different", "units": "1"}},
         )
-        assert assignments == {"mystery-variable": ("xx", "1")}
+        assert assignments == {}
+
+    def test_leftover_pairs_when_the_short_name_shares_a_token(self):
+        """The 1:1 leftover case still resolves when the names agree."""
+        assignments = _match_variables(
+            ["wind-speed-of-gusts"],
+            {"wind_speed_gust": {"long_name": "", "units": "m s-1"}},
+        )
+        assert assignments == {"wind-speed-of-gusts": ("wind_speed_gust", "m s-1")}
+
+    @pytest.mark.parametrize(
+        ("slug", "nc_name", "long_name", "expected"),
+        [
+            # True positives - abbreviations a token-overlap test would reject.
+            ("2m-temperature", "t2m", "", True),
+            ("sea-surface-temperature", "sst", "", True),
+            ("total-precipitation", "tp", "", True),
+            # True positives - a shared token with the short or long name.
+            ("mean-uth", "uth", "", True),
+            (
+                "terrestrial-water-storage-anomaly",
+                "lwe_thickness",
+                "Liquid Water Equivalent Thickness",
+                True,
+            ),
+            # False positives - unrelated names must keep the placeholder.
+            ("number-of-wet-days", "elevation", "", False),
+            ("number-of-dry-spells", "elevation", "Surface elevation", False),
+            ("glacier-area", "elevation", "", False),
+            # A near-miss prefix is not an initialism.
+            ("precipitation", "pressure", "", False),
+        ],
+    )
+    def test_leftover_pairing_table(self, slug, nc_name, long_name, expected):
+        """The lone-slug/lone-variable rule pairs only on real name evidence."""
+        assignments = _match_variables(
+            [slug], {nc_name: {"long_name": long_name, "units": "1"}}
+        )
+        assert bool(assignments) is expected
+        if expected:
+            assert assignments == {slug: (nc_name, "1")}
+
+    def test_stopword_only_slug_is_never_paired(self):
+        """A slug that reduces to stopwords carries no evidence to match on."""
+        assignments = _match_variables(
+            ["of-the"], {"xx": {"long_name": "totally different", "units": "1"}}
+        )
+        assert assignments == {}
 
     def test_exact_short_name_never_swaps(self):
         """Multiple data vars map by exact short name, never zipped/swapped."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -360,6 +360,14 @@ class TestClaimedNcNames:
         """A row still carrying the unknown sentinel has not bound its name yet."""
         assert "z" not in _claimed_nc_names(_CLAIMED_BLOCK)
 
+    def test_a_row_without_an_nc_variable_key_reserves_nothing(self):
+        """A hydrated row that never names a variable has claimed none."""
+        block = """      keyless-row:
+        cds_variable: k
+        units: m
+"""
+        assert _claimed_nc_names(block) == frozenset()
+
     def test_an_empty_block_reserves_nothing(self):
         """A stanza with no variables reserves nothing."""
         assert _claimed_nc_names("") == frozenset()
@@ -619,6 +627,40 @@ class TestBulkHydrateEmpty:
         summary = bulk_hydrate_empty()
         assert summary["unmatched"] == 0
         assert summary["skipped"] == 1
+
+    def test_a_stanza_with_nothing_left_to_fill_is_a_skip(self, tmp_path, monkeypatch):
+        """A stanza whose placeholders are already filled is not a declined match."""
+        (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")
+        _patch_catalog(
+            monkeypatch,
+            tmp_path,
+            {"other-dataset": _placeholder_dataset("total-precipitation")},
+        )
+        monkeypatch.setattr(
+            hydrate_mod, "_retrieve_netcdf_vars", lambda ds: dict(_NC_META)
+        )
+        summary = bulk_hydrate_empty()
+        assert summary["unmatched"] == 0
+        assert summary["skipped"] == 1
+
+    def test_a_retrieve_of_only_auxiliaries_says_so(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """When nothing retrieved is a data variable, the echo names that case."""
+        (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")
+        _patch_catalog(
+            monkeypatch,
+            tmp_path,
+            {"reanalysis-era5-single-levels": _placeholder_dataset("2m-temperature")},
+        )
+        monkeypatch.setattr(
+            hydrate_mod,
+            "_retrieve_netcdf_vars",
+            lambda ds: {"latitude": {"long_name": "latitude", "units": "degrees"}},
+        )
+        summary = bulk_hydrate_empty()
+        assert summary["unmatched"] == 1
+        assert "only coordinates and auxiliaries" in capsys.readouterr().out
 
     def test_limit_caps_candidates(self, tmp_path, monkeypatch):
         """A --limit truncates the placeholder worklist."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -364,6 +364,14 @@ class TestPairIsEvidenced:
             _match_variables(["land-sea-mask"], meta, reserved=frozenset({"msl"})) == {}
         )
 
+    @pytest.mark.parametrize(
+        ("slug", "name"),
+        [("co2", "co"), ("ethene", "e"), ("methane", "met")],
+    )
+    def test_a_single_word_slug_is_not_abbreviated_by_a_prefix(self, slug, name):
+        """Compressing one word leaves only a prefix of it, which is not evidence."""
+        assert _pair_is_evidenced(slug, name, {}) is False
+
     def test_unrelated_names_carry_no_evidence(self):
         """Two names with nothing in common are not paired."""
         assert _pair_is_evidenced("number-of-wet-days", "elevation", {}) is False

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -436,6 +436,7 @@ class TestBulkHydrateEmpty:
             "hydrated": 1,
             "skipped": 0,
             "timed_out": 0,
+            "unmatched": 0,
             "filled": ["reanalysis-era5-single-levels"],
         }
         variables = yaml.safe_load((tmp_path / "era5.yaml").read_text())["datasets"][
@@ -459,6 +460,26 @@ class TestBulkHydrateEmpty:
         summary = bulk_hydrate_empty()
         assert summary["hydrated"] == 0
         assert summary["skipped"] == 1
+
+    def test_a_declined_match_is_reported_apart_from_a_skip(
+        self, tmp_path, monkeypatch
+    ):
+        """A retrieve that yields nothing confident is unmatched, not skipped."""
+        (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")
+        _patch_catalog(
+            monkeypatch,
+            tmp_path,
+            {"reanalysis-era5-single-levels": _placeholder_dataset("2m-temperature")},
+        )
+        monkeypatch.setattr(
+            hydrate_mod,
+            "_retrieve_netcdf_vars",
+            lambda ds: {"elevation": {"long_name": "Surface elevation", "units": "m"}},
+        )
+        summary = bulk_hydrate_empty()
+        assert summary["hydrated"] == 0
+        assert summary["unmatched"] == 1
+        assert summary["skipped"] == 1, "unmatched still counts toward skipped"
 
     def test_limit_caps_candidates(self, tmp_path, monkeypatch):
         """A --limit truncates the placeholder worklist."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -183,14 +183,6 @@ class TestMatchVariables:
                 "Liquid Water Equivalent Thickness",
                 True,
             ),
-            # True positives - a chemical formula behind a product prefix.
-            (
-                "co2",
-                "xco2",
-                "column-averaged dry-air mole fraction of carbon dioxide",
-                True,
-            ),
-            ("ch4", "xch4", "column-averaged dry-air mole fraction of methane", True),
             # True negatives - unrelated names must keep the placeholder.
             ("number-of-wet-days", "elevation", "", False),
             ("number-of-dry-spells", "elevation", "Surface elevation", False),
@@ -225,14 +217,6 @@ class TestMatchVariables:
             ["sea-surface-temperature"], {"SST": {"long_name": "", "units": "K"}}
         )
         assert assignments == {"sea-surface-temperature": ("SST", "K")}
-
-    def test_a_buried_token_is_not_a_prefixed_form(self):
-        """A slug token appearing inside an unrelated name is not evidence on its own."""
-        assignments = _match_variables(
-            ["specific-cloud-ice-water-content"],
-            {"iicethic": {"long_name": "", "units": "1"}},
-        )
-        assert assignments == {}
 
     def test_reserved_names_are_withheld_from_the_leftover_rule(self):
         """A reserved NetCDF name is not offered to the lone leftover slug."""
@@ -371,9 +355,14 @@ class TestPairIsEvidenced:
         """An initialism is evidence with no shared token at all."""
         assert _pair_is_evidenced("sea-surface-temperature", "sst", {}) is True
 
-    def test_product_prefix(self):
-        """The slug's own spelling behind a short product prefix is evidence."""
-        assert _pair_is_evidenced("co2", "xco2", {}) is True
+    def test_a_generic_shared_token_is_weak_but_reservation_catches_it(self):
+        """Evidence alone can pass on one generic word; the reservation is the real guard."""
+        meta = {"msl": {"long_name": "Mean sea level pressure", "units": "Pa"}}
+        assert _pair_is_evidenced("land-sea-mask", "msl", meta) is True
+        assert _match_variables(["land-sea-mask"], meta) != {}
+        assert (
+            _match_variables(["land-sea-mask"], meta, reserved=frozenset({"msl"})) == {}
+        )
 
     def test_unrelated_names_carry_no_evidence(self):
         """Two names with nothing in common are not paired."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -11,6 +11,7 @@ import yaml
 
 from earthlens.ecmwf import _hydrate as hydrate_mod
 from earthlens.ecmwf._hydrate import (
+    _claimed_nc_names,
     _find_file_for_dataset,
     _is_initialism,
     _match_variables,
@@ -314,6 +315,51 @@ class TestMatchVariables:
         assert assignments == {"temperature": ("t", "K")}, (
             "quality-flag stays unhydrated"
         )
+
+
+_CLAIMED_BLOCK = """      total-precipitation:
+        cds_variable: total_precipitation
+        nc_variable: tp  # ERA5 short name
+        units: m
+      quoted-row:
+        cds_variable: x
+        nc_variable: 'SST'
+        units: K
+      empty-row:
+        cds_variable: y
+        nc_variable: null
+        units: K
+      still-a-placeholder:
+        cds_variable: z
+        nc_variable: z
+        units: unknown
+"""
+
+
+class TestClaimedNcNames:
+    """Tests for the reservation set read out of a stanza's hydrated rows."""
+
+    def test_an_inline_comment_does_not_become_part_of_the_name(self):
+        """A trailing YAML comment is stripped, so the bare name is reserved."""
+        assert "tp" in _claimed_nc_names(_CLAIMED_BLOCK)
+
+    def test_a_quoted_value_is_unquoted_and_lowercased(self):
+        """Quotes are dropped and case folded, so SST and sst reserve alike."""
+        assert "sst" in _claimed_nc_names(_CLAIMED_BLOCK)
+
+    def test_a_null_value_reserves_nothing(self):
+        """A null nc_variable is not a claim on any name."""
+        claimed = _claimed_nc_names(_CLAIMED_BLOCK)
+        assert "null" not in claimed
+        assert "" not in claimed
+
+    def test_a_placeholder_row_claims_nothing(self):
+        """A row still carrying the unknown sentinel has not bound its name yet."""
+        assert "z" not in _claimed_nc_names(_CLAIMED_BLOCK)
+
+    def test_an_empty_block_reserves_nothing(self):
+        """A stanza with no variables reserves nothing."""
+        assert _claimed_nc_names("") == frozenset()
 
 
 class TestIsInitialism:


### PR DESCRIPTION
# Description

The ECMWF placeholder hydrator's rule 4 treated "one slug left, one variable left" as proof the two corresponded.
There was no check that the names had anything to do with each other, so two unrelated names were paired:

```python
>>> _match_variables(["number-of-wet-days"], {"elevation": {"units": "m"}})
{'number-of-wet-days': ('elevation', 'm')}
```

That result is written into the catalog as the row's `nc_variable`, and `aggregate.py` reads exactly that field
(`libs/core/src/earthlens/aggregate.py:797`), so a mis-pair silently reduces the wrong array and writes it out under
the requested variable's name. `_hydrate.py`'s own docstring already stated the standard being violated: *"a wrong
`nc_variable` is worse than the `unknown` placeholder (it silently mis-extracts at `aggregate=` time)"*.

Rule 4 now requires two things beyond arity:

- **The variable is not already claimed.** `_claimed_nc_names` reads the `nc_variable` values bound by rows of the
  same stanza that have lost the `units: unknown` sentinel, and rule 4 declines them. Scoped to rule 4 only — the
  exact and `long_name` rules may still share a short name, because one name legitimately serves several rows where
  CARRA repeats it across level families. Reaching a repeated name by a confident rule is evidence; reaching it by
  the leftover rule is a guess.
- **The two names carry evidence of describing the same quantity.** Either the tokens they share cover at least half
  the slug's meaningful tokens, or the short name is an initialism of the slug (which needs two or more tokens —
  compressing one word leaves only a prefix, which would read `co` as evidence for `co2`).

Coverage rather than bare overlap is what stops a single generic word from passing as evidence: `land-sea-mask`
shares only `sea` with mean sea level pressure, and `sub-surface-runoff` only `surface` with surface net solar
radiation. Measured over the curated catalog, it cuts the pairings rule 4 would get wrong from 111 to 38.

A slug that stays ambiguous keeps its `unknown` placeholder and is now reported and counted separately, so it can be
curated by hand rather than silently missing.

## Known limits, measured rather than assumed

- **The initialism arm is not policed by coverage** — it has no shared tokens to measure, and it admits 34 of the 38
  wrong pairings that remain, reading `msl` as m(ask) s(ea) l(and). Requiring it to consume tokens in slug order
  would remove some, but it also rejects `2m-temperature` → `t2m`, which #1089 lists as a Definition-of-Done item.
- **The evidence check leans on `long_name`.** 89% of curated rows needing more than an exact-name match would fail
  it if a retrieve carried no `long_name` at all.
- **Reservation is not a general guard.** Of the 8 stanzas rule 4 can reach in the shipped catalog, 6 have no
  hydrated sibling row and so reserve nothing; the evidence check stands alone there.

## Scope

`_ecmwf_deep_sample` truncates every request list with `value[:1]` (`cli.py:247`), so each probe returns a single
data variable and rule 4 only fires for a dataset with exactly one leftover placeholder. Across the catalog, 110
datasets have placeholders, 31 have exactly one, and 23 of those are the `all` pseudo-slug already excluded by
#1055 — so 8 rows are genuinely reachable. Note that `co2` and `ch4` are **not** among the rows that should pair:
`satellite-carbon-dioxide` already carries a hydrated `xco2` row owning that name, so pairing the `co2` placeholder
to it would duplicate the variable. Both correctly decline.

# Issues

- Closes #1089 — the hydrator pairs a lone slug with a lone variable on arity alone

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Reproduced the defect on `origin/main` first, then verified each acceptance criterion against the branch. Two full
`/review-rounds` passes ran over the diff; both rounds' findings are resolved.

- [x] `number-of-wet-days` × `elevation` is no longer paired
- [x] `2m-temperature` → `t2m` and `sea-surface-temperature` → `sst` still pair
- [x] the `all` pseudo-slug exclusion and the auxiliary filter from #1055 still hold
- [x] a sibling row's `nc_variable` is withheld, so a re-run cannot make two rows claim one variable
- [x] `test_ecmwf_hydrate.py` — 75 passed (was 29 on `main`)
- [x] targeted suite (`test_ecmwf_hydrate.py` + `libs/core/tests/cli/test_datasets.py`) — 147 passed
- [x] full non-e2e suite — 10026 passed, 14 skipped, 0 failed
- [x] doctests — 150 passed across `libs/providers/atmosphere/src`
- [x] branch coverage of `_hydrate.py` — 97%; every remaining miss is pre-existing code this branch does not touch
- [x] `ruff check` / `ruff format --check` clean (pinned v0.15.22), `mypy` clean across 407 source files
- [x] SonarCloud — 0 open issues on this PR's HEAD, quality gate OK

`test_order_fallback_pairs_leftovers` asserted the defect was correct behaviour — it required an unrelated variable
whose `long_name` was literally `"totally different"` to pair. It is replaced by the corrected expectation plus a
parametrized table over the known true and false positives.

**CI note:** three `e2e` legs are red — `rest-of-hazards`, `rest-of-ocean` and `stac`. They are unrelated to this
branch, which changes only `_hydrate.py`, its tests, `cli/datasets.py` and one docs page. Their failing tests live in
`hazards/tests/admin`, `hazards/tests/aqueduct`, `ocean/tests/argo`, `ocean/tests/caravan` and `imagery/tests/stac`,
none of the failing logs mention any symbol this branch touches, and the e2e workflow has been red on `main` for its
last several runs. The `e2e (ecmwf)` leg — the one that exercises this change — passes.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
