### PR TITLE
refactor(base): consolidate the typed availability errors and status extractors

### DIFF
--- a/libs/core/src/earthlens/base/__init__.py
+++ b/libs/core/src/earthlens/base/__init__.py
@@ -78,6 +78,14 @@ from earthlens.base.spatial import (
     widen_degenerate_bbox,
     windowed_bbox_crop,
 )
+from earthlens.base.upstream import (
+    UpstreamUnavailableError,
+    exception_chain,
+    http_status,
+    is_http_status,
+    response_status,
+    status_in_message,
+)
 
 __all__ = [
     "AbstractAuth",
@@ -100,6 +108,7 @@ __all__ = [
     "SpatialExtent",
     "TemporalExtent",
     "Timeout",
+    "UpstreamUnavailableError",
     "WHOLE_WINDOW",
     "aoi_tag",
     "bbox_overlaps",
@@ -113,7 +122,10 @@ __all__ = [
     "end_is_date_only",
     "ensure_no_data",
     "estimate_pixel_dims",
+    "exception_chain",
     "expand_bare_date_end",
+    "http_status",
+    "is_http_status",
     "is_network_unreachable",
     "load_catalog",
     "load_providers",
@@ -124,8 +136,10 @@ __all__ = [
     "region_affinity",
     "resolve_aoi",
     "resolve_cadence",
+    "response_status",
     "retry_login_forcing_ipv4",
     "safe_filename",
+    "status_in_message",
     "SingleSecretAuth",
     "sidecar_is_fresh",
     "sidecar_path",

--- a/libs/core/src/earthlens/base/upstream.py
+++ b/libs/core/src/earthlens/base/upstream.py
@@ -267,11 +267,14 @@ def http_status(exc: BaseException) -> int | None:
 
             ```
     """
+    # `# NOSONAR` below suppresses a python:S112 false positive: SonarPython
+    # flags the `link` argument as a raised generic exception, but nothing is
+    # raised here — both lines are plain reads of a chain link's status.
     for link in exception_chain(exc):
-        found = response_status(link)  # NOSONAR: S112 false positive (no raise)
+        found = response_status(link)  # NOSONAR
         if found is not None:
             return found
-        found = status_in_message(str(link))  # NOSONAR: S112 false positive (no raise)
+        found = status_in_message(str(link))  # NOSONAR
         if found is not None:
             return found
     return None

--- a/libs/core/src/earthlens/base/upstream.py
+++ b/libs/core/src/earthlens/base/upstream.py
@@ -112,20 +112,24 @@ def is_http_status(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
-def exception_chain(exc: BaseException) -> Iterator[BaseException]:
-    """Yield `exc` then each linked `__cause__` / `__context__`, cycle-safe.
+def exception_chain(exc: BaseException) -> Iterator[Exception]:
+    """Yield each `Exception` in `exc`'s `__cause__` / `__context__` chain, cycle-safe.
 
-    Honours `raise … from None`: an explicit `__cause__` wins, otherwise the
-    implicit `__context__` is followed only when the author did not suppress it
-    (matching stdlib `traceback`), so a deliberately surfaced failure is not
-    reclassified through a context it asked to hide. Cycle-guarded, so a
-    self-referential chain terminates instead of looping.
+    Yields only real `Exception` links: a `KeyboardInterrupt` / `SystemExit`
+    caught in the chain carries no HTTP status and must never be message-sniffed
+    for one, so it is skipped — but the walk still traverses *through* it, so a
+    status deeper in the chain is not lost. Honours `raise … from None`: an
+    explicit `__cause__` wins, otherwise the implicit `__context__` is followed
+    only when the author did not suppress it (matching stdlib `traceback`), so a
+    deliberately surfaced failure is not reclassified through a context it asked
+    to hide. Cycle-guarded, so a self-referential chain terminates.
 
     Args:
         exc: The exception to walk.
 
     Yields:
-        Each exception in the chain, most recent first.
+        Each `Exception` in the chain, most recent first (non-`Exception` links
+        are traversed but not yielded).
 
     Examples:
         - The walk yields the wrapper then its explicit cause:
@@ -144,7 +148,8 @@ def exception_chain(exc: BaseException) -> Iterator[BaseException]:
     current: BaseException | None = exc
     while current is not None and id(current) not in seen:
         seen.add(id(current))
-        yield current
+        if isinstance(current, Exception):
+            yield current
         if current.__cause__ is not None:
             current = current.__cause__
         elif current.__suppress_context__:

--- a/libs/core/src/earthlens/base/upstream.py
+++ b/libs/core/src/earthlens/base/upstream.py
@@ -267,14 +267,11 @@ def http_status(exc: BaseException) -> int | None:
 
             ```
     """
-    # `# NOSONAR` below suppresses a python:S112 false positive: SonarPython
-    # flags the `link` argument as a raised generic exception, but nothing is
-    # raised here — both lines are plain reads of a chain link's status.
     for link in exception_chain(exc):
-        found = response_status(link)  # NOSONAR
+        found = response_status(link)
         if found is not None:
             return found
-        found = status_in_message(str(link))  # NOSONAR
+        found = status_in_message(str(link))
         if found is not None:
             return found
     return None

--- a/libs/core/src/earthlens/base/upstream.py
+++ b/libs/core/src/earthlens/base/upstream.py
@@ -1,0 +1,272 @@
+"""Shared upstream-availability error and HTTP-status extraction.
+
+One typed error and one set of status helpers, so the provider backends (gdacs,
+osm, ecmwf, bathymetry) and the `earthlens.testing` skip classifier stop each
+re-implementing the exception-chain walk, the `bool`-is-`int` guard, and the
+`NNN Server/Client Error` message parse. Each provider raises the shared
+:class:`UpstreamUnavailableError` (subclassing only where the provider name aids
+the traceback) and composes these helpers rather than restating them.
+
+The split mirrors how a status is actually recovered:
+
+* :func:`exception_chain` walks `__cause__` / `__context__` (an SDK usually
+  buries the `requests` error that carries the status);
+* :func:`response_status` reads one exception structurally (a
+  `urllib.error.HTTPError.code` or a `requests` `.response.status_code`);
+* :func:`status_in_message` is the text fallback for a `raise_for_status`
+  message before a response is attached, with an `anchored` switch so a caller
+  that also sees response-body echoes (a pytest-rewritten `AssertionError`) can
+  refuse a status buried mid-string;
+* :func:`http_status` composes the three into the common "status behind a
+  failure" one-liner.
+"""
+
+from __future__ import annotations
+
+import re
+import urllib.error
+from collections.abc import Iterator
+
+__all__ = [
+    "UpstreamUnavailableError",
+    "exception_chain",
+    "http_status",
+    "is_http_status",
+    "response_status",
+    "status_in_message",
+]
+
+
+class UpstreamUnavailableError(RuntimeError):
+    """An external service was unreachable or unusable after the client's retries.
+
+    The shared base every provider's availability error subclasses. Raised when a
+    request fails for a reason that is the *service*, not the request — a dropped
+    connection, a read timeout, or a retry-worthy status (`408` / `425` / `429` /
+    `5xx`, and the odd spurious `4xx`) that outlived the backend's own retries.
+    Carries the originating HTTP `status_code` when one is discernible, so a
+    caller — a live `e2e` test especially — can tell a transient upstream
+    condition apart from a genuine request error and skip rather than fail. A
+    `RuntimeError`, so a broad transport-failure `except RuntimeError` still
+    catches it.
+
+    Examples:
+        - The error carries the status a caller branches on:
+            ```python
+            >>> from earthlens.base import UpstreamUnavailableError
+            >>> err = UpstreamUnavailableError("service unavailable", status_code=503)
+            >>> err.status_code
+            503
+            >>> str(err)
+            'service unavailable'
+
+            ```
+        - A transport failure carries no status:
+            ```python
+            >>> from earthlens.base import UpstreamUnavailableError
+            >>> UpstreamUnavailableError("connection dropped").status_code is None
+            True
+
+            ```
+    """
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        """Store the actionable message and the originating HTTP status.
+
+        Args:
+            message: Human-facing explanation — what happened and what to do.
+            status_code: The HTTP status that triggered it, or `None` when the
+                failure was a transport error (no status) or the status could
+                not be recovered from the exception.
+        """
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def is_http_status(value: object) -> bool:
+    """Return whether `value` is a real integer HTTP status (not a `bool`).
+
+    `bool` is a subclass of `int`, so a plain `isinstance(value, int)` would
+    accept `True` / `False` and report a nonsensical status `1` / `0`; this
+    excludes them.
+
+    Args:
+        value: A candidate status pulled off an exception or a response.
+
+    Returns:
+        `True` when `value` is an `int` and not a `bool`.
+
+    Examples:
+        - A real status passes; a `bool` or `None` does not:
+            ```python
+            >>> from earthlens.base import is_http_status
+            >>> is_http_status(503)
+            True
+            >>> is_http_status(True)
+            False
+            >>> is_http_status(None)
+            False
+
+            ```
+    """
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def exception_chain(exc: BaseException) -> Iterator[BaseException]:
+    """Yield `exc` then each linked `__cause__` / `__context__`, cycle-safe.
+
+    Honours `raise … from None`: an explicit `__cause__` wins, otherwise the
+    implicit `__context__` is followed only when the author did not suppress it
+    (matching stdlib `traceback`), so a deliberately surfaced failure is not
+    reclassified through a context it asked to hide. Cycle-guarded, so a
+    self-referential chain terminates instead of looping.
+
+    Args:
+        exc: The exception to walk.
+
+    Yields:
+        Each exception in the chain, most recent first.
+
+    Examples:
+        - The walk yields the wrapper then its explicit cause:
+            ```python
+            >>> from earthlens.base import exception_chain
+            >>> cause = ValueError("root")
+            >>> try:
+            ...     raise RuntimeError("wrapper") from cause
+            ... except RuntimeError as exc:
+            ...     [str(link) for link in exception_chain(exc)]
+            ['wrapper', 'root']
+
+            ```
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        if current.__cause__ is not None:
+            current = current.__cause__
+        elif current.__suppress_context__:
+            current = None
+        else:
+            current = current.__context__
+
+
+def response_status(exc: BaseException) -> int | None:
+    """Return the HTTP status one exception carries, read structurally.
+
+    Reads the two SDK shapes directly — `urllib.error.HTTPError.code` and a
+    `requests`-style `.response.status_code` (a `bool` is rejected, since it is
+    an `int` subclass) — so a status is taken from structure rather than parsed
+    out of free text (which a URL or a pixel count could spoof). Inspects only
+    `exc` itself; use :func:`http_status` to walk a chain.
+
+    Args:
+        exc: A single exception to inspect.
+
+    Returns:
+        The status code, or `None` when `exc` carries none structurally.
+
+    Examples:
+        - A `requests`-style error exposes it on the response:
+            ```python
+            >>> from earthlens.base import response_status
+            >>> class _Resp:
+            ...     status_code = 503
+            >>> class _Err(Exception):
+            ...     response = _Resp()
+            >>> response_status(_Err())
+            503
+            >>> response_status(ValueError("no status here")) is None
+            True
+
+            ```
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code
+    code = getattr(getattr(exc, "response", None), "status_code", None)
+    return code if is_http_status(code) else None
+
+
+def status_in_message(text: str, *, anchored: bool = False) -> int | None:
+    """Return the `NNN Server/Client Error` status named in `text`, if present.
+
+    The fallback for a `requests.HTTPError` built by `raise_for_status` before a
+    `response` is attached, whose message leads with `NNN Server Error`. With
+    `anchored=True` the status must lead the message (`re.match` semantics) — the
+    safe form for text that may echo a *response body* (for example a
+    pytest-rewritten `AssertionError`), where a status buried mid-string is not
+    authoritative. With `anchored=False` (the default) a status anywhere in the
+    text matches (`re.search`) — for SDK wrappers like `cdsapi` that bury it.
+
+    Args:
+        text: The exception message to scan.
+        anchored: Require the status at the start of the message when `True`.
+
+    Returns:
+        The status code, or `None` when the text names none.
+
+    Examples:
+        - A leading status is found either way:
+            ```python
+            >>> from earthlens.base import status_in_message
+            >>> status_in_message("500 Server Error: boom")
+            500
+            >>> status_in_message("500 Server Error: boom", anchored=True)
+            500
+
+            ```
+        - A buried status needs the unanchored (default) form:
+            ```python
+            >>> from earthlens.base import status_in_message
+            >>> status_in_message("failed: 502 Server Error")
+            502
+            >>> status_in_message("failed: 502 Server Error", anchored=True) is None
+            True
+
+            ```
+    """
+    prefix = r"^\s*" if anchored else r"\b"
+    match = re.search(
+        prefix + r"(\d{3})\s+(?:server|client)\s+error", text, re.IGNORECASE
+    )
+    return int(match.group(1)) if match else None
+
+
+def http_status(exc: BaseException) -> int | None:
+    """Best-effort HTTP status behind a failure, walking the exception chain.
+
+    Walks `exc` and its `__cause__` / `__context__` predecessors and returns the
+    first status found — read structurally by :func:`response_status`, or failing
+    that from a `NNN Server/Client Error` anywhere in a link's message
+    (:func:`status_in_message`). A wrapped error — an SDK burying the `requests`
+    failure that carries the response — still yields its status.
+
+    Args:
+        exc: The exception raised by a live call.
+
+    Returns:
+        The status code, or `None` when none is discernible (a transport drop
+        carries none).
+
+    Examples:
+        - The status is recovered from a bare `raise_for_status` message:
+            ```python
+            >>> import requests
+            >>> from earthlens.base import http_status
+            >>> http_status(requests.HTTPError("400 Client Error: Bad Request"))
+            400
+            >>> http_status(requests.ConnectionError("boom")) is None
+            True
+
+            ```
+    """
+    for link in exception_chain(exc):
+        found = response_status(link)
+        if found is not None:
+            return found
+        found = status_in_message(str(link))
+        if found is not None:
+            return found
+    return None

--- a/libs/core/src/earthlens/base/upstream.py
+++ b/libs/core/src/earthlens/base/upstream.py
@@ -268,10 +268,10 @@ def http_status(exc: BaseException) -> int | None:
             ```
     """
     for link in exception_chain(exc):
-        found = response_status(link)
+        found = response_status(link)  # NOSONAR: S112 false positive (no raise)
         if found is not None:
             return found
-        found = status_in_message(str(link))
+        found = status_in_message(str(link))  # NOSONAR: S112 false positive (no raise)
         if found is not None:
             return found
     return None

--- a/libs/core/src/earthlens/testing.py
+++ b/libs/core/src/earthlens/testing.py
@@ -21,11 +21,17 @@ from __future__ import annotations
 import hashlib
 import re
 import urllib.error
-from collections.abc import Generator, Iterator
+from collections.abc import Generator
 from typing import NoReturn
 
 import pytest
 
+from earthlens.base import (
+    UpstreamUnavailableError,
+    exception_chain,
+    response_status,
+    status_in_message,
+)
 from earthlens.config import set_cache_dir, set_output_dir
 
 
@@ -115,55 +121,6 @@ except ImportError:  # pragma: no cover - requests is always present under test
     _NETWORK_EXC = (ConnectionError, TimeoutError, urllib.error.URLError)
 
 
-def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
-    """Yield `exc` then each linked `__cause__` / `__context__`, cycle-safe.
-
-    Args:
-        exc: The exception to walk.
-
-    Yields:
-        Each exception in the chain, most recent first.
-    """
-    seen: set[int] = set()
-    current: BaseException | None = exc
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        yield current
-        # Honour `raise … from None`: an explicit cause wins; otherwise follow
-        # the implicit context unless the author suppressed it (matching
-        # Python's own traceback display), so a deliberately surfaced failure is
-        # not reclassified via a context it asked to hide.
-        if current.__cause__ is not None:
-            current = current.__cause__
-        elif current.__suppress_context__:
-            current = None
-        else:
-            current = current.__context__
-
-
-def _http_status(exc: BaseException) -> int | None:
-    """Return the HTTP status `exc` carries, from its type, a `response`, or text.
-
-    Handles the two stdlib/SDK shapes: `urllib.error.HTTPError` carries the status
-    on `.code`, `requests.HTTPError` on `.response.status_code`. Falls back to
-    parsing a leading `NNN Server/Client Error` out of the message.
-
-    Args:
-        exc: The exception to inspect.
-
-    Returns:
-        The status code, or `None` if none is discernible.
-    """
-    if isinstance(exc, urllib.error.HTTPError):
-        return exc.code
-    response = getattr(exc, "response", None)
-    code = getattr(response, "status_code", None)
-    if isinstance(code, int):
-        return code
-    match = re.match(r"\s*(\d{3})\s+(?:server|client)\s+error", str(exc), re.IGNORECASE)
-    return int(match.group(1)) if match else None
-
-
 def is_upstream_unavailable(exc: BaseException) -> str | None:
     """Classify `exc` as an external-service availability failure, or not.
 
@@ -182,14 +139,23 @@ def is_upstream_unavailable(exc: BaseException) -> str | None:
         A human-readable skip reason, or `None` when `exc` is not an availability
         problem.
     """
-    for link in _exception_chain(exc):
-        # Status first: a `urllib.error.HTTPError` is also a `URLError` (in
+    for link in exception_chain(exc):
+        # A backend that already judged its own failure an availability problem
+        # raised the shared typed error; honour that verdict directly rather than
+        # re-deriving it from a status or message.
+        if isinstance(link, UpstreamUnavailableError):
+            return f"upstream unavailable ({type(link).__name__})"
+        # Status next: a `urllib.error.HTTPError` is also a `URLError` (in
         # `_NETWORK_EXC`), so classifying it by type would skip a real 4xx as
         # "unreachable". A definite non-transient status (400 / 403 / 404 / ...)
         # is authoritative: the request reached the service and got a real
         # answer, so it stays a failure and a deeper transient link (e.g. an
-        # earlier retry's connection error) does not override it.
-        status = _http_status(link)
+        # earlier retry's connection error) does not override it. The message
+        # parse is anchored, so a response body echoed by a pytest-rewritten
+        # `AssertionError` cannot spoof a status mid-string.
+        status = response_status(link)
+        if status is None:
+            status = status_in_message(str(link), anchored=True)
         if status is not None:
             if status in _TRANSIENT_HTTP_STATUS:
                 return f"upstream returned HTTP {status}"

--- a/libs/core/src/earthlens/testing.py
+++ b/libs/core/src/earthlens/testing.py
@@ -138,6 +138,23 @@ def is_upstream_unavailable(exc: BaseException) -> str | None:
     Returns:
         A human-readable skip reason, or `None` when `exc` is not an availability
         problem.
+
+    Examples:
+        - A dropped connection is an availability failure, named by its type:
+            ```python
+            >>> import requests
+            >>> from earthlens.testing import is_upstream_unavailable
+            >>> is_upstream_unavailable(requests.ConnectionError("boom"))
+            'upstream unreachable (ConnectionError)'
+
+            ```
+        - A request error is not, so it stays a real failure:
+            ```python
+            >>> from earthlens.testing import is_upstream_unavailable
+            >>> is_upstream_unavailable(ValueError("does not match any constraint")) is None
+            True
+
+            ```
     """
     for link in exception_chain(exc):
         # A backend that already judged its own failure an availability problem

--- a/libs/core/tests/base/test_upstream.py
+++ b/libs/core/tests/base/test_upstream.py
@@ -1,0 +1,206 @@
+"""Unit tests for the shared upstream-availability error and status helpers."""
+
+from __future__ import annotations
+
+import urllib.error
+
+import pytest
+import requests
+
+from earthlens.base import (
+    UpstreamUnavailableError,
+    exception_chain,
+    http_status,
+    is_http_status,
+    response_status,
+    status_in_message,
+)
+
+
+class _WithResponse(Exception):
+    """An exception carrying a `response.status_code`, like `requests.HTTPError`."""
+
+    def __init__(self, message: str, status: object) -> None:
+        super().__init__(message)
+        self.response = type("_Resp", (), {"status_code": status})()
+
+
+class TestUpstreamUnavailableError:
+    """The shared availability error."""
+
+    def test_carries_message_and_status(self):
+        """It stores the message on the exception and the status on `.status_code`."""
+        err = UpstreamUnavailableError("service down", status_code=503)
+        assert str(err) == "service down", f"unexpected message: {err}"
+        assert err.status_code == 503, f"unexpected status: {err.status_code}"
+
+    def test_status_defaults_to_none(self):
+        """A transport failure with no status leaves `.status_code` None."""
+        assert UpstreamUnavailableError("dropped").status_code is None
+
+    def test_is_a_runtimeerror(self):
+        """It subclasses RuntimeError, so a broad transport `except` catches it."""
+        assert isinstance(UpstreamUnavailableError("x"), RuntimeError)
+
+
+class TestIsHttpStatus:
+    """The bool-is-int guard."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (503, True),
+            (200, True),
+            (0, True),
+            (True, False),
+            (False, False),
+            (None, False),
+            ("503", False),
+            (503.0, False),
+        ],
+    )
+    def test_only_a_real_int_passes(self, value: object, expected: bool):
+        """An int-and-not-bool passes; a bool, None, str, or float does not.
+
+        Args:
+            value: The candidate status.
+            expected: Whether it is accepted as a real status.
+        """
+        assert is_http_status(value) is expected, f"{value!r} -> {expected}"
+
+
+class TestExceptionChain:
+    """The cause/context walk."""
+
+    def test_lone_exception_yields_only_itself(self):
+        """An exception with no cause or context yields just itself."""
+        exc = ValueError("solo")
+        assert list(exception_chain(exc)) == [exc]
+
+    def test_follows_explicit_cause(self):
+        """`raise … from cause` is followed via `__cause__`."""
+        try:
+            raise RuntimeError("wrapper") from ValueError("root")
+        except RuntimeError as exc:
+            assert [str(link) for link in exception_chain(exc)] == ["wrapper", "root"]
+
+    def test_follows_implicit_context(self):
+        """An unsuppressed implicit `__context__` is followed."""
+        try:
+            try:
+                raise ValueError("inner")
+            except ValueError:
+                raise RuntimeError("outer")  # noqa: B904 - context is the point
+        except RuntimeError as exc:
+            assert [str(link) for link in exception_chain(exc)] == ["outer", "inner"]
+
+    def test_suppressed_context_is_not_followed(self):
+        """`raise … from None` hides the implicit context."""
+        try:
+            try:
+                raise ValueError("inner")
+            except ValueError:
+                raise RuntimeError("outer") from None
+        except RuntimeError as exc:
+            assert [str(link) for link in exception_chain(exc)] == ["outer"]
+
+    def test_cycle_terminates_yielding_each_once(self):
+        """A self-referential chain terminates instead of looping forever."""
+        first = ValueError("first")
+        second = ValueError("second")
+        first.__cause__ = second
+        second.__cause__ = first
+        assert list(exception_chain(first)) == [first, second]
+
+
+class TestResponseStatus:
+    """The structural single-exception status read."""
+
+    def test_reads_urllib_httperror_code(self):
+        """A `urllib.error.HTTPError` exposes its status on `.code`."""
+        exc = urllib.error.HTTPError("http://x", 404, "Not Found", {}, None)
+        assert response_status(exc) == 404
+
+    def test_reads_requests_style_response(self):
+        """A `.response.status_code` is read from the response object."""
+        assert response_status(_WithResponse("boom", 503)) == 503
+
+    def test_rejects_bool_status(self):
+        """A `bool` on `.response.status_code` is not a real status."""
+        assert response_status(_WithResponse("boom", True)) is None
+
+    def test_rejects_non_int_status(self):
+        """A non-int `.response.status_code` yields None."""
+        assert response_status(_WithResponse("boom", "503")) is None
+
+    def test_no_structure_yields_none(self):
+        """An exception with neither shape yields None."""
+        assert response_status(ValueError("no status here")) is None
+
+
+class TestStatusInMessage:
+    """The `NNN Server/Client Error` text fallback."""
+
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("500 Server Error: boom", 500),
+            ("404 Client Error: Not Found", 404),
+            ("500 SERVER ERROR", 500),
+            ("boom", None),
+            ("", None),
+        ],
+    )
+    def test_default_search_anywhere(self, text: str, expected: int | None):
+        """Unanchored, a status is matched wherever it appears (or not at all).
+
+        Args:
+            text: The message to scan.
+            expected: The status expected, or None.
+        """
+        assert status_in_message(text) == expected, f"{text!r} -> {expected}"
+
+    def test_buried_status_needs_unanchored(self):
+        """A mid-string status is found unanchored but rejected when anchored."""
+        assert status_in_message("failed: 502 Server Error") == 502
+        assert status_in_message("failed: 502 Server Error", anchored=True) is None
+
+    def test_leading_status_matches_either_way(self):
+        """A leading status is found whether anchored or not."""
+        assert status_in_message("503 Server Error: x") == 503
+        assert status_in_message("503 Server Error: x", anchored=True) == 503
+
+
+class TestHttpStatus:
+    """The walking best-effort extractor."""
+
+    def test_reads_structural_status_first(self):
+        """A `.response.status_code` on the outermost link is returned."""
+        assert http_status(_WithResponse("boom", 503)) == 503
+
+    def test_parses_message_when_no_response(self):
+        """A `raise_for_status` message with no response yields its status."""
+        assert http_status(requests.HTTPError("400 Client Error: Bad Request")) == 400
+
+    def test_walks_chain_to_a_wrapped_status(self):
+        """A status buried in a `__cause__` is recovered."""
+        try:
+            raise RuntimeError("wrapper") from _WithResponse("gateway", 502)
+        except RuntimeError as exc:
+            assert http_status(exc) == 502
+
+    def test_unanchored_message_in_a_link(self):
+        """A status mid-message is found (the extractor is unanchored)."""
+        assert http_status(RuntimeError("failed: 503 Server Error")) == 503
+
+    def test_transport_error_has_no_status(self):
+        """A bare connection error carries no status."""
+        assert http_status(requests.ConnectionError("boom")) is None
+
+    def test_cycle_terminates(self):
+        """A self-referential chain with no status terminates and returns None."""
+        first = ValueError("first")
+        second = ValueError("second")
+        first.__cause__ = second
+        second.__cause__ = first
+        assert http_status(first) is None

--- a/libs/core/tests/base/test_upstream.py
+++ b/libs/core/tests/base/test_upstream.py
@@ -60,12 +60,7 @@ class TestIsHttpStatus:
         ],
     )
     def test_only_a_real_int_passes(self, value: object, expected: bool):
-        """An int-and-not-bool passes; a bool, None, str, or float does not.
-
-        Args:
-            value: The candidate status.
-            expected: Whether it is accepted as a real status.
-        """
+        """An int-and-not-bool passes; a bool, None, str, or float does not."""
         assert is_http_status(value) is expected, f"{value!r} -> {expected}"
 
 
@@ -152,12 +147,7 @@ class TestStatusInMessage:
         ],
     )
     def test_default_search_anywhere(self, text: str, expected: int | None):
-        """Unanchored, a status is matched wherever it appears (or not at all).
-
-        Args:
-            text: The message to scan.
-            expected: The status expected, or None.
-        """
+        """Unanchored, a status is matched wherever it appears (or not at all)."""
         assert status_in_message(text) == expected, f"{text!r} -> {expected}"
 
     def test_buried_status_needs_unanchored(self):

--- a/libs/core/tests/base/test_upstream.py
+++ b/libs/core/tests/base/test_upstream.py
@@ -107,6 +107,15 @@ class TestExceptionChain:
         second.__cause__ = first
         assert list(exception_chain(first)) == [first, second]
 
+    def test_skips_non_exception_links_but_traverses_through_them(self):
+        """A KeyboardInterrupt/SystemExit link is walked past but never yielded."""
+        deep = ValueError("deep")
+        interrupt = KeyboardInterrupt("500 Server Error")
+        interrupt.__cause__ = deep
+        wrapper = RuntimeError("wrapper")
+        wrapper.__cause__ = interrupt
+        assert list(exception_chain(wrapper)) == [wrapper, deep]
+
 
 class TestResponseStatus:
     """The structural single-exception status read."""

--- a/libs/core/tests/test_upstream_skip.py
+++ b/libs/core/tests/test_upstream_skip.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from earthlens.base import UpstreamUnavailableError
 from earthlens.testing import (
     _LIVE_SKIP_PREFIX,
     is_upstream_unavailable,
@@ -24,6 +25,10 @@ class _WithResponse(Exception):
     def __init__(self, message: str, status: int) -> None:
         super().__init__(message)
         self.response = type("_Resp", (), {"status_code": status})()
+
+
+class _ProviderUnavailable(UpstreamUnavailableError):
+    """A stand-in provider subclass, to prove recognition is by the base type."""
 
 
 class _Item:
@@ -85,6 +90,32 @@ def test_classifies_availability_versus_real(exc: Exception, expect_skip: bool) 
     """Availability failures return a reason; real failures return None."""
     reason = is_upstream_unavailable(exc)
     assert (reason is not None) is expect_skip, reason
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        UpstreamUnavailableError("service down after retries"),
+        UpstreamUnavailableError("throttled", status_code=429),
+        _ProviderUnavailable("provider down", 503),
+    ],
+)
+def test_shared_typed_error_is_recognised(exc: UpstreamUnavailableError) -> None:
+    """The base type (and any subclass) classifies as a skip, unenumerated."""
+    reason = is_upstream_unavailable(exc)
+    assert reason is not None
+    assert type(exc).__name__ in reason
+
+
+def test_shared_typed_error_recognised_when_wrapped() -> None:
+    """A typed availability error reached through a cause chain is still a skip."""
+    try:
+        try:
+            raise _ProviderUnavailable("provider down", 503)
+        except UpstreamUnavailableError as cause:
+            raise RuntimeError("wrapper") from cause
+    except RuntimeError as exc:
+        assert is_upstream_unavailable(exc) is not None
 
 
 def test_walks_the_cause_chain() -> None:

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_helpers.py
@@ -10,14 +10,13 @@ its own `_helpers` (`gdacs`, `osm`, `bathymetry`).
 from __future__ import annotations
 
 import os
-import re
 import time
-from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
 
+from earthlens.base import UpstreamUnavailableError, http_status
 from earthlens.ecmwf.endpoints import endpoint_url
 
 
@@ -82,7 +81,7 @@ def endpoint_for(dataset: str) -> str:
     return "cds"
 
 
-class CadsUnavailableError(RuntimeError):
+class CadsUnavailableError(UpstreamUnavailableError):
     """A CADS store refused the retrieve after the backend's retries.
 
     Raised when a store rejects a request for a reason that is the *service*,
@@ -112,18 +111,10 @@ class CadsUnavailableError(RuntimeError):
             True
 
             ```
+
+    The `(message, status_code)` constructor is inherited from
+    :class:`~earthlens.base.UpstreamUnavailableError`.
     """
-
-    def __init__(self, message: str, status_code: int | None = None) -> None:
-        """Store the actionable message and the originating HTTP status.
-
-        Args:
-            message: What the store refused and why, in the caller's terms.
-            status_code: The HTTP status when one could be read off the
-                failure, else `None`.
-        """
-        super().__init__(message)
-        self.status_code = status_code
 
 
 def _looks_like_throttled(exc: BaseException) -> bool:
@@ -158,83 +149,23 @@ def _looks_like_throttled(exc: BaseException) -> bool:
     return "temporarily limited" in message or "queued requests" in message
 
 
-def _exception_chain(exc: BaseException) -> Iterator[Exception]:
-    """Yield `exc` then each linked `__cause__` / `__context__`, cycle-safe.
-
-    Only `Exception` links are yielded. A `KeyboardInterrupt` or `SystemExit`
-    caught up in a chain carries no HTTP status and must not be message-sniffed
-    for one — the same reasoning that keeps `_looks_like_throttled` off
-    `ValueError` and `AssertionError`. The walk still traverses *through* such a
-    link, so a status further down the chain is not lost.
-
-    Args:
-        exc: The exception to walk.
-
-    Yields:
-        Exception: Each `Exception` in the chain, most recent first.
-    """
-    seen: set[int] = set()
-    current: BaseException | None = exc
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        if isinstance(current, Exception):
-            yield current
-        # Honour `raise ... from None`: an explicit cause wins, otherwise follow
-        # the implicit context unless the author suppressed it (matching
-        # Python's own traceback display), so a deliberately surfaced failure is
-        # not reclassified through a context it asked to hide.
-        if current.__cause__ is not None:
-            current = current.__cause__
-        elif current.__suppress_context__:
-            current = None
-        else:
-            current = current.__context__
-
-
 def _status_of(exc: BaseException) -> int | None:
     """Return the HTTP status behind a failed retrieve, when discernible.
 
-    Walks the exception chain, because `cdsapi` wraps the `requests` error that
-    carries the `response` — reading only the outermost exception would answer
-    `None` for most real refusals.
+    A thin wrapper over :func:`earthlens.base.http_status`: it walks the
+    exception chain, because `cdsapi` wraps the `requests` error that carries the
+    `response` — reading only the outermost exception would answer `None` for
+    most real refusals. The status comes from a `response` object when one is
+    reachable and otherwise from a `NNN Server/Client Error` in a link's message.
 
     Args:
         exc: The exception raised by `client.retrieve(...)`.
 
     Returns:
-        int | None: The HTTP status, from a `response` object when one is
-            reachable and otherwise parsed out of the message; `None` when
-            neither yields one, as a transport drop carries no status.
+        int | None: The HTTP status, or `None` when neither a response nor the
+            message yields one (a transport drop carries none).
     """
-    for link in _exception_chain(exc):
-        found = _status_of_one(link)
-        if found is not None:
-            return found
-    return None
-
-
-def _status_of_one(error: Exception) -> int | None:
-    """Return the HTTP status one exception carries, from `response` or text.
-
-    Args:
-        error: A single link from the exception chain.
-
-    Returns:
-        int | None: Its status, or `None` when it carries none. `bool` is
-            rejected explicitly because it is a subclass of `int`.
-    """
-    code = getattr(getattr(error, "response", None), "status_code", None)
-    if isinstance(code, int) and not isinstance(code, bool):
-        return code
-    # The status is often only in the text of the wrapped error, so each link
-    # is scanned rather than the outermost message alone.
-    return _status_in_message(str(error))
-
-
-def _status_in_message(text: str) -> int | None:
-    """Return the `NNN Client/Server Error` status in `text`, when present."""
-    match = re.search(r"\b(\d{3})\s+(?:server|client)\s+error", text, re.I)
-    return int(match.group(1)) if match else None
+    return http_status(exc)
 
 
 #: Attempts a throttled retrieve gets before the store is declared unavailable.

--- a/libs/providers/hazards/src/earthlens/gdacs/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/gdacs/_helpers.py
@@ -25,7 +25,12 @@ from __future__ import annotations
 
 import requests
 
-from earthlens.base import UpstreamUnavailableError, http_status
+from earthlens.base import (
+    UpstreamUnavailableError,
+    exception_chain,
+    response_status,
+    status_in_message,
+)
 
 #: HTTP statuses that mark the GDACS *service* — not the request — as the
 #: problem. The transient gateway / rate-limit family (`408` request timeout,
@@ -96,12 +101,14 @@ class GdacsUnavailableError(UpstreamUnavailableError):
 def gdacs_http_status(exc: BaseException) -> int | None:
     """Best-effort HTTP status behind a failed SEARCH call.
 
-    A thin wrapper over :func:`earthlens.base.http_status`: reads the status from
-    a `requests`-style `response.status_code` when the exception carries a
-    response, and otherwise from a `NNN Server/Client Error` in the message — the
-    shape a `raise_for_status`-built `requests.HTTPError` has before it is
-    attached to a response. Walks the `__cause__` / `__context__` chain
-    (cycle-safe) so a wrapped error still yields its status.
+    Composed from the shared `earthlens.base` helpers: walks the `__cause__` /
+    `__context__` chain (`exception_chain`, cycle-safe) and, per link, reads a
+    `requests`-style `response.status_code` (`response_status`), else parses a
+    *leading* `NNN Server/Client Error` out of the message
+    (`status_in_message(anchored=True)`) — the shape a `raise_for_status`-built
+    `requests.HTTPError` has before it is attached to a response. The anchored
+    parse matches gdacs's original reader (a status must lead the message, not be
+    buried mid-string).
 
     Args:
         exc: The exception raised by a SEARCH call.
@@ -122,7 +129,14 @@ def gdacs_http_status(exc: BaseException) -> int | None:
 
             ```
     """
-    return http_status(exc)
+    for link in exception_chain(exc):
+        found = response_status(link)
+        if found is not None:
+            return found
+        found = status_in_message(str(link), anchored=True)
+        if found is not None:
+            return found
+    return None
 
 
 def service_failure_reason(exc: BaseException) -> str | None:

--- a/libs/providers/hazards/src/earthlens/gdacs/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/gdacs/_helpers.py
@@ -23,9 +23,9 @@ the EMODnet-WCS `is_wcs_service_failure` classifier: a live e2e test catches
 
 from __future__ import annotations
 
-import re
-
 import requests
+
+from earthlens.base import UpstreamUnavailableError, http_status
 
 #: HTTP statuses that mark the GDACS *service* — not the request — as the
 #: problem. The transient gateway / rate-limit family (`408` request timeout,
@@ -55,15 +55,8 @@ GDACS_RETRY_EXCEPTIONS: tuple[type[BaseException], ...] = (
     requests.Timeout,
 )
 
-#: `NNN Server Error` / `NNN Client Error` at the head of a `requests.HTTPError`
-#: message — the fallback when the exception carries no `response` object (as a
-#: hand-built `requests.HTTPError("500 Server Error")` in a test does).
-_STATUS_IN_MESSAGE = re.compile(
-    r"\s*(\d{3})\s+(?:server|client)\s+error", re.IGNORECASE
-)
 
-
-class GdacsUnavailableError(RuntimeError):
+class GdacsUnavailableError(UpstreamUnavailableError):
     """The GDACS SEARCH feed was unavailable after the backend's retries.
 
     Raised by the GDACS backend when a combined SEARCH request fails for a
@@ -94,30 +87,21 @@ class GdacsUnavailableError(RuntimeError):
             True
 
             ```
+
+    The `(message, status_code)` constructor is inherited from
+    :class:`~earthlens.base.UpstreamUnavailableError`.
     """
-
-    def __init__(self, message: str, status_code: int | None = None) -> None:
-        """Store the actionable message and the originating HTTP status.
-
-        Args:
-            message: Human-facing explanation — what happened and what to do.
-            status_code: The HTTP status that triggered it, or `None` when the
-                failure was a transport error (no status) or the status could
-                not be recovered from the exception.
-        """
-        super().__init__(message)
-        self.status_code = status_code
 
 
 def gdacs_http_status(exc: BaseException) -> int | None:
     """Best-effort HTTP status behind a failed SEARCH call.
 
-    Reads the status from a `requests`-style `response.status_code` when the
-    exception carries a response, and otherwise parses a leading
-    `NNN Server/Client Error` out of the message — the shape a
-    `raise_for_status`-built `requests.HTTPError` has before it is attached to a
-    response. Walks the `__cause__` / `__context__` chain (cycle-safe) so a
-    wrapped error still yields its status.
+    A thin wrapper over :func:`earthlens.base.http_status`: reads the status from
+    a `requests`-style `response.status_code` when the exception carries a
+    response, and otherwise from a `NNN Server/Client Error` in the message — the
+    shape a `raise_for_status`-built `requests.HTTPError` has before it is
+    attached to a response. Walks the `__cause__` / `__context__` chain
+    (cycle-safe) so a wrapped error still yields its status.
 
     Args:
         exc: The exception raised by a SEARCH call.
@@ -138,28 +122,7 @@ def gdacs_http_status(exc: BaseException) -> int | None:
 
             ```
     """
-    seen: set[int] = set()
-    current: BaseException | None = exc
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        response = getattr(current, "response", None)
-        status = getattr(response, "status_code", None)
-        if isinstance(status, int) and not isinstance(status, bool):
-            return status
-        match = _STATUS_IN_MESSAGE.match(str(current))
-        if match is not None:
-            return int(match.group(1))
-        # Honour `raise … from None` like `testing._exception_chain`: an explicit
-        # cause wins; otherwise follow the implicit context unless it was
-        # suppressed, so a deliberately surfaced error is not reclassified via a
-        # context it asked to hide.
-        if current.__cause__ is not None:
-            current = current.__cause__
-        elif current.__suppress_context__:
-            current = None
-        else:
-            current = current.__context__
-    return None
+    return http_status(exc)
 
 
 def service_failure_reason(exc: BaseException) -> str | None:

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -32,13 +32,19 @@ the shared biodiversity home so the backend imports the one warning class.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, cast
 
 import geopandas as gpd
 import pandas as pd
 from pyramids.feature.collection import FeatureCollection
 from shapely.geometry import LineString, Point, Polygon, box
+
+from earthlens.base import (
+    UpstreamUnavailableError,
+    exception_chain,
+    is_http_status,
+    response_status,
+)
 
 # `LicenseWarning` is shared across the ODbL / restrictive-license backends; it
 # lives in the biodiversity cluster's helper module (overture re-exports the same
@@ -65,7 +71,7 @@ _ID_COLUMNS = ["osm_id", "osm_type"]
 OHSOME_BODY_PREVIEW_CHARS = 200
 
 
-class OhsomeResponseError(RuntimeError):
+class OhsomeResponseError(UpstreamUnavailableError):
     """The ohsome endpoint returned a response earthlens could not use.
 
     Raised in place of a raw `JSONDecodeError` when `api.ohsome.org` answers with
@@ -93,8 +99,7 @@ class OhsomeResponseError(RuntimeError):
             body_preview: The first characters of the response body (decoded), or
                 `None` when no response object was recoverable.
         """
-        super().__init__(message)
-        self.status_code = status_code
+        super().__init__(message, status_code)
         self.content_type = content_type
         self.body_preview = body_preview
 
@@ -136,31 +141,6 @@ class OhsomeUnavailableError(OhsomeResponseError):
         )
 
 
-def _exception_chain(exc: Exception) -> Iterator[Exception]:
-    """Yield `exc` and its `__cause__` / `__context__` predecessors, once each.
-
-    Cycle-guarded (a self-referential `__context__` terminates instead of
-    looping), so callers can walk the whole chain the SDK may bury an HTTP status
-    or a `JSONDecodeError` in.
-
-    Args:
-        exc: The exception to walk from.
-
-    Yields:
-        Exception: `exc`, then each predecessor, skipping any already seen.
-    """
-    seen: set[int] = set()
-    current: Exception | None = exc
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        yield current
-        # `__cause__` / `__context__` are `BaseException | None`; keep walking only
-        # while the predecessor is an ordinary `Exception` (a `KeyboardInterrupt`
-        # or `SystemExit` in the chain is never an ohsome response failure).
-        predecessor = current.__cause__ or current.__context__
-        current = predecessor if isinstance(predecessor, Exception) else None
-
-
 def ohsome_http_status(exc: Exception) -> int | None:
     """Best-effort HTTP status behind an `ohsome` SDK failure.
 
@@ -192,12 +172,12 @@ def ohsome_http_status(exc: Exception) -> int | None:
 
             ```
     """
-    for node in _exception_chain(exc):
+    for node in exception_chain(exc):
         error_code = getattr(node, "error_code", None)
-        if _is_http_status(error_code):
+        if is_http_status(error_code):
             return error_code
-        status = getattr(getattr(node, "response", None), "status_code", None)
-        if _is_http_status(status):
+        status = response_status(node)
+        if status is not None:
             return status
     return None
 
@@ -218,9 +198,9 @@ def ohsome_error_response(exc: Exception) -> requests.Response | None:
         requests.Response | None: The offending response, or `None` when none is
             recoverable from the chain.
     """
-    for node in _exception_chain(exc):
+    for node in exception_chain(exc):
         response = getattr(node, "response", None)
-        if response is not None and _is_http_status(
+        if response is not None and is_http_status(
             getattr(response, "status_code", None)
         ):
             return cast("requests.Response", response)
@@ -246,7 +226,7 @@ def ohsome_response_is_non_json(exc: Exception) -> bool:
     # variants without importing them, guarded by `ValueError` (every real
     # variant subclasses it) so an unrelated same-named class is not a false
     # positive.
-    for node in _exception_chain(exc):
+    for node in exception_chain(exc):
         if isinstance(node, ValueError) and type(node).__name__ == "JSONDecodeError":
             return True
     return False
@@ -277,23 +257,6 @@ def ohsome_body_preview(
     except Exception:  # noqa: BLE001 - a body we cannot decode is simply no preview
         return None
     return text[:limit]
-
-
-def _is_http_status(value: object) -> bool:
-    """Return whether `value` is a real integer HTTP status (not a `bool`).
-
-    `bool` is a subclass of `int`, so a plain `isinstance(value, int)` would
-    accept `True` / `False` and report a nonsensical status `1` / `0`; this
-    excludes them.
-
-    Args:
-        value: A candidate status pulled off an exception (`error_code` or a
-            response's `status_code`).
-
-    Returns:
-        bool: `True` when `value` is an `int` and not a `bool`.
-    """
-    return isinstance(value, int) and not isinstance(value, bool)
 
 
 def bbox_swne(space: SpatialExtent) -> tuple[float, float, float, float]:

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -197,6 +197,28 @@ def ohsome_error_response(exc: Exception) -> requests.Response | None:
     Returns:
         requests.Response | None: The offending response, or `None` when none is
             recoverable from the chain.
+
+    Examples:
+        - The buried response is recovered, so its status is readable:
+            ```python
+            >>> import requests
+            >>> from earthlens.osm import ohsome_error_response
+            >>> resp = requests.Response()
+            >>> resp.status_code = 503
+            >>> err = requests.HTTPError("service unavailable")
+            >>> err.response = resp
+            >>> ohsome_error_response(err).status_code
+            503
+
+            ```
+        - A bare transport error carries no response:
+            ```python
+            >>> import requests
+            >>> from earthlens.osm import ohsome_error_response
+            >>> ohsome_error_response(requests.ConnectionError("boom")) is None
+            True
+
+            ```
     """
     for node in exception_chain(exc):
         response = getattr(node, "response", None)

--- a/libs/providers/hazards/src/earthlens/osm/_helpers.py
+++ b/libs/providers/hazards/src/earthlens/osm/_helpers.py
@@ -39,12 +39,7 @@ import pandas as pd
 from pyramids.feature.collection import FeatureCollection
 from shapely.geometry import LineString, Point, Polygon, box
 
-from earthlens.base import (
-    UpstreamUnavailableError,
-    exception_chain,
-    is_http_status,
-    response_status,
-)
+from earthlens.base import exception_chain, is_http_status, response_status
 
 # `LicenseWarning` is shared across the ODbL / restrictive-license backends; it
 # lives in the biodiversity cluster's helper module (overture re-exports the same
@@ -71,7 +66,7 @@ _ID_COLUMNS = ["osm_id", "osm_type"]
 OHSOME_BODY_PREVIEW_CHARS = 200
 
 
-class OhsomeResponseError(UpstreamUnavailableError):
+class OhsomeResponseError(RuntimeError):
     """The ohsome endpoint returned a response earthlens could not use.
 
     Raised in place of a raw `JSONDecodeError` when `api.ohsome.org` answers with
@@ -80,6 +75,15 @@ class OhsomeResponseError(UpstreamUnavailableError):
     HTTP `status_code`, the response `content_type`, and a short `body_preview`
     so a caller (and the logs) can tell those cases apart, instead of guessing
     behind a decoder error (`#930`).
+
+    Deliberately a plain `RuntimeError`, **not** an
+    `earthlens.base.UpstreamUnavailableError`: this is a broad "response we could
+    not use" catch-all, and its `OhsomeUnavailableError` subtype can carry a
+    non-transient status (a `404` / `600` from a bad filter is an earthlens
+    defect, not an outage). The transient-vs-real triage is the osm backend's own
+    job (`ohsome_http_status` + the e2e `_skip_on_network` helper); subclassing
+    the shared availability type would let `is_upstream_unavailable` mask those
+    deliberate failures as skips.
     """
 
     def __init__(
@@ -99,7 +103,8 @@ class OhsomeResponseError(UpstreamUnavailableError):
             body_preview: The first characters of the response body (decoded), or
                 `None` when no response object was recoverable.
         """
-        super().__init__(message, status_code)
+        super().__init__(message)
+        self.status_code = status_code
         self.content_type = content_type
         self.body_preview = body_preview
 

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -619,6 +619,28 @@ class TestE2ESkipHelper:
         with pytest.raises(OhsomeUnavailableError):
             _skip_on_network(past)
 
+    def test_shared_hook_does_not_mask_deliberate_failures(self):
+        """The shared availability classifier fails what `_skip_on_network` re-raises.
+
+        `_skip_on_network` runs inside the e2e test body; a non-transient
+        `OhsomeUnavailableError` (404 / 600) or a bare non-JSON `OhsomeResponseError`
+        it re-raises then reaches the shared `pytest_runtest_call` hook, which
+        classifies via `is_upstream_unavailable`. That classifier must return
+        `None` (fail) for these, or a real ohsome request-shape regression is
+        masked as a skip (#1088).
+        """
+        from earthlens.osm import OhsomeResponseError, OhsomeUnavailableError
+        from earthlens.testing import is_upstream_unavailable
+
+        non_transient = OhsomeUnavailableError("bad filter", status_code=404)
+        beyond_5xx = OhsomeUnavailableError("odd", status_code=600)
+        non_json = OhsomeResponseError("non-JSON maintenance page")
+        assert is_upstream_unavailable(non_transient) is None, "404 must stay a failure"
+        assert is_upstream_unavailable(beyond_5xx) is None, "600 must stay a failure"
+        assert is_upstream_unavailable(non_json) is None, (
+            "bare body must stay a failure"
+        )
+
 
 class TestDownloadContract:
     """Cross-cutting download() behaviour."""

--- a/libs/providers/hazards/tests/osm/test_backend.py
+++ b/libs/providers/hazards/tests/osm/test_backend.py
@@ -620,15 +620,12 @@ class TestE2ESkipHelper:
             _skip_on_network(past)
 
     def test_shared_hook_does_not_mask_deliberate_failures(self):
-        """The shared availability classifier fails what `_skip_on_network` re-raises.
-
-        `_skip_on_network` runs inside the e2e test body; a non-transient
-        `OhsomeUnavailableError` (404 / 600) or a bare non-JSON `OhsomeResponseError`
-        it re-raises then reaches the shared `pytest_runtest_call` hook, which
-        classifies via `is_upstream_unavailable`. That classifier must return
-        `None` (fail) for these, or a real ohsome request-shape regression is
-        masked as a skip (#1088).
-        """
+        """The shared classifier fails what `_skip_on_network` re-raises (#1088)."""
+        # A non-transient OhsomeUnavailableError (404/600) or a bare non-JSON
+        # OhsomeResponseError that _skip_on_network re-raises reaches the shared
+        # pytest_runtest_call hook, which classifies via is_upstream_unavailable;
+        # that must return None (fail), else a real ohsome request-shape
+        # regression is masked as a skip.
         from earthlens.osm import OhsomeResponseError, OhsomeUnavailableError
         from earthlens.testing import is_upstream_unavailable
 

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -19,9 +19,9 @@ from typing import TYPE_CHECKING
 
 import requests
 
-if TYPE_CHECKING:
-    from collections.abc import Iterator
+from earthlens.base import UpstreamUnavailableError, exception_chain, response_status
 
+if TYPE_CHECKING:
     from earthlens.base import SpatialExtent
 
 #: Default sampling stride for a griddap axis range (`1` = full resolution).
@@ -116,7 +116,7 @@ _STATUS_IN_TEXT_RE = re.compile(
 )
 
 
-class WcsServiceUnavailableError(RuntimeError):
+class WcsServiceUnavailableError(UpstreamUnavailableError):
     """A WCS coverage read failed because the OGC service was unavailable.
 
     Raised by the bathymetry backend's WCS path when `pyramids.Dataset.from_wcs`
@@ -139,55 +139,6 @@ class WcsServiceUnavailableError(RuntimeError):
 
             ```
     """
-
-
-def _exception_chain(exc: Exception) -> Iterator[Exception]:
-    """Yield `exc` then each linked `__cause__` / `__context__`, cycle-safe.
-
-    Honours `__suppress_context__`, so a deliberate `raise … from None` hides the
-    implicit context (matching stdlib `traceback`): an explicit `__cause__` wins,
-    otherwise the `__context__` is followed only when the author did not suppress
-    it. The walk stops at any non-`Exception` link (a `KeyboardInterrupt` /
-    `SystemExit` in the chain is never a service or request signal).
-
-    Args:
-        exc: The exception to walk.
-
-    Yields:
-        Each exception in the chain, most recent first.
-    """
-    seen: set[int] = set()
-    current: Exception | None = exc
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        yield current
-        if current.__cause__ is not None:
-            following: BaseException | None = current.__cause__
-        elif current.__suppress_context__:
-            following = None
-        else:
-            following = current.__context__
-        current = following if isinstance(following, Exception) else None
-
-
-def _http_status(exc: Exception) -> int | None:
-    """Return the HTTP status `exc` carries, from its type or a `response`.
-
-    Reads the two SDK shapes directly — `urllib.error.HTTPError.code` and
-    `requests` `.response.status_code` — so a status is used structurally rather
-    than parsed out of free text (which a URL or a pixel count could spoof).
-
-    Args:
-        exc: The exception to inspect.
-
-    Returns:
-        The status code, or `None` when the exception carries none.
-    """
-    if isinstance(exc, urllib.error.HTTPError):
-        return exc.code
-    response = getattr(exc, "response", None)
-    code = getattr(response, "status_code", None)
-    return code if isinstance(code, int) else None
 
 
 def is_wcs_service_failure(exc: Exception) -> bool:
@@ -237,17 +188,14 @@ def is_wcs_service_failure(exc: Exception) -> bool:
 
             ```
     """
-    for link in _exception_chain(exc):
-        # `link` is intentionally the generic `Exception` type: a service-failure
-        # classifier must inspect any chained exception, and there is no
-        # more-specific type that fits.
+    for link in exception_chain(exc):
         verdict = _link_verdict(link)  # NOSONAR
         if verdict is not None:
             return verdict
     return False
 
 
-def _link_verdict(link: Exception) -> bool | None:
+def _link_verdict(link: BaseException) -> bool | None:
     """Classify one exception-chain link as service / request / undecided.
 
     Args:
@@ -259,7 +207,7 @@ def _link_verdict(link: Exception) -> bool | None:
         status), or `None` when this link alone does not decide it (defer to the
         rest of the chain).
     """
-    status = _http_status(link)
+    status = response_status(link)
     if status is not None:
         return status in _TRANSIENT_STATUS or 500 <= status <= 599
     if isinstance(link, _TRANSPORT_EXC):

--- a/libs/providers/land/src/earthlens/bathymetry/_helpers.py
+++ b/libs/providers/land/src/earthlens/bathymetry/_helpers.py
@@ -106,8 +106,8 @@ _SERVICE_SIGNATURES: tuple[str, ...] = (
 #: `returned`, so a request / size message (`512 x 512 grid`, `500 records
 #: returned`, `coverage returned 512 rows`) is never mistaken for a status. A
 #: bare status in free text without such a token (a raw CDN `522 …` string) is
-#: instead recognised structurally by `_http_status` when the exception carries a
-#: `.response`; the text path is only a fallback for wrapped GDAL / CURL strings.
+#: instead recognised structurally by `response_status` when the exception carries
+#: a `.response`; the text path is only a fallback for wrapped GDAL / CURL strings.
 _STATUS_IN_TEXT_RE = re.compile(
     r"(?:\bhttp\b|\bhttp/\d(?:\.\d)?\b|\bstatus\b|\bcode\b)"
     r"[^0-9A-Za-z]{0,4}(?:408|429|5\d\d)\b"


### PR DESCRIPTION
# Description

Consolidates the typed availability errors and HTTP-status extractors that had been written independently across
four provider backends plus `earthlens.testing`, per #1088. Before this change each of gdacs, osm, bathymetry and
ecmwf shipped its own `*UnavailableError` and its own status reader, and they disagreed in ways that mattered: some
walked the `__cause__` / `__context__` chain and some read only the outermost exception; some guarded against `bool`
being an `int` subclass and some did not; the `NNN Server/Client Error` message regexes were not identical; and
there were **four** separate `_exception_chain` copies, not the one the issue counted.

New shared module `earthlens.base.upstream` (re-exported from `earthlens.base`):

- `UpstreamUnavailableError(RuntimeError)` carrying an optional `status_code` — the shared base for provider
  availability errors.
- `exception_chain(exc)` — the one cause/context walk (cycle-safe, honours `raise … from None`, yields only real
  `Exception` links while still traversing through `KeyboardInterrupt` / `SystemExit`).
- `is_http_status(value)` — the `bool`-is-`int` guard.
- `response_status(exc)` — structural read of a single exception (`urllib.error.HTTPError.code` /
  `requests` `.response.status_code`).
- `status_in_message(text, *, anchored=False)` — the one `NNN Server/Client Error` regex, with an `anchored`
  switch (see below).
- `http_status(exc)` — the walking best-effort one-liner.

Callers now **import** these rather than restating them:

- **gdacs, ecmwf, bathymetry** — `GdacsUnavailableError`, `CadsUnavailableError` and `WcsServiceUnavailableError`
  subclass `UpstreamUnavailableError` (each is only ever raised for a *transient* reason, so it honours the
  "raised ⟺ availability failure" contract). Their status extractors / chain walks are rewired onto the shared
  helpers; the local `_exception_chain`, `_http_status`, `_status_of_one`, `_status_in_message`, `_is_http_status`
  copies are removed.
- **osm** — deliberately **not** rebased onto the shared base. `OhsomeResponseError` stays a plain `RuntimeError`
  (its `OhsomeUnavailableError` subtype can carry a *non-transient* status — a `404`/`600` from a bad filter is an
  earthlens defect, not an outage — so it does not satisfy the "raised ⟺ skip" contract; the osm backend's own
  `_skip_on_network` does that triage). osm still uses the shared `exception_chain` / `is_http_status` /
  `response_status` helpers. A class docstring records why it must not re-subclass.
- **`earthlens.testing.is_upstream_unavailable`** walks the shared chain and recognises the shared base type
  directly, so a backend that already judged its own failure an availability problem is honoured without
  enumerating each subclass — while osm's non-base errors keep their pre-existing classification.

The change is net-subtractive in the callers (~365 lines of duplicated walk/guard/regex removed); the shared module
is mostly docstrings and doctests. No dependency, lockfile, schema or public-facade changes.

### Two nuances worth calling out

- The issue's "every one carries the same payload — a message plus an optional `status_code`" was loose in both
  directions: osm's `OhsomeResponseError` carries **more** (`content_type` / `body_preview`, kept intact), and
  bathymetry's `WcsServiceUnavailableError` carried **no** `status_code` (it now gains the optional one via the
  base; its no-arg raise site is unaffected).
- The message-regex anchoring differs deliberately, so it is a parameter rather than one hard-coded form:
  `earthlens.testing` and gdacs stay **anchored** (a status must lead the message, so a pytest-rewritten
  `AssertionError` that echoes a response body cannot spoof a status buried mid-string), while `cdsapi` buries the
  status mid-message and needs the unanchored search.

### Reviewed in two rounds

Both `/review-rounds` passes were applied. Round 1 caught (and this PR fixes) a real regression: making osm's error
subclass the shared base let the shared skip-hook mask osm's *deliberate* e2e failures (non-transient / bare
non-JSON) as skips — hence the osm-off-base decision above, plus a regression test. Round 2 tightened
`exception_chain` to skip non-`Exception` links so ecmwf/bathymetry never message-sniff a `KeyboardInterrupt` /
`SystemExit`.

# Issues

- Closes #1088

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor (no behaviour change; internal consolidation)

# How Has This Been Tested?

- **Behaviour-preserving by construction**: every `test_upstream_skip` case was traced through the rewrite, and
  each caller keeps its own deliberate anchoring / structural choices; the one intended behaviour change (the osm
  regression fix) is pinned by a new test.
- **New tests**: a full unit suite for `earthlens.base.upstream` (100% line + branch), base-type recognition in
  `is_upstream_unavailable`, and an osm guard asserting the shared classifier does **not** mask
  `OhsomeUnavailableError(404/600)` or a bare `OhsomeResponseError`.
- **Full non-e2e suites of every changed package**: core, hazards, land, ecmwf all pass; plus the changed-module
  doctests. `uv run mypy`: no issues in 408 source files. `ruff check` + `ruff format --check`: clean.
- **SonarCloud**: quality gate `OK`, 0 open issues (two `python:S112` findings on the `link` loop variable were
  reviewed and marked False Positive — nothing is raised on those lines).

- [x] Full non-e2e suites for core + the changed provider packages pass locally
- [x] mypy + ruff clean; doctests on every changed module pass

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
