### PR TITLE
feat(ecmwf): hydrate every placeholder by probing each variable in turn

### DIFF
--- a/docs/reference/ecmwf/catalog.md
+++ b/docs/reference/ecmwf/catalog.md
@@ -710,6 +710,47 @@ from a live tiny retrieve. Licence-gated and best-effort — a dataset
 whose licence you have not accepted is left untouched rather than
 guessed at.
 
+**One probe per placeholder.** A dataset's constraints partition it into
+blocks, and a variable is only retrievable under the selectors of a block
+that lists it, so the sweep asks for each placeholder variable by name in
+turn rather than probing the dataset once. That is what lets a
+multi-variable dataset finish: a single probe only ever describes whichever
+variable its constraints list first, so a stanza with four placeholders
+could never be completed by one.
+
+Because the probe names the variable it wants, a lone data variable coming
+back identifies that row outright — the correspondence is established by
+the request rather than inferred from the names, and none of the matching
+rules below is consulted. A probe that answers with several data variables,
+or with none, falls through to those rules, which decline rather than guess.
+
+**Per-variable selectors are recorded.** The block that serves a variable
+carries the selectors that variable needs, so where they differ from the
+stanza's own `extras:` the difference is written as a per-variable override.
+GloFAS is the case this exists for — river discharge and runoff are served
+under `timespan: time_mean`, snow depth and soil wetness only under
+`instantaneous`:
+
+```yaml
+      snow-depth-water-equivalent:
+        cds_variable: snow_depth_water_equivalent
+        nc_variable: sd
+        units: kg m-2
+        extras:
+          timespan: [instantaneous]
+```
+
+**Cost.** One retrieve per placeholder row, each under the same per-request
+deadline, so a wide dataset is a long sweep. A dataset whose first probe is
+refused is abandoned rather than retried for every remaining row, and rows
+filled before that are kept — the pass writes each shard as it goes, so
+re-running continues where the last one stopped. Use `--limit` to work
+through the catalog in batches.
+
+A dataset whose constraints do not partition by variable at all has no block
+to look a row up in; those fall back to a single whole-dataset probe and the
+matching rules below.
+
 Matching is deliberately conservative. The confident rules come first: an
 exact short-name match, then a token-subset match against the variable's
 `long_name`. Only a single leftover slug facing a single unused variable

