### PR TITLE
fix(eea_aq): mask EEA no-data sentinels to NaN

### DIFF
--- a/libs/providers/atmosphere/src/earthlens/eea_aq/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/_helpers.py
@@ -126,6 +126,14 @@ SCHEMA: dict[str, str] = {
     "provider": "object",
 }
 
+#: `Value` literals the EEA writes to mean "no reading" rather than a real
+#: concentration. The legacy Historical export fills an invalid row's `Value`
+#: with `-999`; a negatively-flagged row is masked regardless of its value, so
+#: this set is consulted only to catch a sentinel on a row whose `Validity`
+#: flag is null (where the flag cannot betray it). Kept deliberately small — a
+#: real reading must never be clipped — so it lists only the documented `-999`.
+_NODATA_SENTINELS: frozenset[float] = frozenset({-999.0})
+
 
 def countries_in_bbox(
     lat_lim: tuple[float, float],
@@ -271,6 +279,15 @@ def shape_frame(
     to UTC. Rows whose numeric code is not in `code_to_name` are dropped
     (a pollutant the request did not ask for).
 
+    A reading the EEA does not vouch for has its `value` masked to `NaN` so
+    a no-data sentinel never masquerades as a measured concentration: a row
+    with a negative `Validity` flag (`-1` invalid, `-99` maintenance) is
+    masked whatever its `Value` (catching both the `-999` sentinel and the
+    plain `0.0` some invalid rows carry), and a row with a null flag is
+    masked when its `Value` is a known sentinel. The flag itself is kept in
+    `validity`; valid rows keep their published value, small near-zero
+    negatives included.
+
     Args:
         raw: One Parquet file read with `pandas.read_parquet`.
         dataset: The dataset era this frame came from (`"Verified"`),
@@ -308,6 +325,18 @@ def shape_frame(
     out["agg_type"] = keep["AggType"]
     out["validity"] = keep["Validity"].astype("Int64")
     out["verification"] = keep["Verification"].astype("Int64")
+    # Mask no-data readings to NaN so a caller's mean / percentile is not
+    # silently skewed by them; a bare `value.dropna()` cannot help because the
+    # sentinels are numbers, not nulls. EEA flags a reading it does not vouch
+    # for with a negative `Validity` (-1 invalid, -99 maintenance) and fills its
+    # `Value` with a sentinel (-999) or a plain 0.0 -- gate on the flag, not the
+    # literal, so both are caught, while the flag itself is preserved in
+    # `validity`. A null flag is trusted for neither verdict, so a null-flag row
+    # is masked only when its value is a known sentinel, leaving a genuine
+    # reading that merely lacks a flag untouched.
+    invalid_flag = (out["validity"] < 0).fillna(False)
+    unflagged_sentinel = out["validity"].isna() & out["value"].isin(_NODATA_SENTINELS)
+    out.loc[invalid_flag | unflagged_sentinel, "value"] = pd.NA
     out["dataset"] = dataset
     out["provider"] = "EEA"
     return out.reset_index(drop=True).astype(SCHEMA)

--- a/libs/providers/atmosphere/src/earthlens/eea_aq/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/_helpers.py
@@ -296,6 +296,34 @@ def shape_frame(
 
     Returns:
         pd.DataFrame: The frame in the `SCHEMA` columns / dtypes.
+
+    Examples:
+        - A valid reading is kept while an invalid `-999` sentinel is masked to
+          `NaN`, its `-1` flag preserved in `validity`:
+            ```python
+            >>> import pandas as pd
+            >>> from earthlens.eea_aq._helpers import shape_frame
+            >>> raw = pd.DataFrame(
+            ...     {
+            ...         "Samplingpoint": ["MT/SPO-1", "MT/SPO-1"],
+            ...         "Pollutant": [6001, 6001],
+            ...         "Start": pd.to_datetime(["2011-06-01", "2011-06-01"]),
+            ...         "Value": ["14.6", "-999"],
+            ...         "Unit": ["ug.m-3", "ug.m-3"],
+            ...         "AggType": ["hour", "hour"],
+            ...         "Validity": [1, -1],
+            ...         "Verification": [3, 3],
+            ...     }
+            ... )
+            >>> out = shape_frame(raw, "Historical", {6001: "pm25"})
+            >>> out["value"].tolist()
+            [14.6, nan]
+            >>> out["validity"].tolist()
+            [1, -1]
+            >>> out["parameter"].tolist()
+            ['pm25', 'pm25']
+
+            ```
     """
     if raw.empty:
         return empty_frame()

--- a/libs/providers/atmosphere/src/earthlens/eea_aq/_helpers.py
+++ b/libs/providers/atmosphere/src/earthlens/eea_aq/_helpers.py
@@ -364,7 +364,11 @@ def shape_frame(
     # reading that merely lacks a flag untouched.
     invalid_flag = (out["validity"] < 0).fillna(False)
     unflagged_sentinel = out["validity"].isna() & out["value"].isin(_NODATA_SENTINELS)
-    out.loc[invalid_flag | unflagged_sentinel, "value"] = pd.NA
+    # `value` is a numpy float column, so use a float NaN rather than `pd.NA`:
+    # pd.NA is the marker for pandas nullable dtypes and can upcast the column
+    # to object, which would make the trailing astype(SCHEMA) raise instead of
+    # coerce on older pandas. float("nan") settles to float64 unconditionally.
+    out.loc[invalid_flag | unflagged_sentinel, "value"] = float("nan")
     out["dataset"] = dataset
     out["provider"] = "EEA"
     return out.reset_index(drop=True).astype(SCHEMA)

--- a/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
@@ -215,10 +215,23 @@ class TestShapeFrame:
         out = shape_frame(self._flagged("7.2", None), "Unverified", {6001: "pm25"})
         assert out.loc[0, "value"] == 7.2
 
-    def test_masked_value_column_stays_float(self):
-        """Masking keeps the value column float64 rather than upcasting to object."""
-        out = shape_frame(self._flagged("-999", -1), "Historical", {6001: "pm25"})
+    def test_masked_sentinels_are_removed_by_dropna(self):
+        """Masked no-data rows are real float NaNs, so value.dropna() now drops them."""
+        raw = pd.DataFrame(
+            {
+                "Samplingpoint": ["MT/SPO-1", "MT/SPO-1"],
+                "Pollutant": [6001, 6001],
+                "Start": pd.to_datetime(["2011-01-01T00:00", "2011-01-01T01:00"]),
+                "Value": ["14.6", "-999"],
+                "Unit": ["ug.m-3", "ug.m-3"],
+                "AggType": ["hour", "hour"],
+                "Validity": [1, -1],
+                "Verification": [3, 3],
+            }
+        )
+        out = shape_frame(raw, "Historical", {6001: "pm25"})
         assert str(out["value"].dtype) == "float64"
+        assert out["value"].dropna().tolist() == [14.6]
 
     def test_zero_flag_is_not_masked(self):
         """A zero Validity is not negative, so the reading is kept (strict < 0 boundary)."""

--- a/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
@@ -230,7 +230,6 @@ class TestShapeFrame:
             }
         )
         out = shape_frame(raw, "Historical", {6001: "pm25"})
-        assert str(out["value"].dtype) == "float64"
         assert out["value"].dropna().tolist() == [14.6]
 
     def test_zero_flag_is_not_masked(self):

--- a/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
@@ -167,6 +167,59 @@ class TestShapeFrame:
         logger.remove(sink)
         assert any("schema drift" in message.lower() for message in messages)
 
+    def _flagged(self, value, validity):
+        """One MT pm25 row carrying value/validity for the no-data masking tests."""
+        return pd.DataFrame(
+            {
+                "Samplingpoint": ["MT/SPO-1"],
+                "Pollutant": [6001],
+                "Start": pd.to_datetime(["2011-01-01T00:00"]),
+                "Value": [value],
+                "Unit": ["ug.m-3"],
+                "AggType": ["hour"],
+                "Validity": [validity],
+                "Verification": [3],
+            }
+        )
+
+    def test_negative_flag_masks_sentinel_to_nan(self):
+        """A -999 reading flagged invalid comes back as NaN with the flag preserved."""
+        out = shape_frame(self._flagged("-999", -1), "Historical", {6001: "pm25"})
+        assert pd.isna(out.loc[0, "value"])
+        assert out.loc[0, "validity"] == -1
+
+    def test_negative_flag_masks_zero_value(self):
+        """An invalid row published as 0.0 is masked too, gated on the flag not the value."""
+        out = shape_frame(self._flagged("0.0", -1), "Historical", {6001: "pm25"})
+        assert pd.isna(out.loc[0, "value"])
+
+    def test_maintenance_flag_masks_value(self):
+        """A -99 maintenance flag also masks the reading."""
+        out = shape_frame(self._flagged("12.0", -99), "Historical", {6001: "pm25"})
+        assert pd.isna(out.loc[0, "value"])
+
+    def test_valid_row_keeps_value_including_small_negative(self):
+        """A valid row keeps its value, small near-zero instrument noise included."""
+        out = shape_frame(self._flagged("-5.3", 1), "Verified", {6001: "pm25"})
+        assert out.loc[0, "value"] == -5.3
+        assert out.loc[0, "validity"] == 1
+
+    def test_null_flag_sentinel_is_masked(self):
+        """A -999 sentinel carried under a null flag is masked, not passed through."""
+        out = shape_frame(self._flagged("-999", None), "Historical", {6001: "pm25"})
+        assert pd.isna(out.loc[0, "value"])
+        assert pd.isna(out.loc[0, "validity"])
+
+    def test_null_flag_real_value_is_kept(self):
+        """A genuine reading with a null flag is not over-masked."""
+        out = shape_frame(self._flagged("7.2", None), "Unverified", {6001: "pm25"})
+        assert out.loc[0, "value"] == 7.2
+
+    def test_masked_value_column_stays_float(self):
+        """Masking keeps the value column float64 rather than upcasting to object."""
+        out = shape_frame(self._flagged("-999", -1), "Historical", {6001: "pm25"})
+        assert str(out["value"].dtype) == "float64"
+
 
 @pytest.mark.eea
 def test_empty_frame_schema():

--- a/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
+++ b/libs/providers/atmosphere/tests/eea_aq/test_helpers.py
@@ -220,6 +220,36 @@ class TestShapeFrame:
         out = shape_frame(self._flagged("-999", -1), "Historical", {6001: "pm25"})
         assert str(out["value"].dtype) == "float64"
 
+    def test_zero_flag_is_not_masked(self):
+        """A zero Validity is not negative, so the reading is kept (strict < 0 boundary)."""
+        out = shape_frame(self._flagged("3.0", 0), "Verified", {6001: "pm25"})
+        assert out.loc[0, "value"] == 3.0
+        assert out.loc[0, "validity"] == 0
+
+    def test_masks_only_the_flagged_rows_in_a_mixed_frame(self):
+        """Masking is row-selective: only the no-data rows in a mixed frame become NaN."""
+        raw = pd.DataFrame(
+            {
+                "Samplingpoint": ["MT/SPO-1"] * 4,
+                "Pollutant": [6001] * 4,
+                "Start": pd.to_datetime(["2011-01-01T00:00"] * 4),
+                "Value": ["14.6", "-999", "-999", "-5.3"],
+                "Unit": ["ug.m-3"] * 4,
+                "AggType": ["hour"] * 4,
+                "Validity": [
+                    1,
+                    -1,
+                    None,
+                    1,
+                ],  # valid / invalid / null-flag / valid-negative
+                "Verification": [3] * 4,
+            }
+        )
+        out = shape_frame(raw, "Historical", {6001: "pm25"})
+        assert list(out["value"].isna()) == [False, True, True, False]
+        assert out.loc[0, "value"] == 14.6
+        assert out.loc[3, "value"] == -5.3
+
 
 @pytest.mark.eea
 def test_empty_frame_schema():


### PR DESCRIPTION
# Description

`shape_frame` coerced the raw EEA Parquet `Value` to float and passed EEA's no-data sentinels straight through into
the returned `value` column, so a sizeable share of returned rows were sentinels masquerading as measured
concentrations. EEA flags a reading it does not vouch for with a negative `Validity` (`-1` invalid, `-99`
maintenance) and fills its `Value` with a sentinel (`-999` in the legacy Historical export) or a plain `0.0` —
none of which `shape_frame` masked. Consequences: any mean / percentile a caller computed was silently skewed
(dragged far negative by the `-999`s), and `value.dropna()` could not remove them because they are numbers, not
nulls.

This masks `value` to `NaN` for a reading the EEA does not vouch for, gating on the **flag** rather than the
`-999` literal:

- a **negative `Validity`** masks the row whatever its `Value` — catching both the `-999` sentinel and the plain
  `0.0` some invalid rows carry — while the flag itself is preserved in the `validity` column;
- a **null flag** is trusted for neither verdict, so a null-flag row is masked only when its value is a known
  sentinel (`_NODATA_SENTINELS = {-999.0}`), leaving a genuine reading that merely lacks a flag untouched;
- **valid rows keep their published value**, small near-zero instrument noise (`-5.3`, `-0.5`) included.

The mask assigns a **float NaN** (`float("nan")`), not `pd.NA`: `value` is a numpy-float column, and `pd.NA` (the
marker for pandas nullable dtypes) could upcast it to `object`, which would make the trailing `.astype(SCHEMA)`
raise instead of coerce on older pandas. `float("nan")` settles to `float64` unconditionally.

**Behaviour change:** values previously returned for invalid rows (`-999`, `0.0`) now read as `NaN`.

**Design note (the null-flag decision the issue left open):** I chose *treat an unflagged sentinel value as
no-data* rather than *fill the null flag → mask every null-flag row*, so a genuine reading with a missing flag is
preserved.

No new dependencies.

# Issues
- Closes #1047 — invalid EEA readings returned their no-data sentinel (`-999` / `0.0`) as a real concentration;
  `shape_frame` now masks negatively-flagged (and null-flag sentinel) readings to `NaN`, flag preserved.

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Offline unit tests in `tests/eea_aq/test_helpers.py` (`TestShapeFrame`) drive `shape_frame` directly on
constructed frames (no network), plus a runnable `shape_frame` doctest. The branch went through two review rounds
and a SonarCloud sweep.

Reproduce:

```
uv sync --extra all --group dev
uv run pytest libs/providers/atmosphere/tests/eea_aq -m "not e2e"
```

Result: **82 passed, 1 deselected** (e2e), including the `--doctest-modules` example. `ruff check`,
`ruff format --check`, and `mypy` on the changed module are clean, and `_helpers.py` is at **100% line + branch**
coverage.

- [x] Masking: `-999` sentinel masked, invalid-`0.0` masked, `-99` maintenance masked, and a null-flag `-999`
  sentinel masked — each returns `NaN` with the flag preserved in `validity`.
- [x] Preservation: a valid row keeps its value (small near-zero negative included) and a null-flag *non*-sentinel
  reading is not over-masked.
- [x] Boundary / vectorisation: `Validity == 0` is not masked (strict `< 0`), a mixed frame masks only the no-data
  rows, and the masked sentinel is a real float `NaN` so `value.dropna()` now drops it.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