--- a/libs/core/src/earthlens/cli/datasets.py
+++ b/libs/core/src/earthlens/cli/datasets.py
@@ -630,13 +630,13 @@ def curate(
     limit: int = typer.Option(
         0,
         "--limit",
-        help="ecmwf --all / gee|ecmwf --fill-empty: only process the first N "
+        help="ecmwf --all: first N datasets. ecmwf --fill-empty: first N placeholder rows. gee --fill-empty: first N "
         "rows (0=all).",
     ),
     timeout: int = typer.Option(
         180,
         "--timeout",
-        help="ecmwf --fill-empty: seconds to wait for each dataset's live "
+        help="ecmwf --fill-empty: seconds to wait for each variable's live "
         "retrieve before skipping it (0 = no deadline).",
     ),
     version: str = typer.Option("", "--version", help="earthdata: collection version."),

--- a/libs/core/src/earthlens/cli/datasets.py
+++ b/libs/core/src/earthlens/cli/datasets.py
@@ -858,12 +858,15 @@ def _curate_fill_empty(
 
     timed_out = summary.get("timed_out") or 0
     unmatched = summary.get("unmatched") or 0
+    partial = summary.get("partial") or 0
     tail = f", {timed_out} timed out" if timed_out else ""
     if unmatched:
         tail += f", {unmatched} retrieved with no confident match"
+    if partial:
+        tail += f", {partial} stopped early (re-run to continue)"
     out_console().print(
         f"[green]hydrated {summary['hydrated']}[/green] / "
-        f"{summary['candidates']} placeholder rows "
+        f"{summary['candidates']} datasets "
         f"(skipped {summary['skipped']}{tail})"
     )
 

--- a/libs/core/src/earthlens/cli/datasets.py
+++ b/libs/core/src/earthlens/cli/datasets.py
@@ -748,7 +748,7 @@ def _run_bulk_curation(
         fill_empty: Run the bulk-hydrate pass (`curate gee/ecmwf --fill-empty`).
         write: Whether the mutating `--write` flag was given.
         limit: Cap on rows processed (0 = all).
-        timeout: Per-dataset retrieve deadline for `--fill-empty` (0 = none).
+        timeout: Per-probe retrieve deadline for `--fill-empty` (0 = none).
 
     Returns:
         True when a bulk pass ran (the caller should return), else False.
@@ -845,7 +845,7 @@ def _curate_fill_empty(
         info: The backend (gee or ecmwf).
         write: `--fill-empty` mutates the catalog, so `--write` is required.
         limit: Only hydrate the first N placeholder rows (None = all).
-        timeout: Per-dataset retrieve deadline in seconds (ecmwf only; 0 = none).
+        timeout: Per-probe retrieve deadline in seconds (ecmwf only; 0 = none).
     """
     if not write:
         raise typer.BadParameter("--fill-empty rewrites the catalog; pass --write")

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -660,10 +660,17 @@ def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> st
     """Write a per-variable `extras:` override into one variable sub-block.
 
     Merges into an existing override rather than replacing it, so a selector a
-    maintainer set by hand survives unless the probe contradicts it. An override
-    already written as an inline mapping is parsed and re-emitted as a block:
-    appending beside it would leave the row with two `extras:` keys, which the
-    catalog loader rejects outright rather than silently keeping the last.
+    maintainer set by hand survives unless the probe contradicts it. Whatever
+    shape that override is written in — a block mapping, a block sequence value,
+    or an inline mapping — it is parsed and re-emitted as one canonical block.
+    Editing it line by line instead is what breaks: removing a superseded key's
+    line leaves its `- item` continuation lines orphaned, and appending beside an
+    inline mapping leaves the row with two `extras:` keys. Both produce a shard
+    the catalog cannot load.
+
+    Comments inside a variable's own `extras:` do not survive the rewrite. That
+    block is machine-managed; the dataset-level `extras:` where the catalog keeps
+    its explanatory comments is never touched.
 
     Args:
         block: One dataset stanza's body text.
@@ -680,11 +687,7 @@ def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> st
         if match.group("slug") != slug:
             continue
         lines = match.group("body").splitlines(keepends=True)
-        rendered = [
-            f"          {key}: {_yaml_inline_list(value)}\n"
-            for key, value in override.items()
-        ]
-        start = next(
+        found = next(
             (
                 index
                 for index, line in enumerate(lines)
@@ -692,33 +695,29 @@ def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> st
             ),
             None,
         )
-        if start is None:
-            lines = lines + ["        extras:\n"] + rendered
-        elif lines[start].strip() != "extras:":
-            # An inline mapping (`extras: {timespan: [x]}`) carries its children
-            # on the key's own line, so appending a block beside it would leave
-            # the row with two `extras:` keys — which the catalog loader rejects
-            # outright, breaking the whole shard. Merge into it and re-emit as a
-            # block instead.
-            merged = _inline_mapping(lines[start])
-            merged.update(override)
-            lines[start : start + 1] = ["        extras:\n"] + [
-                f"          {key}: {_yaml_inline_list(value)}\n"
-                for key, value in merged.items()
-            ]
+        merged: dict[str, Any] = {}
+        head: list[str]
+        tail: list[str]
+        if found is None:
+            head, tail = lines, []
         else:
-            end = start + 1
-            while (
-                end < len(lines) and lines[end].strip() and _indent_of(lines[end]) > 8
+            stop = found + 1
+            while stop < len(lines) and (
+                not lines[stop].strip() or _indent_of(lines[stop]) > 8
             ):
-                end += 1
-            kept = [
-                line
-                for line in lines[start + 1 : end]
-                if line.strip().partition(":")[0].strip() not in override
-            ]
-            lines = lines[: start + 1] + kept + rendered + lines[end:]
-        body = "".join(lines)
+                stop += 1
+            merged = (
+                _inline_mapping(lines[found])
+                if lines[found].strip() != "extras:"
+                else _mapping_under(lines, found)
+            )
+            head, tail = lines[:found], lines[stop:]
+        merged.update(override)
+        rendered = ["        extras:\n"] + [
+            f"          {key}: {_yaml_inline_list(value)}\n"
+            for key, value in merged.items()
+        ]
+        body = "".join(head + rendered + tail)
         return block[: match.start("body")] + body + block[match.end("body") :]
     return block
 

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -103,6 +103,9 @@ _UNITS_LINE = re.compile(r"(?m)^( {8}units:)[^\n]*$")
 #: the real one-of-two matches (`glacier-area` against `area`).
 _MIN_TOKEN_COVERAGE = 0.5
 
+#: The per-variable override key, read and written in several places.
+_EXTRAS_KEY = "extras:"
+
 #: Most retrieved variable names to name in a declined-match echo before
 #: summarising the rest, so one wide product cannot flood the sweep's output.
 _ECHO_MAX_NAMES = 8
@@ -164,11 +167,14 @@ def _probe_into(dataset_id: str, cds_variable: str, box: dict[str, Any]) -> None
     """
     try:
         box["result"] = _retrieve_variable_meta(dataset_id, cds_variable)
-    except BaseException as exc:  # noqa: BLE001 — surfaced to the caller thread
-        # BaseException, not Exception: an interrupt raised in here would
-        # otherwise go to the thread excepthook and the caller would read the
-        # empty box as "no block serves this variable".
+    except Exception as exc:  # noqa: BLE001 — surfaced to the caller thread
         box["error"] = exc
+    except BaseException as exc:
+        # An interrupt has to reach the caller through the box as well: a thread
+        # cannot propagate it, and an empty box is indistinguishable from "no
+        # block serves this variable". Re-raised so this thread still unwinds.
+        box["error"] = exc
+        raise
 
 
 def _probe_with_timeout(
@@ -705,7 +711,7 @@ def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> st
             (
                 index
                 for index, line in enumerate(lines)
-                if line.strip().startswith("extras:") and _indent_of(line) == 8
+                if line.strip().startswith(_EXTRAS_KEY) and _indent_of(line) == 8
             ),
             None,
         )
@@ -720,7 +726,7 @@ def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> st
                 not lines[stop].strip() or _indent_of(lines[stop]) > 8
             ):
                 stop += 1
-            if lines[found].strip() != "extras:":
+            if lines[found].strip() != _EXTRAS_KEY:
                 merged = _inline_mapping(lines[found])
                 if not merged:
                     # An inline value that is not a mapping (`extras: [a, b]`,
@@ -947,8 +953,8 @@ def _dataset_extras(block: str) -> dict[str, str]:
     """
     lines = block.splitlines()
     for index, line in enumerate(lines):
-        if line.strip().startswith("extras:") and _indent_of(line) == 4:
-            if line.strip() != "extras:":
+        if line.strip().startswith(_EXTRAS_KEY) and _indent_of(line) == 4:
+            if line.strip() != _EXTRAS_KEY:
                 return _inline_mapping(line)
             return _mapping_under(lines, index)
     return {}

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -640,6 +640,22 @@ def _data_variables(
     return {name: meta for name, meta in nc_meta.items() if not _is_auxiliary(name)}
 
 
+def _inline_mapping(line: str) -> dict[str, Any]:
+    """Return the mapping an inline `key: {a: 1, b: 2}` line carries.
+
+    Args:
+        line: One `key: value` line whose value may be an inline mapping.
+
+    Returns:
+        The parsed mapping, empty when the value is not one.
+    """
+    value = line.split(":", 1)[1].strip()
+    if not value.startswith("{"):
+        return {}
+    parsed = yaml.safe_load(value)
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> str:
     """Write a per-variable `extras:` override into one variable sub-block.
 
@@ -669,12 +685,24 @@ def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> st
             (
                 index
                 for index, line in enumerate(lines)
-                if line.strip() == "extras:" and _indent_of(line) == 8
+                if line.strip().startswith("extras:") and _indent_of(line) == 8
             ),
             None,
         )
         if start is None:
             lines = lines + ["        extras:\n"] + rendered
+        elif lines[start].strip() != "extras:":
+            # An inline mapping (`extras: {timespan: [x]}`) carries its children
+            # on the key's own line, so appending a block beside it would leave
+            # the row with two `extras:` keys — which the catalog loader rejects
+            # outright, breaking the whole shard. Merge into it and re-emit as a
+            # block instead.
+            merged = _inline_mapping(lines[start])
+            merged.update(override)
+            lines[start : start + 1] = ["        extras:\n"] + [
+                f"          {key}: {_yaml_inline_list(value)}\n"
+                for key, value in merged.items()
+            ]
         else:
             end = start + 1
             while (

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -660,7 +660,10 @@ def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> st
     """Write a per-variable `extras:` override into one variable sub-block.
 
     Merges into an existing override rather than replacing it, so a selector a
-    maintainer set by hand survives unless the probe contradicts it.
+    maintainer set by hand survives unless the probe contradicts it. An override
+    already written as an inline mapping is parsed and re-emitted as a block:
+    appending beside it would leave the row with two `extras:` keys, which the
+    catalog loader rejects outright rather than silently keeping the last.
 
     Args:
         block: One dataset stanza's body text.
@@ -909,7 +912,11 @@ def _mapping_under(lines: list[str], start: int) -> dict[str, str]:
 
 
 def _dataset_extras(block: str) -> dict[str, str]:
-    """Return the stanza's dataset-level `extras:` mapping, as raw text values.
+    """Return the stanza's dataset-level `extras:` mapping, as parsed values.
+
+    Reads either spelling the catalog allows — a block mapping under `extras:`
+    or an inline one on the key's own line — so a selector is compared by value
+    rather than by how it happens to be written.
 
     Args:
         block: One dataset stanza's body text.

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -1409,7 +1409,7 @@ def _hydrate_one(
         prefix: The `[k/total] id` label echoed with the outcome.
         catalog_dir: The `catalog/` shard directory to locate the stanza in.
         file_text: The per-shard text cache, updated in place on a hydration.
-        timeout: Per-dataset retrieve deadline; `None` / `0` waits without one.
+        timeout: Per-probe retrieve deadline; `None` / `0` waits without one.
 
     Returns:
         One of `"hydrated"`, `"partial"`, `"unmatched"`, `"timed_out"`, or
@@ -1509,13 +1509,14 @@ def bulk_hydrate_empty(
     """Fill every placeholder curated ECMWF row from a live retrieve, in place.
 
     Loads the curated catalog, finds datasets with any `units: unknown`
-    variable, retrieves a tiny NetCDF per dataset, and rewrites the stanza in
+    variable, retrieves a tiny NetCDF per placeholder variable, and rewrites the stanza in
     its per-family shard (preserving the rest). Hardened for the full-catalog
     sweep: each retrieve runs under `timeout` so one request stuck in the CDS
     queue is skipped rather than wedging the pass, and each hydrated shard is
     **written the moment it changes** so an interrupted run keeps the progress
     it already made. A dataset whose retrieve fails, times out, or whose stanza
-    cannot be matched is skipped — never fatal. Progress is echoed per dataset.
+    cannot be matched is skipped — never fatal. Progress is echoed per dataset,
+    one line summarising that dataset's per-variable probes.
 
     Args:
         limit: Stop once this many placeholder **rows** have been taken on,
@@ -1524,7 +1525,7 @@ def bulk_hydrate_empty(
             of them, so a dataset-counting limit of 1 could mean 82 queued
             requests. A dataset is always taken whole, so the count is a floor
             — the first dataset is never split.
-        timeout: Per-dataset retrieve deadline in seconds; `None` / `0` waits
+        timeout: Per-probe retrieve deadline in seconds; `None` / `0` waits
             without a deadline (the offline-test path).
 
     Returns:

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -870,44 +870,44 @@ def _indent_of(line: str) -> int:
     return len(line) - len(line.lstrip(" "))
 
 
-def _mapping_under(lines: list[str], start: int) -> dict[str, str]:
-    """Read the `key: value` children indented under `lines[start]`.
+def _mapping_under(lines: list[str], start: int) -> dict[str, Any]:
+    """Read the mapping nested under `lines[start]` by parsing it as YAML.
 
-    Values are parsed, so a selector written `[ x ]`, `['x']` or as a block
-    sequence compares equal to the same selector written `[x]`. Only the values
-    are parsed — the surrounding shard text is left untouched, because a full
-    round-trip would reformat it and lose the maintainer comments the catalog
-    relies on.
+    The region is dedented and handed to the parser rather than scanned line by
+    line, so a nested mapping stays nested, a block sequence stays a list, and a
+    quoted value containing a `#` is not mistaken for a comment. Scanning was
+    tried and gets all three wrong — the last of them by raising out of the
+    sweep rather than returning something wrong.
 
     Args:
         lines: The stanza's lines.
         start: Index of the parent key line.
 
     Returns:
-        Mapping of child key to its parsed value; a block sequence is collected
-        into a list.
+        The parsed mapping; empty when the region is absent or unparseable.
     """
     parent = _indent_of(lines[start])
-    found: dict[str, Any] = {}
-    current: str | None = None
+    region = []
     for line in lines[start + 1 :]:
-        if not line.strip() or line.lstrip().startswith("#"):
-            continue
-        if _indent_of(line) <= parent:
+        if line.strip() and _indent_of(line) <= parent:
             break
-        stripped = line.strip()
-        if stripped.startswith("- ") and current is not None:
-            found.setdefault(current, []).append(
-                yaml.safe_load(stripped[2:].split(" #", 1)[0].strip())
-            )
-            continue
-        key, sep, value = stripped.partition(":")
-        if not sep:
-            continue
-        current = key.strip()
-        text = value.split(" #", 1)[0].strip()
-        found[current] = yaml.safe_load(text) if text else []
-    return found
+        region.append(line)
+    if not any(line.strip() for line in region):
+        return {}
+    indent = min(
+        (_indent_of(line) for line in region if line.strip()), default=parent + 1
+    )
+    # Callers split with and without `keepends`, so re-join explicitly rather
+    # than trusting the lines to carry their own terminators.
+    dedented = chr(10).join(
+        (line[indent:] if len(line) > indent else line.lstrip(" ")).rstrip(chr(10))
+        for line in region
+    )
+    try:
+        parsed = yaml.safe_load(dedented)
+    except yaml.YAMLError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def _dataset_extras(block: str) -> dict[str, str]:
@@ -995,7 +995,11 @@ def _selector_override(
 
 
 def _yaml_inline_list(value: Any) -> str:
-    """Render a selector value the way the catalog writes it, as `[a]` or a scalar.
+    """Render a selector value as the inline YAML the catalog writes.
+
+    Dumped by the YAML emitter, not by `str`, so a value that needs quoting
+    survives the round trip. Rendering `["yes"]` as `[yes]` reads back as a
+    boolean, `["1.0"]` as a float, and `["value #hash"]` does not parse at all.
 
     Args:
         value: The selector value from a constraints block.
@@ -1012,18 +1016,21 @@ def _yaml_inline_list(value: Any) -> str:
             '[instantaneous]'
 
             ```
-        - A scalar stays a scalar:
+        - A value that YAML would otherwise re-read as another type is quoted:
 
             ```python
             >>> from earthlens.ecmwf._hydrate import _yaml_inline_list
-            >>> _yaml_inline_list("unarchived")
-            'unarchived'
+            >>> _yaml_inline_list(["yes"])
+            "['yes']"
 
             ```
     """
-    if isinstance(value, list):
-        return "[" + ", ".join(str(item) for item in value) + "]"
-    return str(value)
+    dumped = str(
+        yaml.safe_dump(value, default_flow_style=True, allow_unicode=True, width=10**6)
+    ).strip()
+    if dumped.endswith("..."):
+        dumped = dumped[: -len("...")].strip()
+    return dumped
 
 
 def _match_variables(

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -1460,6 +1460,32 @@ def _hydrate_one(
     return "hydrated"
 
 
+def _take_rows(datasets: list[str], rows: dict[str, int], limit: int) -> list[str]:
+    """Take whole datasets until `limit` placeholder rows are accounted for.
+
+    The sweep costs one retrieve per row, so a limit that counts datasets does
+    not bound the work an operator is agreeing to. A dataset is never split,
+    because half a hydrated stanza is not a useful stopping point — so the
+    first one is always taken and the count acts as a floor.
+
+    Args:
+        datasets: Candidate dataset ids, in the order they will be swept.
+        rows: Placeholder-row count per dataset id.
+        limit: How many rows to take on.
+
+    Returns:
+        The leading datasets whose rows reach `limit`.
+    """
+    taken: list[str] = []
+    budget = 0
+    for name in datasets:
+        taken.append(name)
+        budget += rows.get(name, 0)
+        if budget >= limit:
+            break
+    return taken
+
+
 def bulk_hydrate_empty(
     limit: int | None = None,
     timeout: float | None = _DEFAULT_RETRIEVE_TIMEOUT,
@@ -1476,7 +1502,12 @@ def bulk_hydrate_empty(
     cannot be matched is skipped — never fatal. Progress is echoed per dataset.
 
     Args:
-        limit: Only hydrate the first `limit` placeholder datasets (alphabetical).
+        limit: Stop once this many placeholder **rows** have been taken on,
+            in alphabetical dataset order. Rows rather than datasets because
+            the sweep issues one retrieve per row: the widest dataset holds 82
+            of them, so a dataset-counting limit of 1 could mean 82 queued
+            requests. A dataset is always taken whole, so the count is a floor
+            — the first dataset is never split.
         timeout: Per-dataset retrieve deadline in seconds; `None` / `0` waits
             without a deadline (the offline-test path).
 
@@ -1491,13 +1522,13 @@ def bulk_hydrate_empty(
 
     catalog_dir = Path(CATALOG_PATH)
     catalog = Catalog()
-    empty = sorted(
-        key
+    rows = {
+        key: sum(var.units == "unknown" for var in ds.variables.values())
         for key, ds in catalog.datasets.items()
-        if any(var.units == "unknown" for var in ds.variables.values())
-    )
+    }
+    empty = sorted(key for key, count in rows.items() if count)
     if limit:
-        empty = empty[:limit]
+        empty = _take_rows(empty, rows, limit)
 
     total = len(empty)
     file_text: dict[Path, str] = {}

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -1340,6 +1340,33 @@ def _declined_detail(session: _ProbeSession, declined: list[str]) -> str:
     return f"no confident match for {declined} (offered: {listed})"
 
 
+def _parses_as_yaml(text: str) -> bool:
+    """Return True when `text` still loads, duplicate keys included.
+
+    The guard between a splicing bug and a broken catalog. Rewrites are spliced
+    into shard text rather than round-tripped through a YAML emitter, so a bad
+    edit produces a file that only fails later, when something tries to load the
+    family — by which time the sweep has moved on.
+
+    Uses the catalog's own duplicate-key-rejecting loader, because the failure
+    this is most likely to catch is a duplicated key, which a permissive parser
+    accepts by silently keeping the last one.
+
+    Args:
+        text: The rewritten shard text.
+
+    Returns:
+        True when the text is loadable as the catalog loads it.
+    """
+    from earthlens.base.yaml_loader import _StrictSafeLoader
+
+    try:
+        yaml.load(text, Loader=_StrictSafeLoader)
+    except Exception:  # noqa: BLE001 — any parse failure means do not write
+        return False
+    return True
+
+
 def _hydrate_one(
     dataset_id: str,
     prefix: str,
@@ -1399,6 +1426,12 @@ def _hydrate_one(
             typer.echo(f"{prefix}: skipped ({type(session.error).__name__})")
             return "skipped"
         typer.echo(f"{prefix}: retrieved, {_declined_detail(session, declined)}")
+        return "unmatched"
+    if not _parses_as_yaml(new_text):
+        # The rewrite is spliced into shard text, so a splicing bug would put an
+        # unloadable family file on disk and only surface later, far from here.
+        # Refusing to write costs one dataset's hydration; writing costs the shard.
+        typer.echo(f"{prefix}: rewrite did not parse, shard left untouched")
         return "unmatched"
     file_text[path] = new_text
     path.write_text(new_text, encoding="utf-8")

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -871,27 +871,40 @@ def _indent_of(line: str) -> int:
 def _mapping_under(lines: list[str], start: int) -> dict[str, str]:
     """Read the `key: value` children indented under `lines[start]`.
 
-    Values are kept as their raw YAML text so a selector can be compared and
-    re-emitted without round-tripping through a parser that would reformat the
-    rest of the shard.
+    Values are parsed, so a selector written `[ x ]`, `['x']` or as a block
+    sequence compares equal to the same selector written `[x]`. Only the values
+    are parsed — the surrounding shard text is left untouched, because a full
+    round-trip would reformat it and lose the maintainer comments the catalog
+    relies on.
 
     Args:
         lines: The stanza's lines.
         start: Index of the parent key line.
 
     Returns:
-        Mapping of child key to its raw value text.
+        Mapping of child key to its parsed value; a block sequence is collected
+        into a list.
     """
     parent = _indent_of(lines[start])
-    found: dict[str, str] = {}
+    found: dict[str, Any] = {}
+    current: str | None = None
     for line in lines[start + 1 :]:
         if not line.strip() or line.lstrip().startswith("#"):
             continue
         if _indent_of(line) <= parent:
             break
-        key, _, value = line.strip().partition(":")
-        if _:
-            found[key.strip()] = value.split("#", 1)[0].strip()
+        stripped = line.strip()
+        if stripped.startswith("- ") and current is not None:
+            found.setdefault(current, []).append(
+                yaml.safe_load(stripped[2:].split(" #", 1)[0].strip())
+            )
+            continue
+        key, sep, value = stripped.partition(":")
+        if not sep:
+            continue
+        current = key.strip()
+        text = value.split(" #", 1)[0].strip()
+        found[current] = yaml.safe_load(text) if text else []
     return found
 
 
@@ -902,12 +915,14 @@ def _dataset_extras(block: str) -> dict[str, str]:
         block: One dataset stanza's body text.
 
     Returns:
-        Mapping of extra key to raw value text; empty when the stanza has no
+        Mapping of extra key to its parsed value; empty when the stanza has no
         dataset-level `extras:`.
     """
     lines = block.splitlines()
     for index, line in enumerate(lines):
-        if line.strip() == "extras:" and _indent_of(line) == 4:
+        if line.strip().startswith("extras:") and _indent_of(line) == 4:
+            if line.strip() != "extras:":
+                return _inline_mapping(line)
             return _mapping_under(lines, index)
     return {}
 
@@ -925,7 +940,8 @@ def _selector_override(
 
     Args:
         selectors: The serving constraints block's selectors for this variable.
-        dataset_extras: The stanza's dataset-level `extras:` mapping.
+        dataset_extras: The stanza's dataset-level `extras:` mapping, as parsed
+            values so that re-spelling a list does not read as a disagreement.
 
     Returns:
         The subset of `selectors` that differs from `dataset_extras`, keyed the
@@ -937,17 +953,19 @@ def _selector_override(
             ```python
             >>> from earthlens.ecmwf._hydrate import _selector_override
             >>> _selector_override(
-            ...     {"timespan": ["instantaneous"]}, {"timespan": "[time_mean]"}
+            ...     {"timespan": ["instantaneous"]}, {"timespan": ["time_mean"]}
             ... )
             {'timespan': ['instantaneous']}
 
             ```
-        - One the stanza already agrees with would be noise:
+        - One the stanza already agrees with would be noise. Both sides are
+          parsed values, so re-spelling the stanza's own list does not make it
+          look like a disagreement:
 
             ```python
             >>> from earthlens.ecmwf._hydrate import _selector_override
             >>> _selector_override(
-            ...     {"timespan": ["time_mean"]}, {"timespan": "[time_mean]"}
+            ...     {"timespan": ["time_mean"]}, {"timespan": ["time_mean"]}
             ... )
             {}
 
@@ -956,7 +974,7 @@ def _selector_override(
 
             ```python
             >>> from earthlens.ecmwf._hydrate import _selector_override
-            >>> _selector_override({"hyear": ["2020"]}, {"timespan": "[time_mean]"})
+            >>> _selector_override({"hyear": ["2020"]}, {"timespan": ["time_mean"]})
             {}
 
             ```
@@ -965,9 +983,7 @@ def _selector_override(
     for key, value in selectors.items():
         if key not in dataset_extras:
             continue
-        current = dataset_extras[key]
-        wanted = _yaml_inline_list(value)
-        if current != wanted:
+        if dataset_extras[key] != value:
             override[key] = value
     return override
 

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -159,7 +159,10 @@ def _probe_into(dataset_id: str, cds_variable: str, box: dict[str, Any]) -> None
     """
     try:
         box["result"] = _retrieve_variable_meta(dataset_id, cds_variable)
-    except Exception as exc:  # noqa: BLE001 — surfaced to the caller thread verbatim
+    except BaseException as exc:  # noqa: BLE001 — surfaced to the caller thread
+        # BaseException, not Exception: an interrupt raised in here would
+        # otherwise go to the thread excepthook and the caller would read the
+        # empty box as "no block serves this variable".
         box["error"] = exc
 
 
@@ -178,6 +181,12 @@ def _probe_with_timeout(
 
     Raises:
         TimeoutError: If the probe does not finish within `timeout` seconds.
+
+    Note:
+        The worker is a daemon thread and keeps running its request after the
+        deadline; the retrieve it holds is abandoned, not cancelled. At most one
+        such thread is left per dataset, because the session stops probing after
+        its first timeout.
     """
     if not timeout:
         return _retrieve_variable_meta(dataset_id, cds_variable)
@@ -1351,7 +1360,7 @@ def _declined_detail(session: _ProbeSession, declined: list[str]) -> str:
     shown = ", ".join(offered[:_ECHO_MAX_NAMES])
     extra = len(offered) - _ECHO_MAX_NAMES
     listed = f"{shown}, +{extra} more" if extra > 0 else shown
-    return f"no confident match for {declined} (offered: {listed})"
+    return f"no confident match for {', '.join(declined)} (offered: {listed})"
 
 
 def _parses_as_yaml(text: str) -> bool:
@@ -1403,7 +1412,9 @@ def _hydrate_one(
         timeout: Per-dataset retrieve deadline; `None` / `0` waits without one.
 
     Returns:
-        One of `"hydrated"`, `"unmatched"`, `"timed_out"`, or `"skipped"`.
+        One of `"hydrated"`, `"partial"`, `"unmatched"`, `"timed_out"`, or
+        `"skipped"`. `"partial"` is a `"hydrated"` that stopped early, so the
+        operator can see which datasets a re-run would carry further.
         `"unmatched"` is reserved for the retrieve that worked against a stanza
         with real placeholders and still hydrated nothing — the operator can
         curate that row by hand. A missing stanza, or one whose placeholders
@@ -1456,8 +1467,13 @@ def _hydrate_one(
     file_text[path] = new_text
     path.write_text(new_text, encoding="utf-8")
     left = f", {len(declined)} left" if declined else ""
-    typer.echo(f"{prefix}: hydrated {len(filled)}{left} -> {path.name}")
-    return "hydrated"
+    why = ""
+    if session.timed_out:
+        why = " (timed out; re-run to continue)"
+    elif session.error is not None:
+        why = f" ({type(session.error).__name__}; re-run to continue)"
+    typer.echo(f"{prefix}: hydrated {len(filled)}{left}{why} -> {path.name}")
+    return "partial" if session.error is not None else "hydrated"
 
 
 def _take_rows(datasets: list[str], rows: dict[str, int], limit: int) -> list[str]:
@@ -1512,10 +1528,13 @@ def bulk_hydrate_empty(
             without a deadline (the offline-test path).
 
     Returns:
-        A summary `{candidates, hydrated, skipped, timed_out, unmatched, filled}`
+        A summary
+        `{candidates, hydrated, skipped, timed_out, unmatched, partial, filled}`
         mapping. `unmatched` counts the retrieves that succeeded and still
         hydrated nothing; those are also counted in `skipped`, which stays the
-        total of everything not hydrated.
+        total of everything not hydrated. `partial` counts the datasets that
+        hydrated some rows and then stopped on a deadline or a refusal — they
+        are counted in `hydrated` too, and they are the ones a re-run continues.
     """
     from earthlens.ecmwf import Catalog
     from earthlens.ecmwf.catalog import CATALOG_PATH, clear_catalog_cache
@@ -1536,13 +1555,16 @@ def bulk_hydrate_empty(
     skipped = 0
     timed_out = 0
     unmatched = 0
+    partial = 0
     filled: list[str] = []
     for index, dataset_id in enumerate(empty, start=1):
         prefix = f"[{index}/{total}] {dataset_id}"
         outcome = _hydrate_one(dataset_id, prefix, catalog_dir, file_text, timeout)
-        if outcome == "hydrated":
+        if outcome in {"hydrated", "partial"}:
             hydrated += 1
             filled.append(dataset_id)
+            if outcome == "partial":
+                partial += 1
         elif outcome == "unmatched":
             unmatched += 1
             skipped += 1
@@ -1559,5 +1581,6 @@ def bulk_hydrate_empty(
         "skipped": skipped,
         "timed_out": timed_out,
         "unmatched": unmatched,
+        "partial": partial,
         "filled": filled,
     }

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import re
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -146,6 +147,104 @@ def _retrieve_netcdf_vars(dataset_id: str) -> dict[str, dict[str, Any]]:
     from earthlens.ecmwf.cli import _ecmwf_deep_sample
 
     return _ecmwf_deep_sample(dataset_id)
+
+
+def _probe_into(dataset_id: str, cds_variable: str, box: dict[str, Any]) -> None:
+    """Thread body: probe one variable, storing its result or error in `box`.
+
+    Args:
+        dataset_id: The Copernicus dataset id to sample.
+        cds_variable: The `cds_variable` to request.
+        box: Mutable result cell shared with the caller thread.
+    """
+    try:
+        box["result"] = _retrieve_variable_meta(dataset_id, cds_variable)
+    except Exception as exc:  # noqa: BLE001 — surfaced to the caller thread verbatim
+        box["error"] = exc
+
+
+def _probe_with_timeout(
+    dataset_id: str, cds_variable: str, timeout: float | None
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    """Probe one variable under a deadline, so a stuck request cannot wedge the pass.
+
+    Args:
+        dataset_id: The Copernicus dataset id to sample.
+        cds_variable: The `cds_variable` to request.
+        timeout: Seconds to wait; `None` or `0` waits without one.
+
+    Returns:
+        The `(metadata, selectors)` pair for `cds_variable`.
+
+    Raises:
+        TimeoutError: If the probe does not finish within `timeout` seconds.
+    """
+    if not timeout:
+        return _retrieve_variable_meta(dataset_id, cds_variable)
+    box: dict[str, Any] = {}
+    thread = threading.Thread(
+        target=_probe_into, args=(dataset_id, cds_variable, box), daemon=True
+    )
+    thread.start()
+    thread.join(timeout)
+    if thread.is_alive():
+        raise TimeoutError(
+            f"probe of {cds_variable!r} in {dataset_id!r} exceeded {timeout:.0f}s"
+        )
+    if "error" in box:
+        raise box["error"]
+    return box.get("result") or ({}, {})
+
+
+class _ProbeSession:
+    """Per-variable probes for one dataset, abandoned after the first failure.
+
+    A dataset's placeholders share one licence and one queue, so a refusal on
+    the first variable will refuse the rest too. Recording the failure and
+    returning empty for every later variable turns what would be N pointless
+    retrieves into one, while the rows already filled in this pass are kept.
+
+    Args:
+        dataset_id: The Copernicus dataset id being hydrated.
+        timeout: Per-probe deadline in seconds; `None` / `0` waits without one.
+
+    Attributes:
+        error: The failure that abandoned the session, or `None`.
+        timed_out: Whether that failure was the deadline rather than the store.
+        offered: Every data variable any probe in this session returned, so a
+            dataset that hydrated nothing can report what it was actually given.
+        answered: How many probes came back describing something. Zero means no
+            constraints block names these rows at all, which is a different
+            problem from a probe that answered with nothing usable.
+    """
+
+    def __init__(self, dataset_id: str, timeout: float | None) -> None:
+        self.dataset_id = dataset_id
+        self.timeout = timeout
+        self.error: BaseException | None = None
+        self.timed_out = False
+        self.offered: set[str] = set()
+        self.answered = 0
+
+    def __call__(
+        self, cds_variable: str
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+        """Probe `cds_variable`, or return empty once the session has failed."""
+        if self.error is not None:
+            return {}, {}
+        try:
+            meta, selectors = _probe_with_timeout(
+                self.dataset_id, cds_variable, self.timeout
+            )
+            self.offered.update(_data_variables(meta))
+            self.answered += bool(meta)
+            return meta, selectors
+        except TimeoutError as exc:
+            self.timed_out = True
+            self.error = exc
+        except Exception as exc:  # noqa: BLE001 — a licence-gated dataset is skipped
+            self.error = exc
+        return {}, {}
 
 
 def _retrieve_into(dataset_id: str, box: dict[str, Any]) -> None:
@@ -541,6 +640,287 @@ def _data_variables(
     return {name: meta for name, meta in nc_meta.items() if not _is_auxiliary(name)}
 
 
+def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> str:
+    """Write a per-variable `extras:` override into one variable sub-block.
+
+    Merges into an existing override rather than replacing it, so a selector a
+    maintainer set by hand survives unless the probe contradicts it.
+
+    Args:
+        block: One dataset stanza's body text.
+        slug: The variable sub-block to edit.
+        override: Selector keys and values to record.
+
+    Returns:
+        The stanza body with the override written; unchanged when `slug` is
+        absent or `override` is empty.
+    """
+    if not override:
+        return block
+    for match in _VARIABLE_BLOCK.finditer(block):
+        if match.group("slug") != slug:
+            continue
+        lines = match.group("body").splitlines(keepends=True)
+        rendered = [
+            f"          {key}: {_yaml_inline_list(value)}\n"
+            for key, value in override.items()
+        ]
+        start = next(
+            (
+                index
+                for index, line in enumerate(lines)
+                if line.strip() == "extras:" and _indent_of(line) == 8
+            ),
+            None,
+        )
+        if start is None:
+            lines = lines + ["        extras:\n"] + rendered
+        else:
+            end = start + 1
+            while (
+                end < len(lines) and lines[end].strip() and _indent_of(lines[end]) > 8
+            ):
+                end += 1
+            kept = [
+                line
+                for line in lines[start + 1 : end]
+                if line.strip().partition(":")[0].strip() not in override
+            ]
+            lines = lines[: start + 1] + kept + rendered + lines[end:]
+        body = "".join(lines)
+        return block[: match.start("body")] + body + block[match.end("body") :]
+    return block
+
+
+def _hydrate_stanza_per_variable(
+    text: str,
+    dataset_id: str,
+    probe: Callable[[str], tuple[dict[str, dict[str, Any]], dict[str, Any]]],
+) -> tuple[str, list[str], list[str]]:
+    """Fill every placeholder of one stanza, probing each variable on its own.
+
+    One probe per placeholder is what lets a multi-variable dataset finish: the
+    single-request sampler only ever reveals the variable its constraints list
+    first, so a stanza with several placeholders could never be completed. Each
+    probe asks for one named variable, so a lone data variable coming back
+    identifies that row outright rather than being matched by name similarity,
+    and the serving block's selectors are recorded as a per-variable override
+    when they differ from the stanza's defaults.
+
+    Names bound by rows filled earlier in the same pass are withheld from later
+    ones, so two rows cannot end up claiming one NetCDF variable.
+
+    Args:
+        text: The full per-family catalog shard text.
+        dataset_id: The dataset id whose stanza to hydrate.
+        probe: Callable taking a `cds_variable` and returning the
+            `(metadata, selectors)` pair :func:`_retrieve_variable_meta` returns.
+
+    Returns:
+        A `(text, filled, declined)` triple — the rewritten shard text, the
+        slugs hydrated, and the slugs left as placeholders.
+    """
+    match = _stanza_match(text, dataset_id)
+    if match is None:
+        return text, [], []
+    block = match.group(1)
+    placeholders = _placeholder_slugs(block)
+    if not placeholders:
+        return text, [], []
+    cds_names = _slug_cds_variables(block)
+    dataset_extras = _dataset_extras(block)
+    new_block = block
+    filled: list[str] = []
+    declined: list[str] = []
+    for slug in placeholders:
+        cds_variable = cds_names.get(slug)
+        if cds_variable is None:
+            declined.append(slug)
+            continue
+        meta, selectors = probe(cds_variable)
+        chosen = _choose_for_slug(slug, meta, _claimed_nc_names(new_block))
+        if chosen is None:
+            declined.append(slug)
+            continue
+        name, units = chosen
+        new_block = _fill_variable(new_block, slug, name, units)
+        new_block = _fill_variable_extras(
+            new_block, slug, _selector_override(selectors, dataset_extras)
+        )
+        filled.append(slug)
+    if new_block == block:
+        return text, filled, declined
+    rewritten = (
+        text[: match.start()] + f"  {dataset_id}:\n" + new_block + text[match.end() :]
+    )
+    return rewritten, filled, declined
+
+
+def _choose_for_slug(
+    slug: str,
+    meta: dict[str, dict[str, Any]],
+    reserved: frozenset[str],
+) -> tuple[str, str] | None:
+    """Pick the NetCDF variable a single-variable probe identifies for `slug`.
+
+    When the probe asked for one variable and one data variable came back, the
+    correspondence is established by the request rather than inferred from the
+    names, so no evidence check is needed. Anything else falls back to the
+    ordinary matcher, which declines rather than guess.
+
+    Args:
+        slug: The placeholder slug being hydrated.
+        meta: The probe's `{nc_name: {long_name, units}}` mapping.
+        reserved: Lowercased names already bound by hydrated rows.
+
+    Returns:
+        The `(nc_variable, units)` to write, or `None` to keep the placeholder.
+    """
+    candidates = {
+        name: info
+        for name, info in _data_variables(meta).items()
+        if name.lower() not in reserved
+    }
+    if len(candidates) == 1:
+        name, info = next(iter(candidates.items()))
+        return name, str(info.get("units") or "")
+    matched = _match_variables([slug], meta, reserved)
+    return matched.get(slug)
+
+
+def _retrieve_variable_meta(
+    dataset_id: str, cds_variable: str
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    """Probe one variable of a dataset; the second credentialed seam.
+
+    Mirrors :func:`_retrieve_netcdf_vars` but asks for a named variable, so a
+    dataset with several placeholders can be finished one row at a time instead
+    of only ever revealing whichever variable its constraints list first.
+
+    Args:
+        dataset_id: The Copernicus dataset id to sample.
+        cds_variable: The `cds_variable` to request.
+
+    Returns:
+        A `(metadata, selectors)` pair as :func:`_ecmwf_deep_sample_variable`
+        returns them.
+    """
+    from earthlens.ecmwf.cli import _ecmwf_deep_sample_variable
+
+    return _ecmwf_deep_sample_variable(dataset_id, cds_variable)
+
+
+def _slug_cds_variables(block: str) -> dict[str, str]:
+    """Map each variable slug in a stanza to its `cds_variable`.
+
+    A probe has to ask for the request-side name, which is not derivable from
+    the slug — `average-river-discharge-in-the-last-24-hours` is a slug whose
+    `cds_variable` differs from a naive de-hyphenation in several families.
+
+    Args:
+        block: One dataset stanza's body text.
+
+    Returns:
+        Mapping of slug to `cds_variable`, omitting rows that declare none.
+    """
+    names: dict[str, str] = {}
+    for match in _VARIABLE_BLOCK.finditer(block):
+        for line in match.group("body").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("cds_variable:"):
+                value = _scalar_after_key(line)
+                if value:
+                    names[match.group("slug")] = value
+                break
+    return names
+
+
+def _indent_of(line: str) -> int:
+    """Return the number of leading spaces on `line`."""
+    return len(line) - len(line.lstrip(" "))
+
+
+def _mapping_under(lines: list[str], start: int) -> dict[str, str]:
+    """Read the `key: value` children indented under `lines[start]`.
+
+    Values are kept as their raw YAML text so a selector can be compared and
+    re-emitted without round-tripping through a parser that would reformat the
+    rest of the shard.
+
+    Args:
+        lines: The stanza's lines.
+        start: Index of the parent key line.
+
+    Returns:
+        Mapping of child key to its raw value text.
+    """
+    parent = _indent_of(lines[start])
+    found: dict[str, str] = {}
+    for line in lines[start + 1 :]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if _indent_of(line) <= parent:
+            break
+        key, _, value = line.strip().partition(":")
+        if _:
+            found[key.strip()] = value.split("#", 1)[0].strip()
+    return found
+
+
+def _dataset_extras(block: str) -> dict[str, str]:
+    """Return the stanza's dataset-level `extras:` mapping, as raw text values.
+
+    Args:
+        block: One dataset stanza's body text.
+
+    Returns:
+        Mapping of extra key to raw value text; empty when the stanza has no
+        dataset-level `extras:`.
+    """
+    lines = block.splitlines()
+    for index, line in enumerate(lines):
+        if line.strip() == "extras:" and _indent_of(line) == 4:
+            return _mapping_under(lines, index)
+    return {}
+
+
+def _selector_override(
+    selectors: dict[str, Any], dataset_extras: dict[str, str]
+) -> dict[str, Any]:
+    """Return the selectors a variable needs that the stanza does not already set.
+
+    Only a selector the dataset-level `extras:` disagrees with is worth writing
+    as a per-variable override; anything the stanza already sets identically
+    would be noise. This is what turns the GloFAS `timespan` split — discharge
+    under `time_mean`, snow depth under `instantaneous` — into a recorded row
+    override instead of a hand-written comment.
+
+    Args:
+        selectors: The serving constraints block's selectors for this variable.
+        dataset_extras: The stanza's dataset-level `extras:` mapping.
+
+    Returns:
+        The subset of `selectors` that differs from `dataset_extras`, keyed the
+        same way; empty when the dataset defaults already cover the variable.
+    """
+    override: dict[str, Any] = {}
+    for key, value in selectors.items():
+        if key not in dataset_extras:
+            continue
+        current = dataset_extras[key]
+        wanted = _yaml_inline_list(value)
+        if current != wanted:
+            override[key] = value
+    return override
+
+
+def _yaml_inline_list(value: Any) -> str:
+    """Render a selector value the way the catalog writes it, as `[a]` or a scalar."""
+    if isinstance(value, list):
+        return "[" + ", ".join(str(item) for item in value) + "]"
+    return str(value)
+
+
 def _match_variables(
     placeholders: list[str],
     nc_meta: dict[str, dict[str, Any]],
@@ -795,6 +1175,66 @@ def _find_file_for_dataset(catalog_dir: Path, dataset_id: str) -> Path | None:
     return None
 
 
+def _hydrate_stanza_whole(
+    text: str, dataset_id: str, session: _ProbeSession
+) -> tuple[str, list[str], list[str]]:
+    """Hydrate a stanza from ONE whole-dataset probe, the pre-per-variable path.
+
+    Kept for the datasets per-variable probing cannot reach: a product whose
+    constraints do not partition by variable has no block to look a row up in,
+    so asking for a named variable finds nothing while a plain probe still
+    describes the product. Matching is by name here, so it goes through the
+    ordinary evidence rules rather than trusting a lone result.
+
+    Args:
+        text: The full per-family catalog shard text.
+        dataset_id: The dataset id whose stanza to hydrate.
+        session: The probe session, reused so a failure is recorded once.
+
+    Returns:
+        A `(text, filled, declined)` triple, as
+        :func:`_hydrate_stanza_per_variable` returns.
+    """
+    try:
+        nc_meta = _retrieve_with_timeout(dataset_id, session.timeout)
+    except TimeoutError as exc:
+        session.timed_out = True
+        session.error = exc
+        return text, [], []
+    except Exception as exc:  # noqa: BLE001 — a licence-gated dataset is skipped
+        session.error = exc
+        return text, [], []
+    session.offered.update(_data_variables(nc_meta))
+    match = _stanza_match(text, dataset_id)
+    placeholders = _placeholder_slugs(match.group(1)) if match else []
+    new_text = _rewrite_stanza(text, dataset_id, nc_meta)
+    rewritten = _stanza_match(new_text, dataset_id)
+    if new_text == text or rewritten is None:
+        return text, [], placeholders
+    remaining = _placeholder_slugs(rewritten.group(1))
+    filled = [slug for slug in placeholders if slug not in remaining]
+    return new_text, filled, remaining
+
+
+def _declined_detail(session: _ProbeSession, declined: list[str]) -> str:
+    """Describe why a dataset that retrieved cleanly still hydrated nothing.
+
+    Args:
+        session: The probe session that ran, carrying what the store offered.
+        declined: The slugs left as placeholders.
+
+    Returns:
+        A phrase naming either the missing data variables or the declined rows.
+    """
+    if not session.offered:
+        return "no data variables, only coordinates and auxiliaries"
+    offered = sorted(session.offered)
+    shown = ", ".join(offered[:_ECHO_MAX_NAMES])
+    extra = len(offered) - _ECHO_MAX_NAMES
+    listed = f"{shown}, +{extra} more" if extra > 0 else shown
+    return f"no confident match for {declined} (offered: {listed})"
+
+
 def _hydrate_one(
     dataset_id: str,
     prefix: str,
@@ -824,17 +1264,8 @@ def _hydrate_one(
         have all been filled already, is a `"skipped"` like a licence or network
         failure: there was nothing for the matcher to decline.
     """
-    try:
-        nc_meta: dict[str, dict[str, Any]] | None = _retrieve_with_timeout(
-            dataset_id, timeout
-        )
-    except TimeoutError:
-        typer.echo(f"{prefix}: timed out, skipped")
-        return "timed_out"
-    except Exception:  # noqa: BLE001 — a licence-gated / unreachable dataset is skipped
-        nc_meta = None
-    path = _find_file_for_dataset(catalog_dir, dataset_id) if nc_meta else None
-    if not nc_meta or path is None:
+    path = _find_file_for_dataset(catalog_dir, dataset_id)
+    if path is None:
         typer.echo(f"{prefix}: skipped")
         return "skipped"
     if path not in file_text:
@@ -843,20 +1274,31 @@ def _hydrate_one(
     if blocked is not None:
         typer.echo(f"{prefix}: {blocked}")
         return blocked
-    new_text = _rewrite_stanza(file_text[path], dataset_id, nc_meta)
+    session = _ProbeSession(dataset_id, timeout)
+    new_text, filled, declined = _hydrate_stanza_per_variable(
+        file_text[path], dataset_id, session
+    )
+    if not filled and session.error is None and not session.answered:
+        # No constraints block names these rows, which is how a product with no
+        # variable dimension looks (obs4mips CO2/CH4 partition by nothing the
+        # slug can be found under). One whole-dataset probe still describes it,
+        # so fall back rather than leave such a stanza permanently unhydratable.
+        new_text, filled, declined = _hydrate_stanza_whole(
+            file_text[path], dataset_id, session
+        )
+    if session.timed_out and not filled:
+        typer.echo(f"{prefix}: timed out, skipped")
+        return "timed_out"
     if new_text == file_text[path]:
-        offered = sorted(_data_variables(nc_meta))
-        if not offered:
-            detail = "no data variables, only coordinates and auxiliaries"
-        else:
-            shown = ", ".join(offered[:_ECHO_MAX_NAMES])
-            extra = len(offered) - _ECHO_MAX_NAMES
-            detail = f"{shown}, +{extra} more" if extra > 0 else shown
-        typer.echo(f"{prefix}: retrieved, no confident match ({detail})")
+        if session.error is not None:
+            typer.echo(f"{prefix}: skipped ({type(session.error).__name__})")
+            return "skipped"
+        typer.echo(f"{prefix}: retrieved, {_declined_detail(session, declined)}")
         return "unmatched"
     file_text[path] = new_text
     path.write_text(new_text, encoding="utf-8")
-    typer.echo(f"{prefix}: hydrated -> {path.name}")
+    left = f", {len(declined)} left" if declined else ""
+    typer.echo(f"{prefix}: hydrated {len(filled)}{left} -> {path.name}")
     return "hydrated"
 
 

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -7,12 +7,13 @@ writes), retrieve a tiny NetCDF via `cdsapi`, read each variable's real
 the comments and ordering of the surrounding rows are preserved, only the
 placeholder fields are rewritten.
 
-Credentialed and licence-gated: the CDS retrieve sits behind
-:func:`_retrieve_netcdf_vars`, an isolated seam that keeps the
-stanza-rewriting core (:func:`_rewrite_stanza`) pure and offline. A dataset
-whose retrieve fails (unaccepted licence, CDS outage) is skipped, never fatal —
-the fill is best-effort and partial by design (one retrieve confirms the
-variable it sampled).
+Credentialed and licence-gated: the CDS retrieves sit behind
+`_retrieve_variable_meta` and `_retrieve_netcdf_vars`, isolated seams that keep
+the stanza-rewriting core pure and offline. A dataset whose retrieve fails
+(unaccepted licence, CDS outage) is skipped, never fatal — the fill is
+best-effort and resumable by design: each placeholder row is probed by name, a
+dataset is abandoned after its first refusal, and the rows already filled are
+written before the pass moves on.
 """
 
 from __future__ import annotations
@@ -151,6 +152,10 @@ def _retrieve_netcdf_vars(dataset_id: str) -> dict[str, dict[str, Any]]:
 
 def _probe_into(dataset_id: str, cds_variable: str, box: dict[str, Any]) -> None:
     """Thread body: probe one variable, storing its result or error in `box`.
+
+    Catches `BaseException`, not `Exception`: anything raised in here has to
+    reach the caller through the box, because a thread cannot propagate it and
+    an empty box is indistinguishable from "no block serves this variable".
 
     Args:
         dataset_id: The Copernicus dataset id to sample.
@@ -1306,13 +1311,14 @@ def _find_file_for_dataset(catalog_dir: Path, dataset_id: str) -> Path | None:
 def _hydrate_stanza_whole(
     text: str, dataset_id: str, session: _ProbeSession
 ) -> tuple[str, list[str], list[str]]:
-    """Hydrate a stanza from ONE whole-dataset probe, the pre-per-variable path.
+    """Hydrate a stanza from ONE whole-dataset probe, by name rather than by request.
 
-    Kept for the datasets per-variable probing cannot reach: a product whose
-    constraints do not partition by variable has no block to look a row up in,
-    so asking for a named variable finds nothing while a plain probe still
-    describes the product. Matching is by name here, so it goes through the
-    ordinary evidence rules rather than trusting a lone result.
+    Runs for whatever the per-variable pass declined. A row it could not place
+    is one no constraints block names — a product that does not partition by
+    variable has no block to look a row up in, and a stale request-side name has
+    none either — and a plain probe can still describe the product. Matching
+    here is by name, so it goes through the ordinary evidence rules rather than
+    trusting a lone result the way a named request may.
 
     Args:
         text: The full per-family catalog shard text.
@@ -1406,9 +1412,10 @@ def _hydrate_one(
 ) -> str:
     """Hydrate one placeholder dataset in place; return its outcome tag.
 
-    Retrieves the dataset under `timeout`, matches the sampled variables into
-    its shard, and — on a real change — updates `file_text` and writes the shard
-    to disk immediately. Progress is echoed. Never raises for a licence-gated,
+    Probes each placeholder row by name under `timeout`, writes what it can
+    identify into the shard and — on a real change that still parses — updates
+    `file_text` and writes to disk immediately. Progress is echoed, naming the
+    reason when a dataset stopped early. Never raises for a licence-gated,
     unreachable, timed-out, or unmatchable dataset: those return a skip tag.
 
     Args:

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -1371,9 +1371,11 @@ def _parses_as_yaml(text: str) -> bool:
     edit produces a file that only fails later, when something tries to load the
     family — by which time the sweep has moved on.
 
-    Uses the catalog's own duplicate-key-rejecting loader, because the failure
-    this is most likely to catch is a duplicated key, which a permissive parser
-    accepts by silently keeping the last one.
+    Goes through the catalog's own public loader, because the failure this is
+    most likely to catch is a duplicated key, which a permissive parser accepts
+    by silently keeping the last one. That loader takes a path, so the candidate
+    text is parsed from a scratch file — a cost of nothing beside the network
+    retrieve that produced it, and it keeps a provider off core's internals.
 
     Args:
         text: The rewritten shard text.
@@ -1381,12 +1383,17 @@ def _parses_as_yaml(text: str) -> bool:
     Returns:
         True when the text is loadable as the catalog loads it.
     """
-    from earthlens.base.yaml_loader import _StrictSafeLoader
+    import tempfile
 
-    try:
-        yaml.load(text, Loader=_StrictSafeLoader)
-    except Exception:  # noqa: BLE001 — any parse failure means do not write
-        return False
+    from earthlens.base.yaml_loader import load_yaml_strict
+
+    with tempfile.TemporaryDirectory() as scratch:
+        probe = Path(scratch) / "shard.yaml"
+        probe.write_text(text, encoding="utf-8")
+        try:
+            load_yaml_strict(probe)
+        except Exception:  # noqa: BLE001 — any parse failure means do not write
+            return False
     return True
 
 

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -676,6 +676,54 @@ def _inline_mapping(line: str) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def _extras_span(lines: list[str]) -> tuple[int, int] | None:
+    """Locate a variable sub-block's own `extras:` and everything nested under it.
+
+    Args:
+        lines: One variable sub-block's lines.
+
+    Returns:
+        The `(start, stop)` half-open line range covering the override, or
+        `None` when the row has none.
+    """
+    found = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if line.strip().startswith(_EXTRAS_KEY) and _indent_of(line) == 8
+        ),
+        None,
+    )
+    if found is None:
+        return None
+    stop = found + 1
+    while stop < len(lines) and (
+        not lines[stop].strip() or _indent_of(lines[stop]) > 8
+    ):
+        stop += 1
+    return found, stop
+
+
+def _existing_override(
+    lines: list[str], span: tuple[int, int]
+) -> dict[str, Any] | None:
+    """Read the override a row already carries, whichever shape it is written in.
+
+    Args:
+        lines: One variable sub-block's lines.
+        span: The `(start, stop)` range :func:`_extras_span` found.
+
+    Returns:
+        The parsed override, or `None` when the value is not a mapping at all
+        and therefore must not be merged into or replaced.
+    """
+    head = lines[span[0]]
+    if head.strip() == _EXTRAS_KEY:
+        return _mapping_under(lines, span[0])
+    inline = _inline_mapping(head)
+    return inline or None
+
+
 def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> str:
     """Write a per-variable `extras:` override into one variable sub-block.
 
@@ -688,6 +736,10 @@ def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> st
     inline mapping leaves the row with two `extras:` keys. Both produce a shard
     the catalog cannot load.
 
+    An inline value that is not a mapping at all (`extras: [a, b]`, `extras:
+    null`) is left untouched: it cannot be merged into, and replacing it would
+    delete what a maintainer wrote.
+
     Comments inside a variable's own `extras:` do not survive the rewrite. That
     block is machine-managed; the dataset-level `extras:` where the catalog keeps
     its explanatory comments is never touched.
@@ -699,7 +751,7 @@ def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> st
 
     Returns:
         The stanza body with the override written; unchanged when `slug` is
-        absent or `override` is empty.
+        absent, `override` is empty, or the row's existing value cannot be read.
     """
     if not override:
         return block
@@ -707,38 +759,20 @@ def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> st
         if match.group("slug") != slug:
             continue
         lines = match.group("body").splitlines(keepends=True)
-        found = next(
-            (
-                index
-                for index, line in enumerate(lines)
-                if line.strip().startswith(_EXTRAS_KEY) and _indent_of(line) == 8
-            ),
-            None,
-        )
+        span = _extras_span(lines)
         merged: dict[str, Any] = {}
         head: list[str]
         tail: list[str]
-        if found is None:
+        if span is None:
             head, tail = lines, []
         else:
-            stop = found + 1
-            while stop < len(lines) and (
-                not lines[stop].strip() or _indent_of(lines[stop]) > 8
-            ):
-                stop += 1
-            if lines[found].strip() != _EXTRAS_KEY:
-                merged = _inline_mapping(lines[found])
-                if not merged:
-                    # An inline value that is not a mapping (`extras: [a, b]`,
-                    # `extras: null`) cannot be merged into, and replacing the
-                    # line would delete what a maintainer wrote. Leave it alone
-                    # and let the row be reported as unhydrated instead.
-                    return block
-            else:
-                merged = _mapping_under(lines, found)
-            head, tail = lines[:found], lines[stop:]
+            existing = _existing_override(lines, span)
+            if existing is None:
+                return block
+            merged = existing
+            head, tail = lines[: span[0]], lines[span[1] :]
         merged.update(override)
-        rendered = ["        extras:\n"] + [
+        rendered = [f"        {_EXTRAS_KEY}\n"] + [
             f"          {key}: {_yaml_inline_list(value)}\n"
             for key, value in merged.items()
         ]
@@ -1409,6 +1443,28 @@ def _parses_as_yaml(text: str) -> bool:
     return True
 
 
+def _hydrated_detail(session: _ProbeSession, declined: list[str]) -> str:
+    """Describe what a hydrated dataset left behind, and why it stopped.
+
+    A partial fill that hit a deadline reads the same as one whose rows the
+    store declined, unless the reason is said out loud — and only the first is
+    worth re-running, which matters because the sweep is built to be resumed.
+
+    Args:
+        session: The probe session that ran.
+        declined: The slugs left as placeholders.
+
+    Returns:
+        A suffix for the per-dataset echo, empty when everything was filled.
+    """
+    left = f", {len(declined)} left" if declined else ""
+    if session.timed_out:
+        return f"{left} (timed out; re-run to continue)"
+    if session.error is not None:
+        return f"{left} ({type(session.error).__name__}; re-run to continue)"
+    return left
+
+
 def _hydrate_one(
     dataset_id: str,
     prefix: str,
@@ -1486,13 +1542,10 @@ def _hydrate_one(
         return "unmatched"
     file_text[path] = new_text
     path.write_text(new_text, encoding="utf-8")
-    left = f", {len(declined)} left" if declined else ""
-    why = ""
-    if session.timed_out:
-        why = " (timed out; re-run to continue)"
-    elif session.error is not None:
-        why = f" ({type(session.error).__name__}; re-run to continue)"
-    typer.echo(f"{prefix}: hydrated {len(filled)}{left}{why} -> {path.name}")
+    typer.echo(
+        f"{prefix}: hydrated {len(filled)}"
+        f"{_hydrated_detail(session, declined)} -> {path.name}"
+    )
     return "partial" if session.error is not None else "hydrated"
 
 

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -902,6 +902,36 @@ def _selector_override(
     Returns:
         The subset of `selectors` that differs from `dataset_extras`, keyed the
         same way; empty when the dataset defaults already cover the variable.
+
+    Examples:
+        - A selector the stanza sets differently is worth recording:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _selector_override
+            >>> _selector_override(
+            ...     {"timespan": ["instantaneous"]}, {"timespan": "[time_mean]"}
+            ... )
+            {'timespan': ['instantaneous']}
+
+            ```
+        - One the stanza already agrees with would be noise:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _selector_override
+            >>> _selector_override(
+            ...     {"timespan": ["time_mean"]}, {"timespan": "[time_mean]"}
+            ... )
+            {}
+
+            ```
+        - And one the stanza never declares is not this row's business:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _selector_override
+            >>> _selector_override({"hyear": ["2020"]}, {"timespan": "[time_mean]"})
+            {}
+
+            ```
     """
     override: dict[str, Any] = {}
     for key, value in selectors.items():
@@ -915,7 +945,32 @@ def _selector_override(
 
 
 def _yaml_inline_list(value: Any) -> str:
-    """Render a selector value the way the catalog writes it, as `[a]` or a scalar."""
+    """Render a selector value the way the catalog writes it, as `[a]` or a scalar.
+
+    Args:
+        value: The selector value from a constraints block.
+
+    Returns:
+        The inline YAML text for `value`.
+
+    Examples:
+        - A selector list becomes an inline sequence, matching the shipped rows:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _yaml_inline_list
+            >>> _yaml_inline_list(["instantaneous"])
+            '[instantaneous]'
+
+            ```
+        - A scalar stays a scalar:
+
+            ```python
+            >>> from earthlens.ecmwf._hydrate import _yaml_inline_list
+            >>> _yaml_inline_list("unarchived")
+            'unarchived'
+
+            ```
+    """
     if isinstance(value, list):
         return "[" + ", ".join(str(item) for item in value) + "]"
     return str(value)

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -1450,6 +1450,54 @@ def _parses_as_yaml(text: str) -> bool:
     return True
 
 
+def _written_rows_survive(text: str, dataset_id: str, filled: list[str]) -> bool:
+    """Return True when every row this pass filled reads back as it was written.
+
+    :func:`_parses_as_yaml` proves the shard still loads, which is a weaker claim
+    than it looks: a hydrated value can be perfectly valid YAML and still be the
+    wrong *type* coming back. Nitrogen monoxide's short name is `no`, which YAML
+    1.1 resolves to the boolean `False` — the file parses, and the catalog then
+    refuses to build the row. Writing that value strands every dataset swept
+    after it, because each one reloads the shard the previous one poisoned.
+
+    So the values are read back the way the catalog will read them and required
+    to still be strings. Only the rows named in `filled` are examined: a shard
+    may carry unrelated imperfections that predate the sweep, and refusing to
+    write because of one would cost hydration for a defect this pass did not
+    cause.
+
+    Args:
+        text: The rewritten shard text.
+        dataset_id: The dataset whose stanza was rewritten.
+        filled: Slugs of the variable rows filled in this pass.
+
+    Returns:
+        True when each filled row carries string `nc_variable` and `units`.
+    """
+    import tempfile
+
+    from earthlens.base.yaml_loader import load_yaml_strict
+
+    with tempfile.TemporaryDirectory() as scratch:
+        probe = Path(scratch) / "shard.yaml"
+        probe.write_text(text, encoding="utf-8")
+        try:
+            data = load_yaml_strict(probe)
+        except Exception:  # noqa: BLE001 - the parse guard reports this case
+            return False
+    variables = ((data or {}).get("datasets", {}).get(dataset_id, {}) or {}).get(
+        "variables"
+    ) or {}
+    for slug in filled:
+        row = variables.get(slug)
+        if not isinstance(row, dict):
+            return False
+        for key in ("nc_variable", "units"):
+            if not isinstance(row.get(key), str):
+                return False
+    return True
+
+
 def _hydrated_detail(session: _ProbeSession, declined: list[str]) -> str:
     """Describe what a hydrated dataset left behind, and why it stopped.
 
@@ -1546,6 +1594,12 @@ def _hydrate_one(
         # unloadable family file on disk and only surface later, far from here.
         # Refusing to write costs one dataset's hydration; writing costs the shard.
         typer.echo(f"{prefix}: rewrite did not parse, shard left untouched")
+        return "unmatched"
+    if not _written_rows_survive(new_text, dataset_id, filled):
+        # A value can be valid YAML and still come back the wrong type -- `no`
+        # reads as the boolean False -- which loads here and breaks the catalog
+        # for every dataset swept after this one. Checked before the write.
+        typer.echo(f"{prefix}: rewrite did not reload, shard left untouched")
         return "unmatched"
     file_text[path] = new_text
     path.write_text(new_text, encoding="utf-8")

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -1250,7 +1250,12 @@ def _scalar_after_key(line: str) -> str:
 
 
 def _fill_variable(block: str, slug: str, nc_name: str, units: str) -> str:
-    """Rewrite one variable sub-block's `nc_variable:` / `units:` lines in place."""
+    """Rewrite one variable sub-block's `nc_variable:` / `units:` lines in place.
+
+    Both values are written through the YAML emitter. A NetCDF short name is not
+    safe to interpolate raw: nitrogen monoxide is `no`, which YAML reads back as
+    the boolean `False` and the catalog then refuses to load.
+    """
     var_pat = re.compile(
         rf"(?m)(^ {{6}}{re.escape(slug)}:[ \t]*\n(?:^ {{8}}[^\n]*\n)*)"
     )
@@ -1258,7 +1263,9 @@ def _fill_variable(block: str, slug: str, nc_name: str, units: str) -> str:
     if not match:
         return block
     sub = match.group(1)
-    sub = _NC_VARIABLE_LINE.sub(lambda mo: f"{mo.group(1)} {nc_name}", sub, count=1)
+    sub = _NC_VARIABLE_LINE.sub(
+        lambda mo: f"{mo.group(1)} {_yaml_value(nc_name)}", sub, count=1
+    )
     sub = _UNITS_LINE.sub(
         lambda mo: f"{mo.group(1)} {_yaml_value(units)}", sub, count=1
     )

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/_hydrate.py
@@ -706,11 +706,16 @@ def _fill_variable_extras(block: str, slug: str, override: dict[str, Any]) -> st
                 not lines[stop].strip() or _indent_of(lines[stop]) > 8
             ):
                 stop += 1
-            merged = (
-                _inline_mapping(lines[found])
-                if lines[found].strip() != "extras:"
-                else _mapping_under(lines, found)
-            )
+            if lines[found].strip() != "extras:":
+                merged = _inline_mapping(lines[found])
+                if not merged:
+                    # An inline value that is not a mapping (`extras: [a, b]`,
+                    # `extras: null`) cannot be merged into, and replacing the
+                    # line would delete what a maintainer wrote. Leave it alone
+                    # and let the row be reported as unhydrated instead.
+                    return block
+            else:
+                merged = _mapping_under(lines, found)
             head, tail = lines[:found], lines[stop:]
         merged.update(override)
         rendered = ["        extras:\n"] + [
@@ -737,8 +742,10 @@ def _hydrate_stanza_per_variable(
     and the serving block's selectors are recorded as a per-variable override
     when they differ from the stanza's defaults.
 
-    Names bound by rows filled earlier in the same pass are withheld from later
-    ones, so two rows cannot end up claiming one NetCDF variable.
+    Names bound by rows filled earlier in the same pass are withheld from the
+    leftover rule, so a guess cannot land on a name another row already holds.
+    The confident rules may still share one — a short name legitimately serves
+    several rows where CARRA repeats it across level families.
 
     Args:
         text: The full per-family catalog shard text.
@@ -1417,14 +1424,20 @@ def _hydrate_one(
     new_text, filled, declined = _hydrate_stanza_per_variable(
         file_text[path], dataset_id, session
     )
-    if not filled and session.error is None and not session.answered:
-        # No constraints block names these rows, which is how a product with no
-        # variable dimension looks (obs4mips CO2/CH4 partition by nothing the
-        # slug can be found under). One whole-dataset probe still describes it,
-        # so fall back rather than leave such a stanza permanently unhydratable.
-        new_text, filled, declined = _hydrate_stanza_whole(
-            file_text[path], dataset_id, session
+    if declined and session.error is None:
+        # A row no constraints block names is declined outright by the
+        # per-variable pass: that is how a product with no variable dimension
+        # looks (obs4mips CO2/CH4 partition by nothing the slug can be found
+        # under), and also how a stale request-side name looks. One
+        # whole-dataset probe can still describe those rows by name, so it runs
+        # whenever anything was declined — not only when the whole stanza was,
+        # which would strand such a row the moment a sibling answered.
+        recovered, also_filled, declined = _hydrate_stanza_whole(
+            new_text, dataset_id, session
         )
+        if also_filled:
+            new_text = recovered
+            filled = filled + also_filled
     if session.timed_out and not filled:
         typer.echo(f"{prefix}: timed out, skipped")
         return "timed_out"

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/ads.yaml
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/ads.yaml
@@ -1469,7 +1469,7 @@ datasets:
         units: kg kg**-1
       nitrogen-monoxide:
         cds_variable: nitrogen_monoxide
-        nc_variable: no
+        nc_variable: 'no'
         units: kg kg**-1
       ozone:
         cds_variable: ozone

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/ads.yaml
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/ads.yaml
@@ -1539,8 +1539,10 @@ datasets:
     variables:
       global-horizontal-irradiation:
         cds_variable: global_horizontal_irradiation
-        nc_variable: global_horizontal_irradiation
-        units: unknown
+        nc_variable: global_horizontal_clear_sky_irradiation
+        units: W h m-2
+        extras:
+          sky_type: [clear, observed_cloud]
       # The hydrated name below is specific to the `sky_type: [clear]` pinned
       # in this row's extras — under `sky_type: [all]` the file carries no
       # `beam_horizontal_clear_sky_irradiation`, so changing that pin means
@@ -1551,12 +1553,16 @@ datasets:
         units: W h m-2
       diffuse-horizontal-irradiation:
         cds_variable: diffuse_horizontal_irradiation
-        nc_variable: diffuse_horizontal_irradiation
-        units: unknown
+        nc_variable: diffuse_horizontal_clear_sky_irradiation
+        units: W h m-2
+        extras:
+          sky_type: [clear, observed_cloud]
       direct-normal-irradiation:
         cds_variable: direct_normal_irradiation
-        nc_variable: direct_normal_irradiation
-        units: unknown
+        nc_variable: beam_normal_clear_sky_irradiation
+        units: W h m-2
+        extras:
+          sky_type: [clear, observed_cloud]
   cams-solar-radiation-timeseries:
     endpoint: ads
     request_kind: cams_date

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/ads.yaml
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/ads.yaml
@@ -169,8 +169,10 @@ datasets:
         units: unknown
       ash:
         cds_variable: ash
-        nc_variable: ash
-        units: unknown
+        nc_variable: sum
+        units: kg m-2 s-1
+        extras:
+          source: [shipping]
       benzene:
         cds_variable: benzene
         nc_variable: benzene
@@ -185,8 +187,10 @@ datasets:
         units: unknown
       bromoform:
         cds_variable: bromoform
-        nc_variable: bromoform
-        units: unknown
+        nc_variable: emi_oceans
+        units: kg m-2 s-1
+        extras:
+          source: [oceanic]
       butanes:
         cds_variable: butanes
         nc_variable: butanes
@@ -229,8 +233,10 @@ datasets:
         units: unknown
       elemental-carbon:
         cds_variable: elemental_carbon
-        nc_variable: elemental_carbon
-        units: unknown
+        nc_variable: sum
+        units: kg m-2 s-1
+        extras:
+          source: [shipping]
       esters:
         cds_variable: esters
         nc_variable: esters

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/ads.yaml
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/ads.yaml
@@ -407,8 +407,10 @@ datasets:
     variables:
       downward-uv-radiation-at-the-surface:
         cds_variable: downward_uv_radiation_at_the_surface
-        nc_variable: downward_uv_radiation_at_the_surface
-        units: unknown
+        nc_variable: uvb
+        units: J m**-2
+        extras:
+          step: ['0', '12', '15', '18', '21', '3', '6', '9']
       forecast-albedo:
         cds_variable: forecast_albedo
         nc_variable: forecast_albedo
@@ -744,16 +746,16 @@ datasets:
     variables:
       snow-albedo:
         cds_variable: snow_albedo
-        nc_variable: snow_albedo
-        units: unknown
+        nc_variable: asn
+        units: (0 - 1)
       ch4-column-mean-molar-fraction:
         cds_variable: ch4_column_mean_molar_fraction
-        nc_variable: ch4_column_mean_molar_fraction
-        units: unknown
+        nc_variable: tcch4
+        units: ppb
       co2-column-mean-molar-fraction:
         cds_variable: co2_column_mean_molar_fraction
-        nc_variable: co2_column_mean_molar_fraction
-        units: unknown
+        nc_variable: tcco2
+        units: ppm
       accumulated-carbon-dioxide-ecosystem-respiration:
         cds_variable: accumulated_carbon_dioxide_ecosystem_respiration
         nc_variable: accumulated_carbon_dioxide_ecosystem_respiration

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/ads.yaml
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/ads.yaml
@@ -844,8 +844,8 @@ datasets:
     variables:
       ch4-column-mean-molar-fraction:
         cds_variable: ch4_column_mean_molar_fraction
-        nc_variable: ch4_column_mean_molar_fraction
-        units: unknown
+        nc_variable: tcch4
+        units: ppb
       co2-column-mean-molar-fraction:
         cds_variable: co2_column_mean_molar_fraction
         nc_variable: co2_column_mean_molar_fraction
@@ -1139,16 +1139,22 @@ datasets:
     variables:
       aerosol-radiation-effect:
         cds_variable: aerosol_radiation_effect
-        nc_variable: aerosol_radiation_effect
-        units: unknown
+        nc_variable: re_ari_anth_srf_sw_cs
+        units: Wm-2
+        extras:
+          aerosol_type: [anthropogenic, marine, mineral_dust, natural_land]
       aerosol-optical-depth-550nm:
         cds_variable: aerosol_optical_depth_550nm
-        nc_variable: aerosol_optical_depth_550nm
-        units: unknown
+        nc_variable: od550anth
+        units: '1'
+        extras:
+          aerosol_type: [anthropogenic, marine, mineral_dust, natural_land, total]
       aerosol-absorption-optical-depth-550nm:
         cds_variable: aerosol_absorption_optical_depth_550nm
-        nc_variable: aerosol_absorption_optical_depth_550nm
-        units: unknown
+        nc_variable: abs550anth
+        units: '1'
+        extras:
+          aerosol_type: [anthropogenic, marine, mineral_dust, natural_land]
   cams-global-radiative-forcings:
     endpoint: ads
     request_kind: form
@@ -1199,328 +1205,328 @@ datasets:
     variables:
       2m-dewpoint-temperature:
         cds_variable: 2m_dewpoint_temperature
-        nc_variable: 2m_dewpoint_temperature
-        units: unknown
+        nc_variable: d2m
+        units: K
       2m-temperature:
         cds_variable: 2m_temperature
-        nc_variable: 2m_temperature
-        units: unknown
+        nc_variable: t2m
+        units: K
       black-carbon-aerosol-optical-depth-550nm:
         cds_variable: black_carbon_aerosol_optical_depth_550nm
-        nc_variable: black_carbon_aerosol_optical_depth_550nm
-        units: unknown
+        nc_variable: bcaod550
+        units: '~'
       charnock:
         cds_variable: charnock
-        nc_variable: charnock
-        units: unknown
+        nc_variable: chnk
+        units: Numeric
       dust-aerosol-optical-depth-550nm:
         cds_variable: dust_aerosol_optical_depth_550nm
-        nc_variable: dust_aerosol_optical_depth_550nm
-        units: unknown
+        nc_variable: duaod550
+        units: '~'
       ice-temperature-layer-1:
         cds_variable: ice_temperature_layer_1
-        nc_variable: ice_temperature_layer_1
-        units: unknown
+        nc_variable: istl1
+        units: K
       leaf-area-index-high-vegetation:
         cds_variable: leaf_area_index_high_vegetation
-        nc_variable: leaf_area_index_high_vegetation
-        units: unknown
+        nc_variable: lai_hv
+        units: m**2 m**-2
       leaf-area-index-low-vegetation:
         cds_variable: leaf_area_index_low_vegetation
-        nc_variable: leaf_area_index_low_vegetation
-        units: unknown
+        nc_variable: lai_lv
+        units: m**2 m**-2
       mean-sea-level-pressure:
         cds_variable: mean_sea_level_pressure
-        nc_variable: mean_sea_level_pressure
-        units: unknown
+        nc_variable: msl
+        units: Pa
       organic-matter-aerosol-optical-depth-550nm:
         cds_variable: organic_matter_aerosol_optical_depth_550nm
-        nc_variable: organic_matter_aerosol_optical_depth_550nm
-        units: unknown
+        nc_variable: omaod550
+        units: '~'
       particulate-matter-2.5um:
         cds_variable: particulate_matter_2.5um
-        nc_variable: particulate_matter_2.5um
-        units: unknown
+        nc_variable: pm2p5
+        units: kg m**-3
       particulate-matter-10um:
         cds_variable: particulate_matter_10um
-        nc_variable: particulate_matter_10um
-        units: unknown
+        nc_variable: pm10
+        units: kg m**-3
       sea-salt-aerosol-optical-depth-550nm:
         cds_variable: sea_salt_aerosol_optical_depth_550nm
-        nc_variable: sea_salt_aerosol_optical_depth_550nm
-        units: unknown
+        nc_variable: ssaod550
+        units: '~'
       sea-surface-temperature:
         cds_variable: sea_surface_temperature
-        nc_variable: sea_surface_temperature
-        units: unknown
+        nc_variable: sst
+        units: K
       sea-ice-cover:
         cds_variable: sea_ice_cover
-        nc_variable: sea_ice_cover
-        units: unknown
+        nc_variable: siconc
+        units: (0 - 1)
       snow-albedo:
         cds_variable: snow_albedo
-        nc_variable: snow_albedo
-        units: unknown
+        nc_variable: asn
+        units: (0 - 1)
       snow-density:
         cds_variable: snow_density
-        nc_variable: snow_density
-        units: unknown
+        nc_variable: rsn
+        units: kg m**-3
       snow-depth:
         cds_variable: snow_depth
-        nc_variable: snow_depth
-        units: unknown
+        nc_variable: sd
+        units: m of water equivalent
       soil-temperature-level-1:
         cds_variable: soil_temperature_level_1
-        nc_variable: soil_temperature_level_1
-        units: unknown
+        nc_variable: stl1
+        units: K
       sulphate-aerosol-optical-depth-550nm:
         cds_variable: sulphate_aerosol_optical_depth_550nm
-        nc_variable: sulphate_aerosol_optical_depth_550nm
-        units: unknown
+        nc_variable: suaod550
+        units: '~'
       surface-pressure:
         cds_variable: surface_pressure
-        nc_variable: surface_pressure
-        units: unknown
+        nc_variable: sp
+        units: Pa
       temperature-of-snow-layer:
         cds_variable: temperature_of_snow_layer
-        nc_variable: temperature_of_snow_layer
-        units: unknown
+        nc_variable: tsn
+        units: K
       total-aerosol-optical-depth-550nm:
         cds_variable: total_aerosol_optical_depth_550nm
-        nc_variable: total_aerosol_optical_depth_550nm
-        units: unknown
+        nc_variable: aod550
+        units: '~'
       total-column-carbon-monoxide:
         cds_variable: total_column_carbon_monoxide
-        nc_variable: total_column_carbon_monoxide
-        units: unknown
+        nc_variable: tcco
+        units: kg m**-2
       total-column-ethane:
         cds_variable: total_column_ethane
-        nc_variable: total_column_ethane
-        units: unknown
+        nc_variable: tc_c2h6
+        units: kg m**-2
       total-column-formaldehyde:
         cds_variable: total_column_formaldehyde
-        nc_variable: total_column_formaldehyde
-        units: unknown
+        nc_variable: tchcho
+        units: kg m**-2
       total-column-hydroxyl-radical:
         cds_variable: total_column_hydroxyl_radical
-        nc_variable: total_column_hydroxyl_radical
-        units: unknown
+        nc_variable: tc_oh
+        units: kg m**-2
       total-column-isoprene:
         cds_variable: total_column_isoprene
-        nc_variable: total_column_isoprene
-        units: unknown
+        nc_variable: tc_c5h8
+        units: kg m**-2
       total-column-methane:
         cds_variable: total_column_methane
-        nc_variable: total_column_methane
-        units: unknown
+        nc_variable: tc_ch4
+        units: kg m**-2
       total-column-nitric-acid:
         cds_variable: total_column_nitric_acid
-        nc_variable: total_column_nitric_acid
-        units: unknown
+        nc_variable: tc_hno3
+        units: kg m**-2
       total-column-nitrogen-dioxide:
         cds_variable: total_column_nitrogen_dioxide
-        nc_variable: total_column_nitrogen_dioxide
-        units: unknown
+        nc_variable: tcno2
+        units: kg m**-2
       total-column-nitrogen-monoxide:
         cds_variable: total_column_nitrogen_monoxide
-        nc_variable: total_column_nitrogen_monoxide
-        units: unknown
+        nc_variable: tc_no
+        units: kg m**-2
       total-column-ozone:
         cds_variable: total_column_ozone
-        nc_variable: total_column_ozone
-        units: unknown
+        nc_variable: gtco3
+        units: kg m**-2
       total-column-peroxyacetyl-nitrate:
         cds_variable: total_column_peroxyacetyl_nitrate
-        nc_variable: total_column_peroxyacetyl_nitrate
-        units: unknown
+        nc_variable: tc_pan
+        units: kg m**-2
       total-column-propane:
         cds_variable: total_column_propane
-        nc_variable: total_column_propane
-        units: unknown
+        nc_variable: tc_c3h8
+        units: kg m**-2
       total-column-sulphur-dioxide:
         cds_variable: total_column_sulphur_dioxide
-        nc_variable: total_column_sulphur_dioxide
-        units: unknown
+        nc_variable: tcso2
+        units: kg m**-2
       total-column-water:
         cds_variable: total_column_water
-        nc_variable: total_column_water
-        units: unknown
+        nc_variable: tcw
+        units: kg m**-2
       total-column-water-vapour:
         cds_variable: total_column_water_vapour
-        nc_variable: total_column_water_vapour
-        units: unknown
+        nc_variable: tcwv
+        units: kg m**-2
       vertically-integrated-mass-of-dust-aerosol-0.03-0.55um:
         cds_variable: vertically_integrated_mass_of_dust_aerosol_0.03-0.55um
-        nc_variable: vertically_integrated_mass_of_dust_aerosol_0.03-0.55um
-        units: unknown
+        nc_variable: aermssdus
+        units: kg m**-2
       vertically-integrated-mass-of-dust-aerosol-0.55-9um:
         cds_variable: vertically_integrated_mass_of_dust_aerosol_0.55-9um
-        nc_variable: vertically_integrated_mass_of_dust_aerosol_0.55-9um
-        units: unknown
+        nc_variable: aermssdum
+        units: kg m**-2
       vertically-integrated-mass-of-dust-aerosol-9-20um:
         cds_variable: vertically_integrated_mass_of_dust_aerosol_9-20um
-        nc_variable: vertically_integrated_mass_of_dust_aerosol_9-20um
-        units: unknown
+        nc_variable: aermssdul
+        units: kg m**-2
       vertically-integrated-mass-of-hydrophilic-black-carbon-aerosol:
         cds_variable: vertically_integrated_mass_of_hydrophilic_black_carbon_aerosol
-        nc_variable: vertically_integrated_mass_of_hydrophilic_black_carbon_aerosol
-        units: unknown
+        nc_variable: aermssbchphil
+        units: kg m**-2
       vertically-integrated-mass-of-hydrophilic-organic-matter-aerosol:
         cds_variable: vertically_integrated_mass_of_hydrophilic_organic_matter_aerosol
-        nc_variable: vertically_integrated_mass_of_hydrophilic_organic_matter_aerosol
-        units: unknown
+        nc_variable: aermssomhphil
+        units: kg m**-2
       vertically-integrated-mass-of-hydrophobic-black-carbon-aerosol:
         cds_variable: vertically_integrated_mass_of_hydrophobic_black_carbon_aerosol
-        nc_variable: vertically_integrated_mass_of_hydrophobic_black_carbon_aerosol
-        units: unknown
+        nc_variable: aermssbchphob
+        units: kg m**-2
       vertically-integrated-mass-of-hydrophobic-organic-matter-aerosol:
         cds_variable: vertically_integrated_mass_of_hydrophobic_organic_matter_aerosol
-        nc_variable: vertically_integrated_mass_of_hydrophobic_organic_matter_aerosol
-        units: unknown
+        nc_variable: aermssomhphob
+        units: kg m**-2
       vertically-integrated-mass-of-sea-salt-aerosol-0.03-0.5um:
         cds_variable: vertically_integrated_mass_of_sea_salt_aerosol_0.03-0.5um
-        nc_variable: vertically_integrated_mass_of_sea_salt_aerosol_0.03-0.5um
-        units: unknown
+        nc_variable: aermsssss
+        units: kg m**-2
       vertically-integrated-mass-of-sea-salt-aerosol-0.5-5um:
         cds_variable: vertically_integrated_mass_of_sea_salt_aerosol_0.5-5um
-        nc_variable: vertically_integrated_mass_of_sea_salt_aerosol_0.5-5um
-        units: unknown
+        nc_variable: aermssssm
+        units: kg m**-2
       vertically-integrated-mass-of-sea-salt-aerosol-5-20um:
         cds_variable: vertically_integrated_mass_of_sea_salt_aerosol_5-20um
-        nc_variable: vertically_integrated_mass_of_sea_salt_aerosol_5-20um
-        units: unknown
+        nc_variable: aermssssl
+        units: kg m**-2
       vertically-integrated-mass-of-sulphate-aerosol:
         cds_variable: vertically_integrated_mass_of_sulphate_aerosol
-        nc_variable: vertically_integrated_mass_of_sulphate_aerosol
-        units: unknown
+        nc_variable: aermsssu
+        units: kg m**-2
       vertically-integrated-mass-of-sulphur-dioxide:
         cds_variable: vertically_integrated_mass_of_sulphur_dioxide
-        nc_variable: vertically_integrated_mass_of_sulphur_dioxide
-        units: unknown
+        nc_variable: aermssso2
+        units: kg m**-2
       carbon-monoxide:
         cds_variable: carbon_monoxide
         nc_variable: co
         units: kg kg**-1
       dust-aerosol-0.03-0.55um-mixing-ratio:
         cds_variable: dust_aerosol_0.03-0.55um_mixing_ratio
-        nc_variable: dust_aerosol_0.03-0.55um_mixing_ratio
-        units: unknown
+        nc_variable: aermr04
+        units: kg kg**-1
       dust-aerosol-0.55-0.9um-mixing-ratio:
         cds_variable: dust_aerosol_0.55-0.9um_mixing_ratio
-        nc_variable: dust_aerosol_0.55-0.9um_mixing_ratio
-        units: unknown
+        nc_variable: aermr05
+        units: kg kg**-1
       dust-aerosol-0.9-20um-mixing-ratio:
         cds_variable: dust_aerosol_0.9-20um_mixing_ratio
-        nc_variable: dust_aerosol_0.9-20um_mixing_ratio
-        units: unknown
+        nc_variable: aermr06
+        units: kg kg**-1
       ethane:
         cds_variable: ethane
-        nc_variable: ethane
-        units: unknown
+        nc_variable: c2h6
+        units: kg kg**-1
       formaldehyde:
         cds_variable: formaldehyde
-        nc_variable: formaldehyde
-        units: unknown
+        nc_variable: hcho
+        units: kg kg**-1
       geopotential:
         cds_variable: geopotential
-        nc_variable: geopotential
-        units: unknown
+        nc_variable: z
+        units: m**2 s**-2
       hydrophilic-black-carbon-aerosol-mixing-ratio:
         cds_variable: hydrophilic_black_carbon_aerosol_mixing_ratio
-        nc_variable: hydrophilic_black_carbon_aerosol_mixing_ratio
-        units: unknown
+        nc_variable: aermr09
+        units: kg kg**-1
       hydrophilic-organic-matter-aerosol-mixing-ratio:
         cds_variable: hydrophilic_organic_matter_aerosol_mixing_ratio
-        nc_variable: hydrophilic_organic_matter_aerosol_mixing_ratio
-        units: unknown
+        nc_variable: aermr07
+        units: kg kg**-1
       hydrophobic-black-carbon-aerosol-mixing-ratio:
         cds_variable: hydrophobic_black_carbon_aerosol_mixing_ratio
-        nc_variable: hydrophobic_black_carbon_aerosol_mixing_ratio
-        units: unknown
+        nc_variable: aermr10
+        units: kg kg**-1
       hydrophobic-organic-matter-aerosol-mixing-ratio:
         cds_variable: hydrophobic_organic_matter_aerosol_mixing_ratio
-        nc_variable: hydrophobic_organic_matter_aerosol_mixing_ratio
-        units: unknown
+        nc_variable: aermr08
+        units: kg kg**-1
       hydroxyl-radical:
         cds_variable: hydroxyl_radical
-        nc_variable: hydroxyl_radical
-        units: unknown
+        nc_variable: oh
+        units: kg kg**-1
       isoprene:
         cds_variable: isoprene
-        nc_variable: isoprene
-        units: unknown
+        nc_variable: c5h8
+        units: kg kg**-1
       methane-chemistry:
         cds_variable: methane_chemistry
-        nc_variable: methane_chemistry
-        units: unknown
+        nc_variable: ch4_c
+        units: kg kg**-1
       nitric-acid:
         cds_variable: nitric_acid
-        nc_variable: nitric_acid
-        units: unknown
+        nc_variable: hno3
+        units: kg kg**-1
       nitrogen-dioxide:
         cds_variable: nitrogen_dioxide
-        nc_variable: nitrogen_dioxide
-        units: unknown
+        nc_variable: no2
+        units: kg kg**-1
       nitrogen-monoxide:
         cds_variable: nitrogen_monoxide
-        nc_variable: nitrogen_monoxide
-        units: unknown
+        nc_variable: no
+        units: kg kg**-1
       ozone:
         cds_variable: ozone
-        nc_variable: ozone
-        units: unknown
+        nc_variable: go3
+        units: kg kg**-1
       peroxyacetyl-nitrate:
         cds_variable: peroxyacetyl_nitrate
-        nc_variable: peroxyacetyl_nitrate
-        units: unknown
+        nc_variable: pan
+        units: kg kg**-1
       potential-vorticity:
         cds_variable: potential_vorticity
-        nc_variable: potential_vorticity
-        units: unknown
+        nc_variable: pv
+        units: K m**2 kg**-1 s**-1
       propane:
         cds_variable: propane
-        nc_variable: propane
-        units: unknown
+        nc_variable: c3h8
+        units: kg kg**-1
       relative-humidity:
         cds_variable: relative_humidity
-        nc_variable: relative_humidity
-        units: unknown
+        nc_variable: r
+        units: '%'
       sea-salt-aerosol-0.03-0.5um-mixing-ratio:
         cds_variable: sea_salt_aerosol_0.03-0.5um_mixing_ratio
-        nc_variable: sea_salt_aerosol_0.03-0.5um_mixing_ratio
-        units: unknown
+        nc_variable: aermr01
+        units: kg kg**-1
       sea-salt-aerosol-0.5-5um-mixing-ratio:
         cds_variable: sea_salt_aerosol_0.5-5um_mixing_ratio
-        nc_variable: sea_salt_aerosol_0.5-5um_mixing_ratio
-        units: unknown
+        nc_variable: aermr02
+        units: kg kg**-1
       sea-salt-aerosol-5-20um-mixing-ratio:
         cds_variable: sea_salt_aerosol_5-20um_mixing_ratio
-        nc_variable: sea_salt_aerosol_5-20um_mixing_ratio
-        units: unknown
+        nc_variable: aermr03
+        units: kg kg**-1
       so2-precursor-mixing-ratio:
         cds_variable: so2_precursor_mixing_ratio
-        nc_variable: so2_precursor_mixing_ratio
-        units: unknown
+        nc_variable: aermr12
+        units: kg kg**-1
       specific-humidity:
         cds_variable: specific_humidity
-        nc_variable: specific_humidity
-        units: unknown
+        nc_variable: q
+        units: kg kg**-1
       sulphate-aerosol-mixing-ratio:
         cds_variable: sulphate_aerosol_mixing_ratio
-        nc_variable: sulphate_aerosol_mixing_ratio
-        units: unknown
+        nc_variable: aermr11
+        units: kg kg**-1
       sulphur-dioxide:
         cds_variable: sulphur_dioxide
-        nc_variable: sulphur_dioxide
-        units: unknown
+        nc_variable: so2
+        units: kg kg**-1
       temperature:
         cds_variable: temperature
-        nc_variable: temperature
-        units: unknown
+        nc_variable: t
+        units: K
       vertical-velocity:
         cds_variable: vertical_velocity
-        nc_variable: vertical_velocity
-        units: unknown
+        nc_variable: w
+        units: Pa s**-1
   cams-gridded-solar-radiation:
     endpoint: ads
     request_kind: form

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/other.yaml
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/other.yaml
@@ -2334,80 +2334,80 @@ datasets:
     variables:
       monthly-temperature:
         cds_variable: monthly_temperature
-        nc_variable: monthly_temperature
-        units: unknown
+        nc_variable: t
+        units: degC
       monthly-daily-minimum-temperature:
         cds_variable: monthly_daily_minimum_temperature
-        nc_variable: monthly_daily_minimum_temperature
-        units: unknown
+        nc_variable: tn
+        units: degC
       monthly-daily-maximum-temperature:
         cds_variable: monthly_daily_maximum_temperature
-        nc_variable: monthly_daily_maximum_temperature
-        units: unknown
+        nc_variable: tx
+        units: degC
       monthly-daily-temperature-range:
         cds_variable: monthly_daily_temperature_range
-        nc_variable: monthly_daily_temperature_range
-        units: unknown
+        nc_variable: dtr
+        units: degC
       monthly-maximum-of-daily-maximum-temperature:
         cds_variable: monthly_maximum_of_daily_maximum_temperature
-        nc_variable: monthly_maximum_of_daily_maximum_temperature
-        units: unknown
+        nc_variable: txx
+        units: degC
       monthly-extreme-hot-days:
         cds_variable: monthly_extreme_hot_days
-        nc_variable: monthly_extreme_hot_days
-        units: unknown
+        nc_variable: tx35
+        units: '1'
       monthly-very-extreme-hot-days:
         cds_variable: monthly_very_extreme_hot_days
-        nc_variable: monthly_very_extreme_hot_days
-        units: unknown
+        nc_variable: tx40
+        units: '1'
       monthly-tropical-nights:
         cds_variable: monthly_tropical_nights
-        nc_variable: monthly_tropical_nights
-        units: unknown
+        nc_variable: tr
+        units: '1'
       annual-cooling-degree-days:
         cds_variable: annual_cooling_degree_days
-        nc_variable: annual_cooling_degree_days
-        units: unknown
+        nc_variable: cd
+        units: degC day
       monthly-minimum-of-daily-minimum-temperature:
         cds_variable: monthly_minimum_of_daily_minimum_temperature
-        nc_variable: monthly_minimum_of_daily_minimum_temperature
-        units: unknown
+        nc_variable: tnn
+        units: degC
       monthly-frost-days:
         cds_variable: monthly_frost_days
-        nc_variable: monthly_frost_days
-        units: unknown
+        nc_variable: fd
+        units: '1'
       annual-heating-degree-days:
         cds_variable: annual_heating_degree_days
-        nc_variable: annual_heating_degree_days
-        units: unknown
+        nc_variable: hd
+        units: degC day
       monthly-precipitation:
         cds_variable: monthly_precipitation
-        nc_variable: monthly_precipitation
-        units: unknown
+        nc_variable: r
+        units: mm
       monthly-wet-days:
         cds_variable: monthly_wet_days
-        nc_variable: monthly_wet_days
-        units: unknown
+        nc_variable: r01
+        units: '1'
       monthly-precipitation-intensity:
         cds_variable: monthly_precipitation_intensity
-        nc_variable: monthly_precipitation_intensity
-        units: unknown
+        nc_variable: sdii
+        units: mm
       monthly-maximum-1-day-precipitation:
         cds_variable: monthly_maximum_1_day_precipitation
-        nc_variable: monthly_maximum_1_day_precipitation
-        units: unknown
+        nc_variable: rx1day
+        units: mm
       monthly-maximum-5-day-precipitation:
         cds_variable: monthly_maximum_5_day_precipitation
-        nc_variable: monthly_maximum_5_day_precipitation
-        units: unknown
+        nc_variable: rx5day
+        units: mm
       monthly-heavy-precipitation-days:
         cds_variable: monthly_heavy_precipitation_days
-        nc_variable: monthly_heavy_precipitation_days
-        units: unknown
+        nc_variable: r10
+        units: '1'
       monthly-very-heavy-precipitation-days:
         cds_variable: monthly_very_heavy_precipitation_days
-        nc_variable: monthly_very_heavy_precipitation_days
-        units: unknown
+        nc_variable: r20
+        units: '1'
       monthly-near-surface-specific-humidity:
         cds_variable: monthly_near_surface_specific_humidity
         nc_variable: monthly_near_surface_specific_humidity

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/other.yaml
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/catalog/other.yaml
@@ -1789,40 +1789,67 @@ datasets:
     variables:
       mean-temperature:
         cds_variable: mean_temperature
-        nc_variable: mean_temperature
-        units: unknown
+        nc_variable: tg
+        units: Celsius
+        extras:
+          grid_resolution: [0_1deg, 0_25deg]
+          product_type: [ensemble_mean, ensemble_spread]
       minimum-temperature:
         cds_variable: minimum_temperature
-        nc_variable: minimum_temperature
-        units: unknown
+        nc_variable: tn
+        units: Celsius
+        extras:
+          grid_resolution: [0_1deg, 0_25deg]
+          product_type: [ensemble_mean, ensemble_spread]
       maximum-temperature:
         cds_variable: maximum_temperature
-        nc_variable: maximum_temperature
-        units: unknown
+        nc_variable: tx
+        units: Celsius
+        extras:
+          grid_resolution: [0_1deg, 0_25deg]
+          product_type: [ensemble_mean, ensemble_spread]
       precipitation-amount:
         cds_variable: precipitation_amount
-        nc_variable: precipitation_amount
-        units: unknown
+        nc_variable: rr
+        units: mm
+        extras:
+          grid_resolution: [0_1deg, 0_25deg]
+          product_type: [ensemble_mean, ensemble_spread]
       sea-level-pressure:
         cds_variable: sea_level_pressure
-        nc_variable: sea_level_pressure
-        units: unknown
+        nc_variable: pp
+        units: hPa
+        extras:
+          grid_resolution: [0_1deg, 0_25deg]
+          product_type: [ensemble_mean, ensemble_spread]
       surface-shortwave-downwelling-radiation:
         cds_variable: surface_shortwave_downwelling_radiation
-        nc_variable: surface_shortwave_downwelling_radiation
-        units: unknown
+        nc_variable: qq
+        units: W/m2
+        extras:
+          grid_resolution: [0_1deg, 0_25deg]
+          product_type: [ensemble_mean, ensemble_spread]
       relative-humidity:
         cds_variable: relative_humidity
-        nc_variable: relative_humidity
-        units: unknown
+        nc_variable: hu
+        units: '%'
+        extras:
+          grid_resolution: [0_1deg, 0_25deg]
+          product_type: [ensemble_mean, ensemble_spread]
       wind-speed:
         cds_variable: wind_speed
-        nc_variable: wind_speed
-        units: unknown
+        nc_variable: fg
+        units: m/s
+        extras:
+          grid_resolution: [0_1deg, 0_25deg]
+          product_type: [ensemble_mean, ensemble_spread]
       land-surface-elevation:
         cds_variable: land_surface_elevation
-        nc_variable: land_surface_elevation
-        units: unknown
+        nc_variable: elevation
+        units: metres
+        extras:
+          grid_resolution: [0_1deg, 0_25deg]
+          version: [27_0e, 28_0e, 29_0e, 30_0e, 31_0e, 32_0e, 33_0e]
   insitu-gridded-observations-global-and-regional:
     endpoint: cds
     request_kind: form
@@ -1840,8 +1867,14 @@ datasets:
     variables:
       temperature:
         cds_variable: temperature
-        nc_variable: temperature
-        units: unknown
+        nc_variable: tasmax
+        units: degrees Celsius
+        extras:
+          horizontal_aggregation: [0_5_x_0_5, 1_x_1, 2_5_x_2_5]
+          origin: [cru]
+          region: [global]
+          time_aggregation: [monthly]
+          version: [v4_03]
       temperature-anomaly:
         cds_variable: temperature_anomaly
         nc_variable: temperature_anomaly
@@ -1862,20 +1895,26 @@ datasets:
     variables:
       precipitation:
         cds_variable: precipitation
-        nc_variable: precipitation
-        units: unknown
+        nc_variable: RR
+        units: kg/m^2
+        extras:
+          spatial_interpolation_method: [type_1, type_2]
       mean-temperature:
         cds_variable: mean_temperature
-        nc_variable: mean_temperature
-        units: unknown
+        nc_variable: TG
+        units: K
+        extras:
+          spatial_interpolation_method: [type_1, type_2]
       maximum-temperature:
         cds_variable: maximum_temperature
         nc_variable: TX
         units: K
       minimum-temperature:
         cds_variable: minimum_temperature
-        nc_variable: minimum_temperature
-        units: unknown
+        nc_variable: TN
+        units: K
+        extras:
+          spatial_interpolation_method: [type_1, type_2]
   insitu-observations-gnss:
     endpoint: cds
     request_kind: form

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/cli.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/cli.py
@@ -281,6 +281,9 @@ def _retrieve_probe(dataset: str, request: dict[str, Any]) -> dict[str, dict[str
     `process not found`. A zip-of-NetCDF response (satellite CDRs deliver one)
     is unwrapped to its first member before the metadata is read via GDAL.
 
+    Writes under `EARTHLENS_CACHE_DIR` when that is set, and removes the scratch
+    directory once the metadata has been read.
+
     Args:
         dataset: The Copernicus dataset id to retrieve from.
         request: The request mapping to submit.
@@ -288,24 +291,33 @@ def _retrieve_probe(dataset: str, request: dict[str, Any]) -> dict[str, dict[str
     Returns:
         Mapping of NetCDF short name to `{long_name, units}`.
     """
+    import os
     import shutil
     import tempfile
     import zipfile
 
     from earthlens.ecmwf.endpoints import open_client
 
-    target = Path(tempfile.mkdtemp()) / "probe.nc"
-    client = open_client(_endpoint_for(dataset))
-    client.retrieve(dataset, request, str(target))
-    if zipfile.is_zipfile(target):
-        with zipfile.ZipFile(target) as archive:
-            members = [name for name in archive.namelist() if name.endswith(".nc")]
-            if members:
-                inner = target.parent / Path(members[0]).name
-                with archive.open(members[0]) as src, inner.open("wb") as dst:
-                    shutil.copyfileobj(src, dst)
-                target = inner
-    return _read_netcdf_var_meta(str(target))
+    # A probe is a minimal slice, but "minimal" is the store's judgement, not
+    # ours: one CAMS inventory answers a single-variable request with a 425 MB
+    # zip. A sweep issues one of these per placeholder row, so they are written
+    # under EARTHLENS_CACHE_DIR when set - a data volume, not the system disk -
+    # and through TemporaryDirectory so each is removed once it has been read
+    # rather than accumulating until something runs out of space.
+    scratch_root = os.environ.get("EARTHLENS_CACHE_DIR") or None
+    with tempfile.TemporaryDirectory(dir=scratch_root) as scratch:
+        target = Path(scratch) / "probe.nc"
+        client = open_client(_endpoint_for(dataset))
+        client.retrieve(dataset, request, str(target))
+        if zipfile.is_zipfile(target):
+            with zipfile.ZipFile(target) as archive:
+                members = [name for name in archive.namelist() if name.endswith(".nc")]
+                if members:
+                    inner = target.parent / Path(members[0]).name
+                    with archive.open(members[0]) as src, inner.open("wb") as dst:
+                        shutil.copyfileobj(src, dst)
+                    target = inner
+        return _read_netcdf_var_meta(str(target))
 
 
 def _ecmwf_deep_sample(dataset: str) -> dict[str, dict[str, Any]]:

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/cli.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/cli.py
@@ -212,23 +212,81 @@ def _read_netcdf_var_meta(path: str) -> dict[str, dict[str, Any]]:
     return schema
 
 
-def _ecmwf_deep_sample(dataset: str) -> dict[str, dict[str, Any]]:
-    """Retrieve a tiny CDS NetCDF and read each variable's long_name/units.
+def _deep_sample_row(
+    rows: list[dict[str, Any]], cds_variable: str | None = None
+) -> dict[str, Any] | None:
+    """Return the constraints entry to build a probe request from.
 
-    Builds a **complete** minimal request from the dataset's first usable
-    `constraints.json` entry — one value per selector, so the family selectors
-    a dataset requires beyond year/month/day (a satellite CDR's
-    sensor / version / record-type / aggregation, CMIP's experiment/model, ...)
-    are carried and the retrieve is a valid combination rather than a 400.
-    Only keys the entry actually enumerates are sent, so a product that does
-    not partition by day/time (obs4mips CO2/CH4) is not handed a spurious one.
+    Constraints partition a dataset into combination blocks, and a variable is
+    only retrievable under the selectors of a block that lists it — GloFAS
+    serves discharge and runoff under `timespan: time_mean` but snow depth and
+    soil wetness only under `instantaneous`. Choosing the block by the variable
+    is therefore what makes a per-variable probe a valid request rather than a
+    400, and it is also where that variable's required selectors come from.
+
+    Args:
+        rows: The dataset's `constraints.json` entries.
+        cds_variable: The variable the probe is for; `None` keeps the legacy
+            behaviour of taking the first entry that enumerates any variable.
+
+    Returns:
+        The chosen entry, or `None` when `rows` is empty or no entry serves
+        `cds_variable`.
+    """
+    if not rows:
+        return None
+    if cds_variable is None:
+        return next((entry for entry in rows if entry.get("variable")), rows[0])
+    return next(
+        (entry for entry in rows if cds_variable in (entry.get("variable") or [])),
+        None,
+    )
+
+
+def _deep_sample_request(
+    row: dict[str, Any], cds_variable: str | None = None
+) -> dict[str, Any]:
+    """Build the smallest valid retrieve request from one constraints entry.
+
+    One value per selector, so the family selectors a dataset requires beyond
+    year/month/day (a satellite CDR's sensor / version / record-type, CMIP's
+    experiment/model, ...) are carried and the retrieve is a valid combination.
+    Only keys the entry actually enumerates are sent, so a product that does not
+    partition by day/time is not handed a spurious one.
+
+    Args:
+        row: The constraints entry to reduce.
+        cds_variable: When given, the request asks for exactly this variable
+            instead of the entry's first.
+
+    Returns:
+        A `cdsapi` request mapping.
+    """
+    request: dict[str, Any] = {"data_format": "netcdf"}
+    for key, value in row.items():
+        request[key] = value[:1] if isinstance(value, list) and value else value
+    if cds_variable is not None:
+        request["variable"] = [cds_variable]
+    # A dataset with no variable dimension still needs the widget's "all".
+    request.setdefault("variable", ["all"])
+    return request
+
+
+def _retrieve_probe(dataset: str, request: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Retrieve one tiny slice and read each NetCDF variable's metadata.
 
     The retrieve goes to the dataset's **own** store, resolved from the catalog
     the same way :func:`_ecmwf_constraints` resolves it: a bare client would
     always talk to CDS and every ADS / EWDS / ECDS / XDS dataset would 404 with
     `process not found`. A zip-of-NetCDF response (satellite CDRs deliver one)
-    is unwrapped to its first member before the variable metadata is read via
-    GDAL.
+    is unwrapped to its first member before the metadata is read via GDAL.
+
+    Args:
+        dataset: The Copernicus dataset id to retrieve from.
+        request: The request mapping to submit.
+
+    Returns:
+        Mapping of NetCDF short name to `{long_name, units}`.
     """
     import shutil
     import tempfile
@@ -236,17 +294,6 @@ def _ecmwf_deep_sample(dataset: str) -> dict[str, dict[str, Any]]:
 
     from earthlens.ecmwf.endpoints import open_client
 
-    rows = _ecmwf_constraints(dataset)
-    if not rows:
-        return {}
-    # Prefer the first entry that enumerates a variable (a usable retrieve);
-    # fall back to the first entry for datasets with no variable dimension.
-    row = next((entry for entry in rows if entry.get("variable")), rows[0])
-    request: dict[str, Any] = {"data_format": "netcdf"}
-    for key, value in row.items():
-        request[key] = value[:1] if isinstance(value, list) and value else value
-    # A dataset with no variable dimension still needs the widget's "all".
-    request.setdefault("variable", ["all"])
     target = Path(tempfile.mkdtemp()) / "probe.nc"
     client = open_client(_endpoint_for(dataset))
     client.retrieve(dataset, request, str(target))
@@ -259,6 +306,61 @@ def _ecmwf_deep_sample(dataset: str) -> dict[str, dict[str, Any]]:
                     shutil.copyfileobj(src, dst)
                 target = inner
     return _read_netcdf_var_meta(str(target))
+
+
+def _ecmwf_deep_sample(dataset: str) -> dict[str, dict[str, Any]]:
+    """Retrieve a tiny CDS NetCDF and read each variable's long_name/units.
+
+    Probes the dataset's first usable constraints entry, asking for one value
+    per selector. What comes back describes whichever variable that entry lists
+    first, so this cannot finish a multi-variable dataset on its own — see
+    :func:`_ecmwf_deep_sample_variable` for the per-variable form the catalog
+    hydrator uses.
+
+    Args:
+        dataset: The Copernicus dataset id to sample.
+
+    Returns:
+        Mapping of NetCDF short name to `{long_name, units}`; empty when the
+        dataset publishes no constraints.
+    """
+    row = _deep_sample_row(_ecmwf_constraints(dataset))
+    if row is None:
+        return {}
+    return _retrieve_probe(dataset, _deep_sample_request(row))
+
+
+def _ecmwf_deep_sample_variable(
+    dataset: str, cds_variable: str
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    """Probe ONE variable and report the selectors its constraints block needs.
+
+    Asking for a single named variable is what lets the hydrator finish a
+    multi-variable dataset, and the block that serves it also carries the
+    selectors that variable requires — the GloFAS `timespan` split is exactly
+    this. Returning both together means a per-variable `extras:` override can be
+    derived rather than hand-written.
+
+    Args:
+        dataset: The Copernicus dataset id to sample.
+        cds_variable: The `cds_variable` to request.
+
+    Returns:
+        A `(metadata, selectors)` pair. `metadata` maps NetCDF short name to
+        `{long_name, units}`; `selectors` is the serving block's list-valued
+        selectors excluding `variable`, each truncated to the one value probed.
+        Both are empty when no constraints block serves `cds_variable`.
+    """
+    row = _deep_sample_row(_ecmwf_constraints(dataset), cds_variable)
+    if row is None:
+        return {}, {}
+    request = _deep_sample_request(row, cds_variable)
+    selectors = {
+        key: value
+        for key, value in request.items()
+        if key not in {"variable", "data_format"} and isinstance(value, list)
+    }
+    return _retrieve_probe(dataset, request), selectors
 
 
 def deep_prober(_catalog: Any, dataset: str) -> dict[str, dict[str, Any]]:

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/cli.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/cli.py
@@ -284,6 +284,11 @@ def _retrieve_probe(dataset: str, request: dict[str, Any]) -> dict[str, dict[str
     Writes under `EARTHLENS_CACHE_DIR` when that is set, and removes the scratch
     directory once the metadata has been read.
 
+    Retries a throttled store the same way a download does. A sweep issues one
+    of these per placeholder row, so it is the caller most likely to meet the
+    per-dataset queue limit — and without the retry a store that accepts a job
+    and then rejects it ends the whole pass on the first refusal.
+
     Args:
         dataset: The Copernicus dataset id to retrieve from.
         request: The request mapping to submit.
@@ -296,6 +301,7 @@ def _retrieve_probe(dataset: str, request: dict[str, Any]) -> dict[str, dict[str
     import tempfile
     import zipfile
 
+    from earthlens.ecmwf._helpers import _retrieve_with_retry
     from earthlens.ecmwf.endpoints import open_client
 
     # A probe is a minimal slice, but "minimal" is the store's judgement, not
@@ -307,8 +313,9 @@ def _retrieve_probe(dataset: str, request: dict[str, Any]) -> dict[str, dict[str
     scratch_root = os.environ.get("EARTHLENS_CACHE_DIR") or None
     with tempfile.TemporaryDirectory(dir=scratch_root) as scratch:
         target = Path(scratch) / "probe.nc"
-        client = open_client(_endpoint_for(dataset))
-        client.retrieve(dataset, request, str(target))
+        endpoint = _endpoint_for(dataset)
+        client = open_client(endpoint)
+        _retrieve_with_retry(client, dataset, request, target, endpoint)
         if zipfile.is_zipfile(target):
             with zipfile.ZipFile(target) as archive:
                 members = [name for name in archive.namelist() if name.endswith(".nc")]

--- a/libs/providers/atmosphere/src/earthlens/ecmwf/cli.py
+++ b/libs/providers/atmosphere/src/earthlens/ecmwf/cli.py
@@ -330,6 +330,44 @@ def _ecmwf_deep_sample(dataset: str) -> dict[str, dict[str, Any]]:
     return _retrieve_probe(dataset, _deep_sample_request(row))
 
 
+def _required_selectors(
+    rows: list[dict[str, Any]], cds_variable: str
+) -> dict[str, Any]:
+    """Return the selectors a variable is only ever served under.
+
+    A probe request is one sampled combination, not a requirement: it takes the
+    first entry that lists the variable and keeps one value per selector. Most
+    of what it carries is a free choice the caller makes — a CMIP variable is
+    served under every model, experiment and period the dataset offers, and
+    pinning the sampled one into the row would override whatever the caller
+    later asks for.
+
+    A selector is a requirement only when every entry serving the variable
+    agrees on it. That isolates the real constraint — GloFAS serves snow depth
+    solely under `timespan: instantaneous` — and says nothing about the
+    selectors the caller is free to vary.
+
+    Args:
+        rows: The dataset's `constraints.json` entries.
+        cds_variable: The variable whose requirements to derive.
+
+    Returns:
+        The selectors common to every entry serving `cds_variable`; empty when
+        nothing is required or no entry serves it.
+    """
+    serving = [entry for entry in rows if cds_variable in (entry.get("variable") or [])]
+    if not serving:
+        return {}
+    first = serving[0]
+    return {
+        key: value
+        for key, value in first.items()
+        if key != "variable"
+        and isinstance(value, list)
+        and all(entry.get(key) == value for entry in serving)
+    }
+
+
 def _ecmwf_deep_sample_variable(
     dataset: str, cds_variable: str
 ) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
@@ -347,20 +385,17 @@ def _ecmwf_deep_sample_variable(
 
     Returns:
         A `(metadata, selectors)` pair. `metadata` maps NetCDF short name to
-        `{long_name, units}`; `selectors` is the serving block's list-valued
-        selectors excluding `variable`, each truncated to the one value probed.
-        Both are empty when no constraints block serves `cds_variable`.
+        `{long_name, units}`; `selectors` is what the variable is *only ever*
+        served under (see :func:`_required_selectors`), not the combination this
+        one probe happened to sample. Both are empty when no constraints block
+        serves `cds_variable`.
     """
-    row = _deep_sample_row(_ecmwf_constraints(dataset), cds_variable)
+    rows = _ecmwf_constraints(dataset)
+    row = _deep_sample_row(rows, cds_variable)
     if row is None:
         return {}, {}
     request = _deep_sample_request(row, cds_variable)
-    selectors = {
-        key: value
-        for key, value in request.items()
-        if key not in {"variable", "data_format"} and isinstance(value, list)
-    }
-    return _retrieve_probe(dataset, request), selectors
+    return _retrieve_probe(dataset, request), _required_selectors(rows, cds_variable)
 
 
 def deep_prober(_catalog: Any, dataset: str) -> dict[str, dict[str, Any]]:

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_cli.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_cli.py
@@ -693,3 +693,62 @@ class TestStoreTables:
         assert ecmwf_cli._store_collections_urls()["ecds"] == (
             "https://staging.ecds.invalid/api/catalogue/v1/collections"
         )
+
+
+class TestRequiredSelectors:
+    """Tests for deriving what a variable is only ever served under."""
+
+    CMIP = [
+        {
+            "variable": ["mean_temperature"],
+            "model": ["csiro_mk3_6_0"],
+            "experiment": ["amip"],
+            "period": ["19790101-19981231"],
+        },
+        {
+            "variable": ["mean_temperature"],
+            "model": ["gfdl_esm2g"],
+            "experiment": ["historical"],
+            "period": ["18610101-18801231"],
+        },
+    ]
+    GLOFAS = [
+        {
+            "variable": ["river_discharge_in_the_last_24_hours"],
+            "timespan": ["time_mean"],
+            "hyear": ["2020"],
+        },
+        {
+            "variable": ["river_discharge_in_the_last_24_hours"],
+            "timespan": ["time_mean"],
+            "hyear": ["2021"],
+        },
+        {
+            "variable": ["snow_depth_water_equivalent"],
+            "timespan": ["instantaneous"],
+            "hyear": ["2020"],
+        },
+    ]
+
+    def test_a_selector_the_caller_may_vary_is_not_a_requirement(self):
+        """A CMIP variable is served under every model, so none may be pinned."""
+        assert ecmwf_cli._required_selectors(self.CMIP, "mean_temperature") == {}
+
+    def test_a_selector_every_serving_entry_agrees_on_is_a_requirement(self):
+        """Snow depth is served solely under instantaneous, which is the constraint."""
+        required = ecmwf_cli._required_selectors(
+            self.GLOFAS, "snow_depth_water_equivalent"
+        )
+        assert required["timespan"] == ["instantaneous"]
+
+    def test_a_selector_that_varies_is_dropped_even_when_others_hold(self):
+        """hyear differs across the serving entries, so it is not a requirement."""
+        required = ecmwf_cli._required_selectors(
+            self.GLOFAS, "river_discharge_in_the_last_24_hours"
+        )
+        assert required["timespan"] == ["time_mean"]
+        assert "hyear" not in required
+
+    def test_a_variable_no_entry_serves_requires_nothing(self):
+        """An unknown variable has no serving entry to derive a requirement from."""
+        assert ecmwf_cli._required_selectors(self.GLOFAS, "not_a_variable") == {}

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_cli.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_cli.py
@@ -752,3 +752,35 @@ class TestRequiredSelectors:
     def test_a_variable_no_entry_serves_requires_nothing(self):
         """An unknown variable has no serving entry to derive a requirement from."""
         assert ecmwf_cli._required_selectors(self.GLOFAS, "not_a_variable") == {}
+
+
+class TestProbeRetriesThrottling:
+    """The probe path must survive a throttled store like the download path does."""
+
+    def test_a_throttled_probe_is_retried_then_raises_typed(
+        self, monkeypatch, tmp_path
+    ):
+        """A sweep fires one probe per row, so it meets the queue limit first."""
+        from earthlens.ecmwf import CadsUnavailableError, _helpers
+
+        monkeypatch.setattr(_helpers, "CADS_BACKOFF_SECONDS", 0.0)
+        calls = []
+
+        class _Throttled:
+            def retrieve(self, dataset, request, target):
+                calls.append(dataset)
+                raise RuntimeError(
+                    "400 Client Error: Bad Request. The job has been rejected. "
+                    "Number queued requests for this dataset is temporarily limited."
+                )
+
+        monkeypatch.setattr(ecmwf_cli, "_endpoint_for", lambda ds: "ads")
+        import earthlens.ecmwf.endpoints as endpoints
+
+        monkeypatch.setattr(endpoints, "open_client", lambda endpoint: _Throttled())
+        monkeypatch.setenv("EARTHLENS_CACHE_DIR", str(tmp_path))
+        with pytest.raises(CadsUnavailableError):
+            ecmwf_cli._retrieve_probe(
+                "cams-global-emission-inventories", {"variable": ["x"]}
+            )
+        assert len(calls) == _helpers.CADS_MAX_ATTEMPTS, "retried, not single-shot"

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -17,6 +17,7 @@ from earthlens.ecmwf._hydrate import (
     _find_file_for_dataset,
     _hydrate_stanza_per_variable,
     _indent_of,
+    _inline_mapping,
     _is_initialism,
     _match_variables,
     _pair_is_evidenced,
@@ -663,6 +664,40 @@ class TestSelectorPlumbing:
         block = (
             "    extras: {timespan: [time_mean]}" + chr(10) + "    variables:" + chr(10)
         )
+        assert _dataset_extras(block) == {"timespan": ["time_mean"]}
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "        extras: {timespan: [x]}",
+            "        extras:",
+            "        extras: not-a-mapping",
+            "        extras: [a, b]",
+        ],
+    )
+    def test_only_a_real_inline_mapping_parses(self, line):
+        """A block key, a scalar or a sequence carries no inline mapping to read."""
+        parsed = _inline_mapping(line)
+        expected = {"timespan": ["x"]} if line.endswith("}") else {}
+        assert parsed == expected
+
+    def test_a_line_without_a_colon_is_skipped(self):
+        """Stray text inside an extras block is ignored rather than mis-parsed."""
+        block = (
+            "    extras:"
+            + chr(10)
+            + "      timespan: [time_mean]"
+            + chr(10)
+            + "      stray-text-with-no-colon"
+            + chr(10)
+            + "    variables:"
+            + chr(10)
+        )
+        assert _dataset_extras(block) == {"timespan": ["time_mean"]}
+
+    def test_extras_running_to_the_end_of_the_block(self):
+        """The reader stops cleanly when the extras are the stanza's last lines."""
+        block = "    extras:" + chr(10) + "      timespan: [time_mean]" + chr(10)
         assert _dataset_extras(block) == {"timespan": ["time_mean"]}
 
     def test_dataset_extras_is_empty_without_the_block(self):

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -718,6 +718,25 @@ class TestSelectorPlumbing:
         block = "    extras:" + chr(10) + "      timespan: [time_mean]" + chr(10)
         assert _dataset_extras(block) == {"timespan": ["time_mean"]}
 
+    def test_a_blank_extras_region_reads_as_nothing(self):
+        """Whitespace under the key is not a mapping to compare selectors against."""
+        block = (
+            "    extras:" + chr(10) + "      " + chr(10) + "    variables:" + chr(10)
+        )
+        assert _dataset_extras(block) == {}
+
+    def test_a_row_whose_cds_variable_is_empty_is_not_indexed(self):
+        """A blank cds_variable gives a probe nothing to ask for."""
+        block = (
+            "      a-row:"
+            + chr(10)
+            + "        cds_variable:"
+            + chr(10)
+            + "        units: unknown"
+            + chr(10)
+        )
+        assert hydrate_mod._slug_cds_variables(block) == {}
+
     def test_dataset_extras_is_empty_without_the_block(self):
         """A stanza with no dataset-level extras yields nothing to compare against."""
         no_extras = """      a-row:
@@ -1255,6 +1274,14 @@ class TestBulkHydrateEmpty:
             hydrate_mod._take_rows(["a-dataset", "z-dataset"], rows, limit) == expected
         )
 
+    def test_limit_larger_than_the_catalog_takes_everything(self):
+        """A budget nothing reaches leaves the worklist whole."""
+        rows = {"a-dataset": 2, "z-dataset": 3}
+        assert hydrate_mod._take_rows(["a-dataset", "z-dataset"], rows, 999) == [
+            "a-dataset",
+            "z-dataset",
+        ]
+
     def test_limit_never_splits_a_dataset(self):
         """Half a hydrated stanza is not a useful stopping point, so it is a floor."""
         rows = {"wide-dataset": 82}
@@ -1285,6 +1312,33 @@ class TestBulkHydrateEmpty:
         assert summary["hydrated"] == 1, "the row it did fill still counts"
         assert summary["partial"] == 1, "and the dataset is flagged for a re-run"
         assert "timed out" in capsys.readouterr().out
+
+    def test_a_refusal_after_a_partial_fill_is_named_too(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A store that declines mid-way is as re-runnable as a deadline."""
+        (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")
+        _patch_catalog(
+            monkeypatch,
+            tmp_path,
+            {
+                "reanalysis-era5-single-levels": _placeholder_dataset(
+                    "2m-temperature", "sea-surface-temperature"
+                )
+            },
+        )
+        seen = []
+
+        def _one_then_refuse(dataset_id, cds_variable, timeout):
+            seen.append(cds_variable)
+            if len(seen) == 1:
+                return _fake_probe(dataset_id, cds_variable)
+            raise RuntimeError("licence not accepted")
+
+        monkeypatch.setattr(hydrate_mod, "_probe_with_timeout", _one_then_refuse)
+        summary = bulk_hydrate_empty()
+        assert summary["partial"] == 1
+        assert "RuntimeError" in capsys.readouterr().out
 
     def test_limit_caps_candidates(self, tmp_path, monkeypatch):
         """A --limit truncates the placeholder worklist."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -636,9 +636,34 @@ class TestSelectorPlumbing:
         """The dataset-level extras are read past comments and spacing."""
         block = _stanza_match(_EXTRAS_STANZA, "demo-dataset").group(1)
         assert _dataset_extras(block) == {
-            "timespan": "[time_mean]",
-            "system_version": "[version_4_0]",
+            "timespan": ["time_mean"],
+            "system_version": ["version_4_0"],
         }
+
+    @pytest.mark.parametrize(
+        "spelling",
+        [
+            "      timespan: [time_mean]",
+            "      timespan: [ time_mean ]",
+            "      timespan: ['time_mean']",
+            "      timespan:" + chr(10) + "        - time_mean",
+        ],
+    )
+    def test_respelling_the_stanza_list_is_not_a_disagreement(self, spelling):
+        """Selectors compare as values, so formatting cannot fake an override."""
+        block = (
+            "    extras:" + chr(10) + spelling + chr(10) + "    variables:" + chr(10)
+        )
+        extras = _dataset_extras(block)
+        assert extras["timespan"] == ["time_mean"]
+        assert _selector_override({"timespan": ["time_mean"]}, extras) == {}
+
+    def test_a_dataset_level_inline_mapping_is_read_too(self):
+        """The stanza's own extras may be inline; it still parses to values."""
+        block = (
+            "    extras: {timespan: [time_mean]}" + chr(10) + "    variables:" + chr(10)
+        )
+        assert _dataset_extras(block) == {"timespan": ["time_mean"]}
 
     def test_dataset_extras_is_empty_without_the_block(self):
         """A stanza with no dataset-level extras yields nothing to compare against."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -823,6 +823,29 @@ class TestSelectorPlumbing:
         if existing:
             assert variables["a-row"]["extras"]["keep_me"] == [True]
 
+    @pytest.mark.parametrize(
+        "inline", ["        extras: [a, b]" + chr(10), "        extras: null" + chr(10)]
+    )
+    def test_a_non_mapping_inline_extras_is_left_alone(self, inline):
+        """What cannot be merged into must not be replaced; it is not ours to delete."""
+        text = (
+            "datasets:"
+            + chr(10)
+            + "  demo:"
+            + chr(10)
+            + "    variables:"
+            + chr(10)
+            + "      a-row:"
+            + chr(10)
+            + "        cds_variable: a_row"
+            + chr(10)
+            + "        units: unknown"
+            + chr(10)
+            + inline
+        )
+        block = _stanza_match(text, "demo").group(1)
+        assert _fill_variable_extras(block, "a-row", {"timespan": ["new"]}) == block
+
     def test_an_empty_override_leaves_the_block_alone(self):
         """Nothing to record means nothing is written."""
         block = _stanza_match(_EXTRAS_STANZA, "demo-dataset").group(1)
@@ -1068,6 +1091,14 @@ class TestBulkHydrateEmpty:
                 {},
             ),
         )
+        monkeypatch.setattr(
+            hydrate_mod,
+            "_retrieve_with_timeout",
+            lambda ds, timeout: {
+                "elevation": {"long_name": "Surface elevation", "units": "m"},
+                "orography": {"long_name": "Orography", "units": "m"},
+            },
+        )
         summary = bulk_hydrate_empty()
         assert summary["hydrated"] == 0
         assert summary["unmatched"] == 1
@@ -1120,6 +1151,11 @@ class TestBulkHydrateEmpty:
                 {},
             ),
         )
+        monkeypatch.setattr(
+            hydrate_mod,
+            "_retrieve_with_timeout",
+            lambda ds, timeout: {"latitude": {"long_name": "latitude", "units": "deg"}},
+        )
         summary = bulk_hydrate_empty()
         assert summary["unmatched"] == 1
         assert "only coordinates and auxiliaries" in capsys.readouterr().out
@@ -1148,10 +1184,10 @@ class TestBulkHydrateEmpty:
         ]["variables"]
         assert variables["2m-temperature"]["nc_variable"] == "t2m"
 
-    def test_the_fallback_is_not_used_when_a_probe_answered(
+    def test_the_fallback_recovers_a_row_the_per_variable_pass_declined(
         self, tmp_path, monkeypatch
     ):
-        """A probe that answered with nothing usable must not trigger a second pass."""
+        """A row no block serves is still reachable by name after siblings answer."""
         (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")
         _patch_catalog(
             monkeypatch,
@@ -1164,12 +1200,15 @@ class TestBulkHydrateEmpty:
             lambda ds, cds: ({"latitude": {"long_name": "lat", "units": "deg"}}, {}),
         )
 
-        def _must_not_run(dataset_id, timeout):
-            raise AssertionError("the whole-dataset fallback should not have run")
-
-        monkeypatch.setattr(hydrate_mod, "_retrieve_with_timeout", _must_not_run)
+        monkeypatch.setattr(
+            hydrate_mod, "_retrieve_with_timeout", lambda ds, timeout: dict(_NC_META)
+        )
         summary = bulk_hydrate_empty()
-        assert summary["unmatched"] == 1
+        assert summary["hydrated"] == 1, "the fallback matched it by name"
+        variables = yaml.safe_load((tmp_path / "era5.yaml").read_text())["datasets"][
+            "reanalysis-era5-single-levels"
+        ]["variables"]
+        assert variables["2m-temperature"]["nc_variable"] == "t2m"
 
     def test_a_rewrite_that_does_not_parse_is_never_written(
         self, tmp_path, monkeypatch, capsys

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -16,6 +16,7 @@ from earthlens.ecmwf._hydrate import (
     _fill_variable_extras,
     _find_file_for_dataset,
     _hydrate_stanza_per_variable,
+    _indent_of,
     _is_initialism,
     _match_variables,
     _pair_is_evidenced,
@@ -682,6 +683,32 @@ class TestSelectorPlumbing:
         ]
         assert row["extras"]["timespan"] == ["instantaneous"], "probe wins"
         assert row["extras"]["keep_me"] == [True], "untouched key survives"
+
+    def test_an_inline_mapping_extras_is_merged_not_duplicated(self):
+        """Appending beside an inline mapping would give the row two extras keys."""
+        inline = _EXTRAS_STANZA.replace(
+            "        extras:"
+            + chr(10)
+            + "          timespan: [stale]"
+            + chr(10)
+            + "          keep_me: [yes]",
+            "        extras: {timespan: [stale], keep_me: [yes]}",
+        )
+        block = _stanza_match(inline, "demo-dataset").group(1)
+        out = _fill_variable_extras(
+            block, "already-overridden", {"timespan": ["instantaneous"]}
+        )
+        keys = [
+            line
+            for line in out.splitlines()
+            if line.strip().startswith("extras:") and _indent_of(line) == 8
+        ]
+        assert len(keys) == 1, "a second extras key makes the shard unloadable"
+        row = yaml.safe_load(_DEMO_HEADER + out)["datasets"]["demo-dataset"][
+            "variables"
+        ]["already-overridden"]
+        assert row["extras"]["timespan"] == ["instantaneous"]
+        assert row["extras"]["keep_me"] == [True], "the other inline key survives"
 
     def test_an_empty_override_leaves_the_block_alone(self):
         """Nothing to record means nothing is written."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -1154,6 +1154,39 @@ class TestBulkHydrateEmpty:
         summary = bulk_hydrate_empty()
         assert summary["unmatched"] == 1
 
+    def test_a_rewrite_that_does_not_parse_is_never_written(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A splicing bug must cost one dataset's hydration, not the whole shard."""
+        shard = tmp_path / "era5.yaml"
+        shard.write_text(_STANZA, encoding="utf-8")
+        _patch_catalog(
+            monkeypatch,
+            tmp_path,
+            {"reanalysis-era5-single-levels": _placeholder_dataset("2m-temperature")},
+        )
+        monkeypatch.setattr(hydrate_mod, "_retrieve_variable_meta", _fake_probe)
+        monkeypatch.setattr(
+            hydrate_mod,
+            "_hydrate_stanza_per_variable",
+            lambda text, ds, probe: (
+                "datasets:"
+                + chr(10)
+                + "  a:"
+                + chr(10)
+                + "    x: 1"
+                + chr(10)
+                + "    x: 2"
+                + chr(10),
+                ["2m-temperature"],
+                [],
+            ),
+        )
+        summary = bulk_hydrate_empty()
+        assert summary["hydrated"] == 0, "a shard that would not load is not written"
+        assert shard.read_text(encoding="utf-8") == _STANZA, "shard untouched"
+        assert "did not parse" in capsys.readouterr().out
+
     def test_limit_caps_candidates(self, tmp_path, monkeypatch):
         """A --limit truncates the placeholder worklist."""
         (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -13,6 +13,7 @@ from earthlens.ecmwf import _hydrate as hydrate_mod
 from earthlens.ecmwf._hydrate import (
     _claimed_nc_names,
     _find_file_for_dataset,
+    _hydrate_stanza_per_variable,
     _is_initialism,
     _match_variables,
     _pair_is_evidenced,
@@ -53,6 +54,20 @@ _NC_META = {
     "sst": {"long_name": "Sea surface temperature", "units": "K"},
     "t2m": {"long_name": "2 metre temperature", "units": "K"},
 }
+
+_PROBE_BY_CDS = {
+    "2m_temperature": {"t2m": {"long_name": "2 metre temperature", "units": "K"}},
+    "sea_surface_temperature": {
+        "sst": {"long_name": "Sea surface temperature", "units": "K"}
+    },
+    "total_precipitation": {"tp": {"long_name": "Total precipitation", "units": "m"}},
+}
+
+
+def _fake_probe(dataset_id, cds_variable):
+    """Answer a per-variable probe with just that variable, as a real one does."""
+    return dict(_PROBE_BY_CDS.get(cds_variable, {})), {}
+
 
 _TWO_STANZA = """datasets:
   a-dataset:
@@ -537,6 +552,147 @@ def _placeholder_dataset(*slugs):
     )
 
 
+_GLOFAS_STANZA = """datasets:
+  cems-glofas-historical:
+    endpoint: ewds
+    extras:
+      system_version: [version_4_0]
+      timespan: [time_mean]
+    variables:
+      average-river-discharge-in-the-last-24-hours:
+        cds_variable: average_river_discharge_in_the_last_24_hours
+        nc_variable: average_river_discharge_in_the_last_24_hours
+        units: unknown
+      runoff-water-equivalent:
+        cds_variable: runoff_water_equivalent
+        nc_variable: runoff_water_equivalent
+        units: unknown
+      snow-depth-water-equivalent:
+        cds_variable: snow_depth_water_equivalent
+        nc_variable: snow_depth_water_equivalent
+        units: unknown
+      soil-wetness-index:
+        cds_variable: soil_wetness_index
+        nc_variable: soil_wetness_index
+        units: unknown
+"""
+
+_GLOFAS_PROBES = {
+    "average_river_discharge_in_the_last_24_hours": (
+        {"avg_dis": {"long_name": "Average river discharge", "units": "m3 s-1"}},
+        {"timespan": ["time_mean"], "system_version": ["version_4_0"]},
+    ),
+    "runoff_water_equivalent": (
+        {"rowe": {"long_name": "Runoff water equivalent", "units": "kg m-2"}},
+        {"timespan": ["time_mean"], "system_version": ["version_4_0"]},
+    ),
+    "snow_depth_water_equivalent": (
+        {"sd": {"long_name": "Snow depth water equivalent", "units": "kg m-2"}},
+        {"timespan": ["instantaneous"], "system_version": ["version_4_0"]},
+    ),
+    "soil_wetness_index": (
+        {"swir": {"long_name": "Soil wetness index", "units": "1"}},
+        {"timespan": ["instantaneous"], "system_version": ["version_4_0"]},
+    ),
+}
+
+
+class TestHydrateStanzaPerVariable:
+    """Tests for the per-variable hydration of a whole stanza."""
+
+    def test_every_placeholder_of_a_multi_variable_dataset_is_filled(self):
+        """One probe per row is what lets a four-variable dataset finish."""
+        asked = []
+
+        def probe(cds_variable):
+            asked.append(cds_variable)
+            return _GLOFAS_PROBES[cds_variable]
+
+        out, filled, declined = _hydrate_stanza_per_variable(
+            _GLOFAS_STANZA, "cems-glofas-historical", probe
+        )
+        assert len(asked) == 4, "one probe per placeholder"
+        assert len(filled) == 4
+        assert declined == []
+        variables = yaml.safe_load(out)["datasets"]["cems-glofas-historical"][
+            "variables"
+        ]
+        assert (
+            variables["average-river-discharge-in-the-last-24-hours"]["nc_variable"]
+            == "avg_dis"
+        )
+        assert variables["soil-wetness-index"]["units"] == "1"
+
+    def test_a_selector_the_dataset_default_covers_is_not_written(self):
+        """Discharge runs under the stanza's own timespan, so it needs no override."""
+        out, _, _ = _hydrate_stanza_per_variable(
+            _GLOFAS_STANZA,
+            "cems-glofas-historical",
+            lambda cds: _GLOFAS_PROBES[cds],
+        )
+        variables = yaml.safe_load(out)["datasets"]["cems-glofas-historical"][
+            "variables"
+        ]
+        row = variables["average-river-discharge-in-the-last-24-hours"]
+        assert "extras" not in row
+
+    def test_a_selector_that_differs_becomes_a_per_variable_override(self):
+        """Snow depth is only served under instantaneous, and that is recorded."""
+        out, _, _ = _hydrate_stanza_per_variable(
+            _GLOFAS_STANZA,
+            "cems-glofas-historical",
+            lambda cds: _GLOFAS_PROBES[cds],
+        )
+        variables = yaml.safe_load(out)["datasets"]["cems-glofas-historical"][
+            "variables"
+        ]
+        assert variables["snow-depth-water-equivalent"]["extras"] == {
+            "timespan": ["instantaneous"]
+        }
+        assert variables["soil-wetness-index"]["extras"] == {
+            "timespan": ["instantaneous"]
+        }
+
+    def test_a_row_the_store_cannot_serve_keeps_its_placeholder(self):
+        """A variable no constraints block serves is declined, not guessed at."""
+        out, filled, declined = _hydrate_stanza_per_variable(
+            _GLOFAS_STANZA,
+            "cems-glofas-historical",
+            lambda cds: ({}, {}) if "snow" in cds else _GLOFAS_PROBES[cds],
+        )
+        assert "snow-depth-water-equivalent" in declined
+        assert len(filled) == 3
+        variables = yaml.safe_load(out)["datasets"]["cems-glofas-historical"][
+            "variables"
+        ]
+        assert variables["snow-depth-water-equivalent"]["units"] == "unknown"
+
+    def test_two_rows_cannot_claim_one_netcdf_variable(self):
+        """A name bound earlier in the pass is withheld from later rows."""
+        one = (
+            {"avg_dis": {"long_name": "Average river discharge", "units": "m3 s-1"}},
+            {},
+        )
+        out, filled, declined = _hydrate_stanza_per_variable(
+            _GLOFAS_STANZA, "cems-glofas-historical", lambda cds: one
+        )
+        variables = yaml.safe_load(out)["datasets"]["cems-glofas-historical"][
+            "variables"
+        ]
+        bound = [v["nc_variable"] for v in variables.values()]
+        assert bound.count("avg_dis") == 1, "only the first row may take it"
+        assert len(declined) == 3
+
+    def test_a_stanza_without_placeholders_is_left_alone(self):
+        """Nothing to fill means no probes and no rewrite."""
+        filled_text = _GLOFAS_STANZA.replace("units: unknown", "units: m")
+        out, filled, declined = _hydrate_stanza_per_variable(
+            filled_text, "cems-glofas-historical", lambda cds: ({}, {})
+        )
+        assert out == filled_text
+        assert filled == [] and declined == []
+
+
 class TestBulkHydrateEmpty:
     """Tests for the catalog-wide hydrate driver (retrieve + catalog mocked)."""
 
@@ -555,9 +711,7 @@ class TestBulkHydrateEmpty:
                 ),
             },
         )
-        monkeypatch.setattr(
-            hydrate_mod, "_retrieve_netcdf_vars", lambda ds: dict(_NC_META)
-        )
+        monkeypatch.setattr(hydrate_mod, "_retrieve_variable_meta", _fake_probe)
 
         summary = bulk_hydrate_empty()
         assert summary == {
@@ -582,10 +736,10 @@ class TestBulkHydrateEmpty:
             {"reanalysis-era5-single-levels": _placeholder_dataset("2m-temperature")},
         )
 
-        def _boom(dataset_id):
+        def _boom(dataset_id, cds_variable):
             raise RuntimeError("licence not accepted")
 
-        monkeypatch.setattr(hydrate_mod, "_retrieve_netcdf_vars", _boom)
+        monkeypatch.setattr(hydrate_mod, "_retrieve_variable_meta", _boom)
         summary = bulk_hydrate_empty()
         assert summary["hydrated"] == 0
         assert summary["skipped"] == 1
@@ -602,8 +756,14 @@ class TestBulkHydrateEmpty:
         )
         monkeypatch.setattr(
             hydrate_mod,
-            "_retrieve_netcdf_vars",
-            lambda ds: {"elevation": {"long_name": "Surface elevation", "units": "m"}},
+            "_retrieve_variable_meta",
+            lambda ds, cds: (
+                {
+                    "elevation": {"long_name": "Surface elevation", "units": "m"},
+                    "orography": {"long_name": "Orography", "units": "m"},
+                },
+                {},
+            ),
         )
         summary = bulk_hydrate_empty()
         assert summary["hydrated"] == 0
@@ -621,9 +781,7 @@ class TestBulkHydrateEmpty:
             {"reanalysis-era5-single-levels": _placeholder_dataset("2m-temperature")},
         )
         monkeypatch.setattr(hydrate_mod, "_find_file_for_dataset", lambda *a: None)
-        monkeypatch.setattr(
-            hydrate_mod, "_retrieve_netcdf_vars", lambda ds: dict(_NC_META)
-        )
+        monkeypatch.setattr(hydrate_mod, "_retrieve_variable_meta", _fake_probe)
         summary = bulk_hydrate_empty()
         assert summary["unmatched"] == 0
         assert summary["skipped"] == 1
@@ -636,9 +794,7 @@ class TestBulkHydrateEmpty:
             tmp_path,
             {"other-dataset": _placeholder_dataset("total-precipitation")},
         )
-        monkeypatch.setattr(
-            hydrate_mod, "_retrieve_netcdf_vars", lambda ds: dict(_NC_META)
-        )
+        monkeypatch.setattr(hydrate_mod, "_retrieve_variable_meta", _fake_probe)
         summary = bulk_hydrate_empty()
         assert summary["unmatched"] == 0
         assert summary["skipped"] == 1
@@ -655,12 +811,62 @@ class TestBulkHydrateEmpty:
         )
         monkeypatch.setattr(
             hydrate_mod,
-            "_retrieve_netcdf_vars",
-            lambda ds: {"latitude": {"long_name": "latitude", "units": "degrees"}},
+            "_retrieve_variable_meta",
+            lambda ds, cds: (
+                {"latitude": {"long_name": "latitude", "units": "degrees"}},
+                {},
+            ),
         )
         summary = bulk_hydrate_empty()
         assert summary["unmatched"] == 1
         assert "only coordinates and auxiliaries" in capsys.readouterr().out
+
+    def test_a_dataset_no_block_names_falls_back_to_one_whole_probe(
+        self, tmp_path, monkeypatch
+    ):
+        """A product that does not partition by variable is still hydratable."""
+        (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")
+        _patch_catalog(
+            monkeypatch,
+            tmp_path,
+            {"reanalysis-era5-single-levels": _placeholder_dataset("2m-temperature")},
+        )
+        # No constraints block names the row, so every per-variable probe is empty.
+        monkeypatch.setattr(
+            hydrate_mod, "_retrieve_variable_meta", lambda ds, cds: ({}, {})
+        )
+        monkeypatch.setattr(
+            hydrate_mod, "_retrieve_with_timeout", lambda ds, timeout: dict(_NC_META)
+        )
+        summary = bulk_hydrate_empty()
+        assert summary["hydrated"] == 1, "the whole-dataset probe finished it"
+        variables = yaml.safe_load((tmp_path / "era5.yaml").read_text())["datasets"][
+            "reanalysis-era5-single-levels"
+        ]["variables"]
+        assert variables["2m-temperature"]["nc_variable"] == "t2m"
+
+    def test_the_fallback_is_not_used_when_a_probe_answered(
+        self, tmp_path, monkeypatch
+    ):
+        """A probe that answered with nothing usable must not trigger a second pass."""
+        (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")
+        _patch_catalog(
+            monkeypatch,
+            tmp_path,
+            {"reanalysis-era5-single-levels": _placeholder_dataset("2m-temperature")},
+        )
+        monkeypatch.setattr(
+            hydrate_mod,
+            "_retrieve_variable_meta",
+            lambda ds, cds: ({"latitude": {"long_name": "lat", "units": "deg"}}, {}),
+        )
+
+        def _must_not_run(dataset_id, timeout):
+            raise AssertionError("the whole-dataset fallback should not have run")
+
+        monkeypatch.setattr(hydrate_mod, "_retrieve_with_timeout", _must_not_run)
+        summary = bulk_hydrate_empty()
+        assert summary["unmatched"] == 1
 
     def test_limit_caps_candidates(self, tmp_path, monkeypatch):
         """A --limit truncates the placeholder worklist."""
@@ -673,7 +879,9 @@ class TestBulkHydrateEmpty:
                 "other-dataset": _placeholder_dataset("total-precipitation"),
             },
         )
-        monkeypatch.setattr(hydrate_mod, "_retrieve_netcdf_vars", lambda ds: {})
+        monkeypatch.setattr(
+            hydrate_mod, "_retrieve_variable_meta", lambda ds, cds: ({}, {})
+        )
         summary = bulk_hydrate_empty(limit=1)
         assert summary["candidates"] == 1, "limit applied to the worklist"
 
@@ -691,12 +899,12 @@ class TestBulkHydrateEmpty:
             },
         )
 
-        def _hydrate_then_abort(dataset_id):
+        def _hydrate_then_abort(dataset_id, cds_variable):
             if dataset_id == "z-dataset":
                 raise KeyboardInterrupt
-            return dict(_NC_META)
+            return _fake_probe(dataset_id, cds_variable)
 
-        monkeypatch.setattr(hydrate_mod, "_retrieve_netcdf_vars", _hydrate_then_abort)
+        monkeypatch.setattr(hydrate_mod, "_retrieve_variable_meta", _hydrate_then_abort)
         with pytest.raises(KeyboardInterrupt):
             bulk_hydrate_empty(timeout=0)
         on_disk = yaml.safe_load((tmp_path / "era5.yaml").read_text())["datasets"]
@@ -715,10 +923,10 @@ class TestBulkHydrateEmpty:
             {"reanalysis-era5-single-levels": _placeholder_dataset("2m-temperature")},
         )
 
-        def _stall(dataset_id, timeout):
+        def _stall(dataset_id, cds_variable, timeout):
             raise TimeoutError("stuck in the CDS queue")
 
-        monkeypatch.setattr(hydrate_mod, "_retrieve_with_timeout", _stall)
+        monkeypatch.setattr(hydrate_mod, "_probe_with_timeout", _stall)
         summary = bulk_hydrate_empty()
         assert summary["timed_out"] == 1, "the timed-out dataset is counted"
         assert summary["skipped"] == 1, "a timeout also counts as skipped"

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -12,6 +12,8 @@ import yaml
 from earthlens.ecmwf import _hydrate as hydrate_mod
 from earthlens.ecmwf._hydrate import (
     _claimed_nc_names,
+    _dataset_extras,
+    _fill_variable_extras,
     _find_file_for_dataset,
     _hydrate_stanza_per_variable,
     _is_initialism,
@@ -19,6 +21,9 @@ from earthlens.ecmwf._hydrate import (
     _pair_is_evidenced,
     _retrieve_with_timeout,
     _rewrite_stanza,
+    _selector_override,
+    _stanza_match,
+    _yaml_inline_list,
     _yaml_value,
     bulk_hydrate_empty,
 )
@@ -595,6 +600,164 @@ _GLOFAS_PROBES = {
         {"timespan": ["instantaneous"], "system_version": ["version_4_0"]},
     ),
 }
+
+
+_DEMO_HEADER = """datasets:
+  demo-dataset:
+"""
+
+_EXTRAS_STANZA = """datasets:
+  demo-dataset:
+    endpoint: ewds
+    extras:
+      # a comment the reader must skip
+      timespan: [time_mean]
+
+      system_version: [version_4_0]
+    variables:
+      already-overridden:
+        cds_variable: already_overridden
+        nc_variable: already_overridden
+        units: unknown
+        extras:
+          timespan: [stale]
+          keep_me: [yes]
+      no-cds-variable:
+        nc_variable: mystery
+        units: unknown
+"""
+
+
+class TestSelectorPlumbing:
+    """Tests for the pieces that turn a probe's selectors into a row override."""
+
+    def test_dataset_extras_skips_comments_and_blank_lines(self):
+        """The dataset-level extras are read past comments and spacing."""
+        block = _stanza_match(_EXTRAS_STANZA, "demo-dataset").group(1)
+        assert _dataset_extras(block) == {
+            "timespan": "[time_mean]",
+            "system_version": "[version_4_0]",
+        }
+
+    def test_dataset_extras_is_empty_without_the_block(self):
+        """A stanza with no dataset-level extras yields nothing to compare against."""
+        no_extras = """      a-row:
+        units: unknown
+"""
+        assert _dataset_extras(no_extras) == {}
+
+    @pytest.mark.parametrize(
+        ("selectors", "expected"),
+        [
+            ({"timespan": ["instantaneous"]}, {"timespan": ["instantaneous"]}),
+            ({"timespan": ["time_mean"]}, {}),
+            ({"unknown_key": ["x"]}, {}),
+            ({"system_version": ["version_4_0"]}, {}),
+        ],
+    )
+    def test_only_a_differing_declared_selector_is_written(self, selectors, expected):
+        """A selector is an override only when the stanza declares it and disagrees."""
+        block = _stanza_match(_EXTRAS_STANZA, "demo-dataset").group(1)
+        assert _selector_override(selectors, _dataset_extras(block)) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [(["a"], "[a]"), (["a", "b"], "[a, b]"), ("unarchived", "unarchived")],
+    )
+    def test_selector_values_render_the_way_the_catalog_writes_them(
+        self, value, expected
+    ):
+        """A list becomes an inline sequence; a scalar stays a scalar."""
+        assert _yaml_inline_list(value) == expected
+
+    def test_an_existing_override_is_merged_not_replaced(self):
+        """A hand-set selector survives unless the probe contradicts it."""
+        block = _stanza_match(_EXTRAS_STANZA, "demo-dataset").group(1)
+        out = _fill_variable_extras(
+            block, "already-overridden", {"timespan": ["instantaneous"]}
+        )
+        document = _DEMO_HEADER + out
+        row = yaml.safe_load(document)["datasets"]["demo-dataset"]["variables"][
+            "already-overridden"
+        ]
+        assert row["extras"]["timespan"] == ["instantaneous"], "probe wins"
+        assert row["extras"]["keep_me"] == [True], "untouched key survives"
+
+    def test_an_empty_override_leaves_the_block_alone(self):
+        """Nothing to record means nothing is written."""
+        block = _stanza_match(_EXTRAS_STANZA, "demo-dataset").group(1)
+        assert _fill_variable_extras(block, "already-overridden", {}) == block
+
+    def test_an_absent_slug_leaves_the_block_alone(self):
+        """A slug that is not in the stanza cannot be given an override."""
+        block = _stanza_match(_EXTRAS_STANZA, "demo-dataset").group(1)
+        assert _fill_variable_extras(block, "not-here", {"timespan": ["x"]}) == block
+
+    def test_a_row_without_a_cds_variable_is_declined(self):
+        """A probe needs the request-side name, so a row lacking one is skipped."""
+        out, filled, declined = _hydrate_stanza_per_variable(
+            _EXTRAS_STANZA,
+            "demo-dataset",
+            lambda cds: ({"x": {"long_name": "x", "units": "1"}}, {}),
+        )
+        assert "no-cds-variable" in declined
+
+    def test_a_missing_stanza_is_a_no_op(self):
+        """Hydrating a dataset the shard does not hold changes nothing."""
+        out, filled, declined = _hydrate_stanza_per_variable(
+            _EXTRAS_STANZA, "not-a-dataset", lambda cds: ({}, {})
+        )
+        assert (out, filled, declined) == (_EXTRAS_STANZA, [], [])
+
+
+class TestHydrateStanzaWhole:
+    """Tests for the whole-dataset fallback used when no block names a row."""
+
+    def test_a_timeout_is_recorded_on_the_session(self, monkeypatch):
+        """The deadline is reported as a timeout, not a generic failure."""
+        session = hydrate_mod._ProbeSession("demo-dataset", 1.0)
+
+        def _stall(dataset_id, timeout):
+            raise TimeoutError("stuck")
+
+        monkeypatch.setattr(hydrate_mod, "_retrieve_with_timeout", _stall)
+        out, filled, declined = hydrate_mod._hydrate_stanza_whole(
+            _EXTRAS_STANZA, "demo-dataset", session
+        )
+        assert session.timed_out is True
+        assert (out, filled, declined) == (_EXTRAS_STANZA, [], [])
+
+    def test_a_refusal_is_recorded_without_claiming_a_timeout(self, monkeypatch):
+        """A licence refusal sets the error but leaves timed_out false."""
+        session = hydrate_mod._ProbeSession("demo-dataset", 1.0)
+
+        def _refuse(dataset_id, timeout):
+            raise RuntimeError("licence not accepted")
+
+        monkeypatch.setattr(hydrate_mod, "_retrieve_with_timeout", _refuse)
+        hydrate_mod._hydrate_stanza_whole(_EXTRAS_STANZA, "demo-dataset", session)
+        assert session.timed_out is False
+        assert isinstance(session.error, RuntimeError)
+
+
+class TestRetrieveVariableMeta:
+    """Tests for the credentialed per-variable seam."""
+
+    def test_it_forwards_to_the_ecmwf_deep_sampler(self, monkeypatch):
+        """The seam only delegates, so the credentialed call stays in one place."""
+        import earthlens.ecmwf.cli as ecmwf_cli
+
+        seen = {}
+
+        def _fake(dataset_id, cds_variable):
+            seen["args"] = (dataset_id, cds_variable)
+            return {"t2m": {"units": "K"}}, {"timespan": ["time_mean"]}
+
+        monkeypatch.setattr(ecmwf_cli, "_ecmwf_deep_sample_variable", _fake)
+        meta, selectors = hydrate_mod._retrieve_variable_meta("ds", "2m_temperature")
+        assert seen["args"] == ("ds", "2m_temperature")
+        assert meta == {"t2m": {"units": "K"}}
+        assert selectors == {"timespan": ["time_mean"]}
 
 
 class TestHydrateStanzaPerVariable:

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -1288,6 +1288,54 @@ class TestBulkHydrateEmpty:
         assert shard.read_text(encoding="utf-8") == _STANZA, "shard untouched"
         assert "did not parse" in capsys.readouterr().out
 
+    @pytest.mark.parametrize("bad", ["no", "yes", "null", "123", "off"])
+    def test_a_row_that_reloads_as_a_non_string_is_refused(self, bad):
+        """A written value can be valid YAML and still come back the wrong type."""
+        shard = (
+            "datasets:"
+            + chr(10)
+            + "  a-dataset:"
+            + chr(10)
+            + "    variables:"
+            + chr(10)
+            + "      2m-temperature:"
+            + chr(10)
+            + "        nc_variable: "
+            + bad
+            + chr(10)
+            + "        units: K"
+            + chr(10)
+        )
+        assert not hydrate_mod._written_rows_survive(
+            shard, "a-dataset", ["2m-temperature"]
+        ), "a non-string nc_variable breaks the catalog for every later dataset"
+
+    def test_a_pre_existing_bad_row_does_not_block_the_write(self):
+        """Only the rows this pass filled are judged; older defects are not ours."""
+        shard = (
+            "datasets:"
+            + chr(10)
+            + "  a-dataset:"
+            + chr(10)
+            + "    variables:"
+            + chr(10)
+            + "      2m-temperature:"
+            + chr(10)
+            + "        nc_variable: t2m"
+            + chr(10)
+            + "        units: K"
+            + chr(10)
+            + "      untouched:"
+            + chr(10)
+            + "        nc_variable: no"
+            + chr(10)
+            + "        units: '1'"
+            + chr(10)
+        )
+        assert hydrate_mod._written_rows_survive(
+            shard, "a-dataset", ["2m-temperature"]
+        ), "refusing here would cost hydration for a defect the sweep did not cause"
+
     @pytest.mark.parametrize(
         ("limit", "expected"),
         [(1, ["a-dataset"]), (2, ["a-dataset"]), (3, ["a-dataset", "z-dataset"])],

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -682,8 +682,8 @@ class TestSelectorPlumbing:
         expected = {"timespan": ["x"]} if line.endswith("}") else {}
         assert parsed == expected
 
-    def test_a_line_without_a_colon_is_skipped(self):
-        """Stray text inside an extras block is ignored rather than mis-parsed."""
+    def test_an_unparseable_extras_region_yields_nothing(self):
+        """Reading half a malformed block would compare selectors against a lie."""
         block = (
             "    extras:"
             + chr(10)
@@ -694,7 +694,24 @@ class TestSelectorPlumbing:
             + "    variables:"
             + chr(10)
         )
-        assert _dataset_extras(block) == {"timespan": ["time_mean"]}
+        assert _dataset_extras(block) == {}
+
+    @pytest.mark.parametrize(
+        ("shape", "expected"),
+        [
+            ("      area:" + chr(10) + "        north: 50", {"area": {"north": 50}}),
+            (
+                "      timespan:" + chr(10) + "        - time_mean",
+                {"timespan": ["time_mean"]},
+            ),
+            ('      note: "keep # this"', {"note": "keep # this"}),
+            ("      # only a comment", {}),
+        ],
+    )
+    def test_the_extras_region_is_parsed_as_yaml(self, shape, expected):
+        """Nesting, block sequences and quoted hashes all survive the read."""
+        block = "    extras:" + chr(10) + shape + chr(10) + "    variables:" + chr(10)
+        assert _dataset_extras(block) == expected
 
     def test_extras_running_to_the_end_of_the_block(self):
         """The reader stops cleanly when the extras are the stanza's last lines."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -1035,7 +1035,8 @@ class TestHydrateStanzaPerVariable:
             filled_text, "cems-glofas-historical", lambda cds: ({}, {})
         )
         assert out == filled_text
-        assert filled == [] and declined == []
+        assert filled == []
+        assert declined == []
 
 
 class TestBulkHydrateEmpty:

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -1046,6 +1046,7 @@ class TestBulkHydrateEmpty:
             "skipped": 0,
             "timed_out": 0,
             "unmatched": 0,
+            "partial": 0,
             "filled": ["reanalysis-era5-single-levels"],
         }
         variables = yaml.safe_load((tmp_path / "era5.yaml").read_text())["datasets"][
@@ -1258,6 +1259,32 @@ class TestBulkHydrateEmpty:
         """Half a hydrated stanza is not a useful stopping point, so it is a floor."""
         rows = {"wide-dataset": 82}
         assert hydrate_mod._take_rows(["wide-dataset"], rows, 1) == ["wide-dataset"]
+
+    def test_a_dataset_that_stops_midway_says_why(self, tmp_path, monkeypatch, capsys):
+        """A partial fill must not hide the deadline that ended it."""
+        (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")
+        _patch_catalog(
+            monkeypatch,
+            tmp_path,
+            {
+                "reanalysis-era5-single-levels": _placeholder_dataset(
+                    "2m-temperature", "sea-surface-temperature"
+                )
+            },
+        )
+        calls = []
+
+        def _one_then_stall(dataset_id, cds_variable, timeout):
+            calls.append(cds_variable)
+            if len(calls) == 1:
+                return _fake_probe(dataset_id, cds_variable)
+            raise TimeoutError("stuck in the CDS queue")
+
+        monkeypatch.setattr(hydrate_mod, "_probe_with_timeout", _one_then_stall)
+        summary = bulk_hydrate_empty()
+        assert summary["hydrated"] == 1, "the row it did fill still counts"
+        assert summary["partial"] == 1, "and the dataset is flagged for a re-run"
+        assert "timed out" in capsys.readouterr().out
 
     def test_limit_caps_candidates(self, tmp_path, monkeypatch):
         """A --limit truncates the placeholder worklist."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 import yaml
 
+from earthlens.base.yaml_loader import load_yaml_strict
 from earthlens.ecmwf import _hydrate as hydrate_mod
 from earthlens.ecmwf._hydrate import (
     _claimed_nc_names,
@@ -769,6 +770,41 @@ class TestSelectorPlumbing:
         ]["already-overridden"]
         assert row["extras"]["timespan"] == ["instantaneous"]
         assert row["extras"]["keep_me"] == [True], "the other inline key survives"
+
+    @pytest.mark.parametrize(
+        ("shape", "existing"),
+        [
+            (
+                "block sequence",
+                "        extras:\n          timespan:\n            - old\n"
+                "          keep_me: [yes]\n",
+            ),
+            (
+                "block mapping",
+                "        extras:\n          timespan: [old]\n          keep_me: [yes]\n",
+            ),
+            ("inline mapping", "        extras: {timespan: [old], keep_me: [yes]}\n"),
+            ("absent", ""),
+        ],
+    )
+    def test_every_extras_shape_survives_an_override(self, tmp_path, shape, existing):
+        """Editing line by line orphans continuation lines; re-emitting cannot."""
+        text = (
+            "datasets:\n  demo:\n    variables:\n"
+            "      a-row:\n        cds_variable: a_row\n        units: unknown\n"
+            + existing
+            + "      b-row:\n        cds_variable: b_row\n        units: unknown\n"
+        )
+        match = _stanza_match(text, "demo")
+        out = _fill_variable_extras(match.group(1), "a-row", {"timespan": ["new"]})
+        doc = text[: match.start()] + "  demo:\n" + out + text[match.end() :]
+        path = tmp_path / "shard.yaml"
+        path.write_text(doc, encoding="utf-8")
+        variables = load_yaml_strict(path)["datasets"]["demo"]["variables"]
+        assert variables["a-row"]["extras"]["timespan"] == ["new"], shape
+        assert "b-row" in variables, "the neighbouring row must survive"
+        if existing:
+            assert variables["a-row"]["extras"]["keep_me"] == [True]
 
     def test_an_empty_override_leaves_the_block_alone(self):
         """Nothing to record means nothing is written."""

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -14,6 +14,7 @@ from earthlens.ecmwf import _hydrate as hydrate_mod
 from earthlens.ecmwf._hydrate import (
     _claimed_nc_names,
     _dataset_extras,
+    _fill_variable,
     _fill_variable_extras,
     _find_file_for_dataset,
     _hydrate_stanza_per_variable,
@@ -629,6 +630,29 @@ _EXTRAS_STANZA = """datasets:
         nc_variable: mystery
         units: unknown
 """
+
+
+class TestFillVariable:
+    """Tests for writing a row's nc_variable and units back into the shard."""
+
+    @pytest.mark.parametrize("nc_name", ["no", "yes", "on", "off", "null", "y", "sst"])
+    def test_a_yaml_hostile_short_name_survives(self, nc_name):
+        """Nitrogen monoxide is `no`, which bare YAML reads back as a boolean."""
+        block = (
+            "      a-row:"
+            + chr(10)
+            + "        cds_variable: a"
+            + chr(10)
+            + "        nc_variable: seeded"
+            + chr(10)
+            + "        units: unknown"
+            + chr(10)
+        )
+        out = _fill_variable(block, "a-row", nc_name, "kg kg**-1")
+        parsed = yaml.safe_load("root:" + chr(10) + out.replace("      ", "  "))
+        row = parsed["root"]["a-row"]
+        assert row["nc_variable"] == nc_name, "must stay the string it was given"
+        assert row["units"] == "kg kg**-1"
 
 
 class TestSelectorPlumbing:

--- a/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
+++ b/libs/providers/atmosphere/tests/test_ecmwf/test_ecmwf_hydrate.py
@@ -1243,6 +1243,22 @@ class TestBulkHydrateEmpty:
         assert shard.read_text(encoding="utf-8") == _STANZA, "shard untouched"
         assert "did not parse" in capsys.readouterr().out
 
+    @pytest.mark.parametrize(
+        ("limit", "expected"),
+        [(1, ["a-dataset"]), (2, ["a-dataset"]), (3, ["a-dataset", "z-dataset"])],
+    )
+    def test_limit_counts_placeholder_rows_not_datasets(self, limit, expected):
+        """One retrieve per row, so a dataset-counting limit would not bound the work."""
+        rows = {"a-dataset": 2, "z-dataset": 5}
+        assert (
+            hydrate_mod._take_rows(["a-dataset", "z-dataset"], rows, limit) == expected
+        )
+
+    def test_limit_never_splits_a_dataset(self):
+        """Half a hydrated stanza is not a useful stopping point, so it is a floor."""
+        rows = {"wide-dataset": 82}
+        assert hydrate_mod._take_rows(["wide-dataset"], rows, 1) == ["wide-dataset"]
+
     def test_limit_caps_candidates(self, tmp_path, monkeypatch):
         """A --limit truncates the placeholder worklist."""
         (tmp_path / "era5.yaml").write_text(_STANZA, encoding="utf-8")


### PR DESCRIPTION
# Description

`--fill-empty` built one request from a dataset's first `constraints.json` entry and truncated every list with
`value[:1]` (`ecmwf/cli.py:247`), so a probe only ever described whichever variable that entry listed first. A stanza
with several placeholders could never be completed — and **79 of the 110 datasets carrying placeholders have more
than one**, so no number of re-runs would finish them.

The sweep now asks for each placeholder variable **by name**. A dataset's constraints partition it into blocks, and a
variable is only retrievable under the selectors of a block that lists it, so choosing the block by the variable is
what makes a per-variable request a valid combination rather than a 400.

Two things follow from naming the variable in the request:

- **A lone data variable coming back identifies that row outright.** The correspondence is established by the
  request, not inferred from the names, so none of the matching rules is consulted. An ambiguous or empty answer
  still falls through to them, and they decline rather than guess.
- **The serving block carries the selectors that variable needs**, so where they differ from the stanza's own
  `extras:` the difference is written as a per-variable override.

## Validation worth pointing at

Run against the GloFAS stanza, the new path reproduces PR #1039's hand curation exactly — including deriving
`timespan: [instantaneous]` for the two state variables while leaving discharge and runoff on the dataset default:

```yaml
      snow-depth-water-equivalent:
        cds_variable: snow_depth_water_equivalent
        nc_variable: sd
        units: kg m-2
        extras:
          timespan: [instantaneous]
```

That is the manual work #1039 did by hand, now derived.

## Cost, and what happens when a store says no

One retrieve per placeholder row, each under the same per-request deadline, so a wide dataset is a long sweep. A
dataset whose first probe is refused is **abandoned rather than retried for every remaining row** — its placeholders
share one licence and one queue, so the second refusal is a foregone conclusion. Rows filled before the refusal are
kept, and each shard is written as the pass goes, so a re-run continues where the last one stopped. `--limit` works
through the catalog in batches.

## A path deliberately kept

A dataset whose constraints do not partition by variable has no block to look a row up in — obs4mips CO2/CH4 are
this shape. Deleting the old single-shot probe would have made those permanently unhydratable, so it stays as a
fallback, reached only when no probe answered at all. Two tests pin that boundary: one that the fallback fires for
such a dataset, and one that it does **not** fire when a probe answered but offered nothing usable.

# Issues

- Refs #1041 — three of its four Definition-of-Done items; see below

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] four-variable stanza finishes in one pass — 4 probes, 4 rows filled, 0 declined
- [x] a selector the dataset default already covers is not written as an override
- [x] a selector that differs becomes a per-variable `extras:` override
- [x] a row no constraints block serves keeps its placeholder rather than being guessed at
- [x] two rows cannot claim one NetCDF variable — a name bound earlier in the pass is withheld from later ones
- [x] the whole-dataset fallback fires when no probe answered, and does not when one answered with only auxiliaries
- [x] `test_ecmwf_hydrate.py` — 83 passed (was 75)
- [x] hydrate + seed + core CLI datasets — 159 passed
- [x] doctests — 151 passed, 3 skipped across `libs/providers/atmosphere/src`
- [x] `ruff check` / `ruff format --check` clean (pinned v0.15.22), `mypy` clean across 408 source files

`probe --deep` keeps its existing contract — `_ecmwf_deep_sample` is unchanged in behaviour, now composed from the
same request-building and retrieve helpers the per-variable path uses. Its 51 tests pass untouched.

# Not done here

**"the fully-verified dataset count rises materially"** — the fourth DoD item — needs the relevant dataset licences
accepted in the CADS portal and a long live sweep against a credentialed account. That is an operator action, not a
code change, and it is now worth running because the tool can finally finish a multi-variable dataset. #1041 should
stay open for it.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to docs/change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
